### PR TITLE
fix: harden account macro against initialization exploits and buffer UB

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -513,6 +513,16 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
     let disc_bytes = &args.discriminator;
     let disc_len = disc_bytes.len();
 
+    let disc_values: Vec<u8> = disc_bytes.iter()
+        .map(|lit| lit.base10_parse::<u8>().expect("discriminator byte must be 0-255"))
+        .collect();
+    if disc_values.iter().all(|&b| b == 0) {
+        return syn::Error::new_spanned(
+            &args.discriminator[0],
+            "discriminator must contain at least one non-zero byte; all-zero discriminators are indistinguishable from uninitialized account data",
+        ).to_compile_error().into();
+    }
+
     let disc_indices: Vec<usize> = (0..disc_len).collect();
 
     let field_types: Vec<_> = match &input.data {
@@ -544,6 +554,9 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[inline(always)]
             fn check(view: &AccountView) -> Result<(), ProgramError> {
                 let __data = unsafe { view.borrow_unchecked() };
+                if __data.len() < #disc_len + core::mem::size_of::<#name>() {
+                    return Err(ProgramError::AccountDataTooSmall);
+                }
                 #(
                     if unsafe { *__data.get_unchecked(#disc_indices) } != #disc_bytes {
                         return Err(ProgramError::InvalidAccountData);
@@ -574,6 +587,15 @@ pub fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[inline(always)]
             pub fn init_signed(self, account: &mut Initialize<Self>, payer: &AccountView, rent: Option<&Rent>, signers: &[quasar_core::cpi::Signer]) -> Result<(), ProgramError> {
                 let view = account.to_account_view();
+
+                {
+                    let __existing = unsafe { view.borrow_unchecked() };
+                    if __existing.len() >= Self::DISCRIMINATOR.len()
+                        && __existing[..Self::DISCRIMINATOR.len()] == *Self::DISCRIMINATOR
+                    {
+                        return Err(QuasarError::AccountAlreadyInitialized.into());
+                    }
+                }
 
                 use quasar_core::sysvars::Sysvar;
                 let lamports = match rent {


### PR DESCRIPTION
## Summary

This PR closes three security holes in the `#[account]` proc macro — all in generated code that validates and initializes on-chain accounts. The fixes are 22 lines of additions to the derive crate, all in code paths that run at account parse time or initialization time.

## All-zero discriminators pass validation on uninitialized accounts

The `#[account]` macro generates an `AccountCheck::check` that validates the discriminator bytes at the start of the account data. If a developer writes `#[account(discriminator = 0)]`, the generated check becomes:

```rust
if unsafe { *__data.get_unchecked(0) } != 0 {
    return Err(ProgramError::InvalidAccountData);
}
```

A fresh uninitialized account has all-zero data. This check passes. An attacker can supply an uninitialized account and the framework treats it as valid — zero addresses, zero amounts, zero everything. In an escrow program, that's an `EscrowAccount` with `maker = Address(0)` and `receive = 0`.

The fix rejects all-zero discriminators at compile time. The `#[account]` macro now parses the discriminator bytes and emits a compile error if every byte is zero:

```
error: discriminator must contain at least one non-zero byte;
       all-zero discriminators are indistinguishable from uninitialized account data
```

## No bounds check before `get_unchecked` in discriminator validation

The generated `AccountCheck::check` uses `get_unchecked` to read discriminator bytes without first checking that the data is long enough. For an account with `data.len() == 0`, this is undefined behavior — reading from an empty slice. Even for accounts with data shorter than `discriminator + struct size`, the subsequent `ZeroCopyDeref` would read past the end of the buffer.

The fix adds a single bounds check before any unchecked access:

```rust
if __data.len() < disc_len + core::mem::size_of::<AccountStruct>() {
    return Err(ProgramError::AccountDataTooSmall);
}
```

One branch, paid once per account at parse time. After this check, every `get_unchecked` in the discriminator loop and every `ZeroCopyDeref` through `Account<T>` is guaranteed in-bounds.

## No re-initialization protection in `init_signed`

`Initialize<T>::from_account_view` performs no validation — it accepts any account, regardless of whether it's already initialized. The `init_signed` method then unconditionally writes the discriminator and serializes data, overwriting whatever was there. An attacker could pass an already-initialized account with lamports and `init_signed` would overwrite its contents.

The fix checks the existing data before proceeding:

```rust
let existing = unsafe { view.borrow_unchecked() };
if existing.len() >= Self::DISCRIMINATOR.len()
    && existing[..Self::DISCRIMINATOR.len()] == *Self::DISCRIMINATOR
{
    return Err(QuasarError::AccountAlreadyInitialized.into());
}
```

If the account already carries the correct discriminator, initialization fails. Combined with the all-zero discriminator ban, this means: fresh accounts (all zeros) can be initialized, accounts with a different discriminator can't be reinterpreted, and accounts with the same discriminator can't be overwritten.