### PR TITLE
feat: remaining accounts, derive extensions, return data

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,21 +1,25 @@
 use crate::prelude::*;
+use crate::remaining::RemainingAccounts;
 
 /// Raw entrypoint context before parsing.
 pub struct Context<'info> {
     pub program_id: &'info [u8; 32],
     pub accounts: &'info [AccountView],
+    pub remaining_ptr: *mut u8,
     pub data: &'info [u8],
 }
 
 /// Parsed instruction context with typed accounts and PDA bumps.
-pub struct Ctx<'info, T: ParseAccounts<'info>> {
+pub struct Ctx<'info, T: ParseAccounts<'info> + AccountCount> {
     pub accounts: T,
     pub bumps: T::Bumps,
     pub program_id: &'info [u8; 32],
     pub data: &'info [u8],
+    remaining_ptr: *mut u8,
+    declared: &'info [AccountView],
 }
 
-impl<'info, T: ParseAccounts<'info>> Ctx<'info, T> {
+impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
     #[inline(always)]
     pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
         let (accounts, bumps) = T::parse(ctx.accounts)?;
@@ -24,6 +28,15 @@ impl<'info, T: ParseAccounts<'info>> Ctx<'info, T> {
             bumps,
             program_id: ctx.program_id,
             data: ctx.data,
+            remaining_ptr: ctx.remaining_ptr,
+            declared: ctx.accounts,
         })
+    }
+
+    /// Access remaining accounts. Zero cost until called.
+    #[inline(always)]
+    pub fn remaining_accounts(&self) -> RemainingAccounts<'info> {
+        let boundary = unsafe { self.data.as_ptr().sub(core::mem::size_of::<u64>()) };
+        RemainingAccounts::new(self.remaining_ptr, boundary, self.declared)
     }
 }

--- a/core/src/entrypoint.rs
+++ b/core/src/entrypoint.rs
@@ -5,11 +5,9 @@ macro_rules! dispatch {
     ($ptr:expr, $ix_data:expr, $disc_len:literal, {
         $([$($disc_byte:literal),+] => $handler:ident($accounts_ty:ty)),+ $(,)?
     }) => {{
-        // Program ID is immediately after instruction_data in the SVM buffer
         let __program_id: &[u8; 32] = unsafe {
             &*($ix_data.as_ptr().add($ix_data.len()) as *const [u8; 32])
         };
-        // Skip the num_accounts u64 prefix to get to the first account
         let __accounts_start = unsafe { ($ptr as *mut u8).add(core::mem::size_of::<u64>()) };
 
         if $ix_data.len() < $disc_len {
@@ -24,13 +22,14 @@ macro_rules! dispatch {
                     let mut __buf = core::mem::MaybeUninit::<
                         [AccountView; <$accounts_ty as AccountCount>::COUNT]
                     >::uninit();
-                    unsafe {
+                    let __remaining_ptr = unsafe {
                         <$accounts_ty>::parse_accounts(__accounts_start, &mut __buf)
                     };
                     let __accounts = unsafe { __buf.assume_init() };
                     $handler(Context {
                         program_id: __program_id,
                         accounts: &__accounts,
+                        remaining_ptr: __remaining_ptr,
                         data: $ix_data,
                     })
                 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -15,4 +15,5 @@ pub enum QuasarError {
     AccountOwnedByWrongProgram,
     AccountNotMutable,
     AccountNotSigner,
+    AddressMismatch,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,8 @@ pub mod context;
 pub mod error;
 pub mod log;
 pub mod event;
+pub mod remaining;
+pub mod return_data;
 pub mod prelude;
 #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub mod client;

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -12,4 +12,5 @@ pub use crate::sysvars::Sysvar;
 pub use crate::cpi::Seed;
 pub use crate::cpi::system::SystemProgram;
 pub use quasar_derive::{Accounts, instruction, account, error_code, program, event, emit_cpi};
+pub use crate::return_data::set_return_data;
 pub use crate::{no_alloc, panic_handler, dispatch, emit};

--- a/core/src/remaining.rs
+++ b/core/src/remaining.rs
@@ -1,0 +1,194 @@
+use solana_account_view::{AccountView, RuntimeAccount, NOT_BORROWED, MAX_PERMITTED_DATA_INCREASE};
+
+const ACCOUNT_HEADER: usize =
+    core::mem::size_of::<RuntimeAccount>()
+    + MAX_PERMITTED_DATA_INCREASE
+    + core::mem::size_of::<u64>();
+
+const MAX_REMAINING_ACCOUNTS: usize = 64;
+
+/// Zero-allocation remaining accounts accessor.
+///
+/// Uses a boundary pointer (end of accounts region in the SVM buffer) instead
+/// of a count. No reads, no arithmetic in the dispatch hot path — the struct
+/// is constructed only when `Ctx::remaining_accounts()` is called.
+pub struct RemainingAccounts<'a> {
+    ptr: *mut u8,
+    boundary: *const u8,
+    declared: &'a [AccountView],
+}
+
+impl<'a> RemainingAccounts<'a> {
+    #[inline(always)]
+    pub fn new(ptr: *mut u8, boundary: *const u8, declared: &'a [AccountView]) -> Self {
+        Self { ptr, boundary, declared }
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.ptr as *const u8 >= self.boundary
+    }
+
+
+    /// Access a single remaining account by index. O(n) — walks from the
+    /// start of the buffer. Use `iter()` for sequential access.
+    pub fn get(&self, index: usize) -> Option<AccountView> {
+        let mut ptr = self.ptr;
+        for i in 0..=index {
+            if ptr as *const u8 >= self.boundary {
+                return None;
+            }
+            let raw = ptr as *mut RuntimeAccount;
+            let borrow = unsafe { (*raw).borrow_state };
+
+            if i == index {
+                return Some(if borrow == NOT_BORROWED {
+                    unsafe { AccountView::new_unchecked(raw) }
+                } else {
+                    resolve_dup_walk(borrow as usize, self.declared, self.ptr, self.boundary)
+                });
+            }
+
+            if borrow == NOT_BORROWED {
+                unsafe {
+                    ptr = ptr.add(ACCOUNT_HEADER + (*raw).data_len as usize);
+                    ptr = ((ptr as usize + 7) & !7) as *mut u8;
+                }
+            } else {
+                unsafe {
+                    ptr = ptr.add(core::mem::size_of::<u64>());
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns an iterator that yields each remaining account in order.
+    /// Builds an index as it walks — duplicate resolution is O(1),
+    /// same pattern as the declared accounts parser in the entrypoint.
+    #[inline(always)]
+    pub fn iter(&self) -> RemainingIter<'a> {
+        RemainingIter {
+            ptr: self.ptr,
+            boundary: self.boundary,
+            declared: self.declared,
+            index: 0,
+            cache: core::mem::MaybeUninit::uninit(),
+        }
+    }
+}
+
+/// Walk-based dup resolution for one-off `get()` access.
+fn resolve_dup_walk(
+    orig_idx: usize,
+    declared: &[AccountView],
+    start: *mut u8,
+    boundary: *const u8,
+) -> AccountView {
+    if orig_idx < declared.len() {
+        unsafe { core::ptr::read(declared.as_ptr().add(orig_idx)) }
+    } else {
+        let target = orig_idx - declared.len();
+        let mut ptr = start;
+        for i in 0..=target {
+            if ptr as *const u8 >= boundary {
+                break;
+            }
+            let raw = ptr as *mut RuntimeAccount;
+            let borrow = unsafe { (*raw).borrow_state };
+
+            if i == target {
+                return if borrow == NOT_BORROWED {
+                    unsafe { AccountView::new_unchecked(raw) }
+                } else {
+                    resolve_dup_walk(borrow as usize, declared, start, boundary)
+                };
+            }
+
+            if borrow == NOT_BORROWED {
+                unsafe {
+                    ptr = ptr.add(ACCOUNT_HEADER + (*raw).data_len as usize);
+                    ptr = ((ptr as usize + 7) & !7) as *mut u8;
+                }
+            } else {
+                unsafe {
+                    ptr = ptr.add(core::mem::size_of::<u64>());
+                }
+            }
+        }
+        unreachable!()
+    }
+}
+
+pub struct RemainingIter<'a> {
+    ptr: *mut u8,
+    boundary: *const u8,
+    declared: &'a [AccountView],
+    index: usize,
+    // SAFETY: Elements 0..index are initialized. Only allocated on the stack
+    // when iter() is called — zero cost when remaining accounts aren't used.
+    cache: core::mem::MaybeUninit<[AccountView; MAX_REMAINING_ACCOUNTS]>,
+}
+
+impl RemainingIter<'_> {
+    #[inline(always)]
+    fn cache_ptr(&self) -> *const AccountView {
+        self.cache.as_ptr() as *const AccountView
+    }
+
+    #[inline(always)]
+    fn cache_mut_ptr(&mut self) -> *mut AccountView {
+        self.cache.as_mut_ptr() as *mut AccountView
+    }
+
+    /// O(1) dup resolution: declared accounts via slice, previously-yielded
+    /// remaining accounts via the iterator's own cache.
+    #[inline(always)]
+    fn resolve_dup(&self, orig_idx: usize) -> AccountView {
+        if orig_idx < self.declared.len() {
+            unsafe { core::ptr::read(self.declared.as_ptr().add(orig_idx)) }
+        } else {
+            let remaining_idx = orig_idx - self.declared.len();
+            // SAFETY: SVM duplicates always reference earlier accounts,
+            // so remaining_idx < self.index (already cached).
+            debug_assert!(remaining_idx < self.index, "forward-reference in remaining accounts");
+            unsafe { core::ptr::read(self.cache_ptr().add(remaining_idx)) }
+        }
+    }
+}
+
+impl Iterator for RemainingIter<'_> {
+    type Item = AccountView;
+
+    fn next(&mut self) -> Option<AccountView> {
+        if self.ptr as *const u8 >= self.boundary || self.index >= MAX_REMAINING_ACCOUNTS {
+            return None;
+        }
+
+        let raw = self.ptr as *mut RuntimeAccount;
+        let borrow = unsafe { (*raw).borrow_state };
+
+        let view = if borrow == NOT_BORROWED {
+            let view = unsafe { AccountView::new_unchecked(raw) };
+            unsafe {
+                self.ptr = self.ptr.add(ACCOUNT_HEADER + (*raw).data_len as usize);
+                self.ptr = ((self.ptr as usize + 7) & !7) as *mut u8;
+            }
+            view
+        } else {
+            unsafe {
+                self.ptr = self.ptr.add(core::mem::size_of::<u64>());
+            }
+            self.resolve_dup(borrow as usize)
+        };
+
+        // Cache for future dup resolution — same pattern as the entrypoint.
+        // SAFETY: AccountView is a thin pointer wrapper; ptr::read is a bitwise copy.
+        unsafe {
+            let copy = core::ptr::read(&view);
+            core::ptr::write(self.cache_mut_ptr().add(self.index), copy);
+        }
+        self.index += 1;
+        Some(view)
+    }
+}

--- a/core/src/return_data.rs
+++ b/core/src/return_data.rs
@@ -1,0 +1,10 @@
+#[inline(always)]
+pub fn set_return_data(_data: &[u8]) {
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+    {
+        use solana_define_syscall::definitions::sol_set_return_data;
+        unsafe {
+            sol_set_return_data(_data.as_ptr(), _data.len() as u64);
+        }
+    }
+}

--- a/derive/src/accounts.rs
+++ b/derive/src/accounts.rs
@@ -11,10 +11,11 @@ use crate::helpers::{seed_slice_expr_for_parse, is_signer_type, strip_generics, 
 
 enum AccountDirective {
     Mut,
-    HasOne(Ident),
-    Constraint(Expr),
+    HasOne(Ident, Option<Expr>),
+    Constraint(Expr, Option<Expr>),
     Seeds(Vec<Expr>),
     Bump(Option<Expr>),
+    Address(Expr, Option<Expr>),
 }
 
 impl Parse for AccountDirective {
@@ -27,11 +28,36 @@ impl Parse for AccountDirective {
         match key.to_string().as_str() {
             "has_one" => {
                 let _: Token![=] = input.parse()?;
-                Ok(Self::HasOne(input.parse()?))
+                let ident: Ident = input.parse()?;
+                let error = if input.peek(Token![@]) {
+                    input.parse::<Token![@]>()?;
+                    Some(input.parse::<Expr>()?)
+                } else {
+                    None
+                };
+                Ok(Self::HasOne(ident, error))
             }
             "constraint" => {
                 let _: Token![=] = input.parse()?;
-                Ok(Self::Constraint(input.parse()?))
+                let expr: Expr = input.parse()?;
+                let error = if input.peek(Token![@]) {
+                    input.parse::<Token![@]>()?;
+                    Some(input.parse::<Expr>()?)
+                } else {
+                    None
+                };
+                Ok(Self::Constraint(expr, error))
+            }
+            "address" => {
+                let _: Token![=] = input.parse()?;
+                let expr: Expr = input.parse()?;
+                let error = if input.peek(Token![@]) {
+                    input.parse::<Token![@]>()?;
+                    Some(input.parse::<Expr>()?)
+                } else {
+                    None
+                };
+                Ok(Self::Address(expr, error))
             }
             "seeds" => {
                 let _: Token![=] = input.parse()?;
@@ -56,10 +82,11 @@ impl Parse for AccountDirective {
 
 struct AccountFieldAttrs {
     is_mut: bool,
-    has_ones: Vec<Ident>,
-    constraints: Vec<Expr>,
+    has_ones: Vec<(Ident, Option<Expr>)>,
+    constraints: Vec<(Expr, Option<Expr>)>,
     seeds: Option<Vec<Expr>>,
     bump: Option<Option<Expr>>,
+    address: Option<(Expr, Option<Expr>)>,
 }
 
 impl Parse for AccountFieldAttrs {
@@ -71,16 +98,18 @@ impl Parse for AccountFieldAttrs {
         let mut constraints = Vec::new();
         let mut seeds = None;
         let mut bump = None;
+        let mut address = None;
         for d in directives {
             match d {
                 AccountDirective::Mut => is_mut = true,
-                AccountDirective::HasOne(ident) => has_ones.push(ident),
-                AccountDirective::Constraint(expr) => constraints.push(expr),
+                AccountDirective::HasOne(ident, err) => has_ones.push((ident, err)),
+                AccountDirective::Constraint(expr, err) => constraints.push((expr, err)),
                 AccountDirective::Seeds(s) => seeds = Some(s),
                 AccountDirective::Bump(b) => bump = Some(b),
+                AccountDirective::Address(expr, err) => address = Some((expr, err)),
             }
         }
-        Ok(Self { is_mut, has_ones, constraints, seeds, bump })
+        Ok(Self { is_mut, has_ones, constraints, seeds, bump, address })
     }
 }
 
@@ -98,7 +127,40 @@ fn parse_field_attrs(field: &syn::Field) -> AccountFieldAttrs {
         constraints: vec![],
         seeds: None,
         bump: None,
+        address: None,
     }
+}
+
+fn is_composite_type(ty: &Type) -> bool {
+    if matches!(ty, Type::Reference(_)) {
+        return false;
+    }
+    if extract_option_inner(ty).is_some() {
+        return false;
+    }
+    if let Type::Path(type_path) = ty {
+        if let Some(last) = type_path.path.segments.last() {
+            if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
+                return args.args.iter().any(|arg| matches!(arg, syn::GenericArgument::Lifetime(_)));
+            }
+        }
+    }
+    false
+}
+
+fn extract_option_inner(ty: &Type) -> Option<&Type> {
+    if let Type::Path(type_path) = ty {
+        if let Some(last) = type_path.path.segments.last() {
+            if last.ident == "Option" {
+                if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        return Some(inner);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 // --- Derive Accounts ---
@@ -137,45 +199,96 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         let attrs = parse_field_attrs(field);
         let field_name = field.ident.as_ref().unwrap();
 
-        let is_ref_mut = matches!(&field.ty, Type::Reference(r) if r.mutability.is_some());
+        let is_optional = extract_option_inner(&field.ty).is_some();
+        let effective_ty = extract_option_inner(&field.ty).unwrap_or(&field.ty);
+        let is_ref_mut = matches!(effective_ty, Type::Reference(r) if r.mutability.is_some());
 
-        match &field.ty {
+        match effective_ty {
             Type::Reference(type_ref) => {
                 let base_type = strip_generics(&type_ref.elem);
-                if type_ref.mutability.is_some() {
-                    field_constructs.push(quote! { #field_name: #base_type::from_account_view_mut(#field_name)? });
+                let construct_expr = if type_ref.mutability.is_some() {
+                    quote! { #base_type::from_account_view_mut(#field_name)? }
+                } else {
+                    quote! { #base_type::from_account_view(#field_name)? }
+                };
+                if is_optional {
+                    field_constructs.push(quote! { #field_name: if *#field_name.address() == crate::ID { None } else { Some(#construct_expr) } });
+                } else {
+                    field_constructs.push(quote! { #field_name: #construct_expr });
+                }
+            }
+            _ => {
+                let base_type = strip_generics(effective_ty);
+                if is_optional {
+                    field_constructs.push(quote! { #field_name: if *#field_name.address() == crate::ID { None } else { Some(#base_type::from_account_view(#field_name)?) } });
                 } else {
                     field_constructs.push(quote! { #field_name: #base_type::from_account_view(#field_name)? });
                 }
             }
-            _ => {
-                let base_type = strip_generics(&field.ty);
-                field_constructs.push(quote! { #field_name: #base_type::from_account_view(#field_name)? });
-            }
         }
 
         if attrs.is_mut && !is_ref_mut {
-            mut_checks.push(quote! {
+            let check = quote! {
                 if !#field_name.to_account_view().is_writable() {
                     return Err(ProgramError::Immutable);
                 }
-            });
+            };
+            if is_optional {
+                mut_checks.push(quote! { if let Some(ref #field_name) = #field_name { #check } });
+            } else {
+                mut_checks.push(check);
+            }
         }
 
-        for target in &attrs.has_ones {
-            has_one_checks.push(quote! {
+        for (target, custom_error) in &attrs.has_ones {
+            let error = match custom_error {
+                Some(err) => quote! { #err.into() },
+                None => quote! { QuasarError::HasOneMismatch.into() },
+            };
+            let check = quote! {
                 if #field_name.#target != *#target.to_account_view().address() {
-                    return Err(QuasarError::HasOneMismatch.into());
+                    return Err(#error);
                 }
-            });
+            };
+            if is_optional {
+                has_one_checks.push(quote! { if let Some(ref #field_name) = #field_name { #check } });
+            } else {
+                has_one_checks.push(check);
+            }
         }
 
-        for expr in &attrs.constraints {
-            constraint_checks.push(quote! {
+        for (expr, custom_error) in &attrs.constraints {
+            let error = match custom_error {
+                Some(err) => quote! { #err.into() },
+                None => quote! { QuasarError::ConstraintViolation.into() },
+            };
+            let check = quote! {
                 if !(#expr) {
-                    return Err(QuasarError::ConstraintViolation.into());
+                    return Err(#error);
                 }
-            });
+            };
+            if is_optional {
+                constraint_checks.push(quote! { if let Some(ref #field_name) = #field_name { #check } });
+            } else {
+                constraint_checks.push(check);
+            }
+        }
+
+        if let Some((addr_expr, custom_error)) = &attrs.address {
+            let error = match custom_error {
+                Some(err) => quote! { #err.into() },
+                None => quote! { QuasarError::AddressMismatch.into() },
+            };
+            let check = quote! {
+                if *#field_name.to_account_view().address() != #addr_expr {
+                    return Err(#error);
+                }
+            };
+            if is_optional {
+                constraint_checks.push(quote! { if let Some(ref #field_name) = #field_name { #check } });
+            } else {
+                constraint_checks.push(check);
+            }
         }
 
         if let Some(ref seed_exprs) = attrs.seeds {
@@ -281,30 +394,77 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         }
     }
 
-    let field_count = field_names.len();
-    let field_indices: Vec<usize> = (0..field_count).collect();
+    let field_attrs: Vec<AccountFieldAttrs> = fields.iter().map(|f| parse_field_attrs(f)).collect();
 
-    let parse_steps: Vec<proc_macro2::TokenStream> = field_indices.iter().map(|&i| {
-        quote! {
-            {
-                let raw = input as *mut quasar_core::__private::RuntimeAccount;
-                if unsafe { (*raw).borrow_state } == quasar_core::__private::NOT_BORROWED {
-                    unsafe {
-                        core::ptr::write(base.add(#i), quasar_core::__private::AccountView::new_unchecked(raw));
-                        input = input.add(__ACCOUNT_HEADER + (*raw).data_len as usize);
-                        let addr = input as usize;
-                        input = ((addr + 7) & !7) as *mut u8;
-                    }
-                } else {
-                    unsafe {
-                        let idx = (*raw).borrow_state as usize;
-                        core::ptr::write(base.add(#i), core::ptr::read(base.add(idx)));
-                        input = input.add(core::mem::size_of::<u64>());
+    let mut has_composites = false;
+    let mut composite_types: Vec<Option<proc_macro2::TokenStream>> = Vec::new();
+    for field in fields.iter() {
+        if is_composite_type(&field.ty) {
+            has_composites = true;
+            composite_types.push(Some(strip_generics(&field.ty)));
+        } else {
+            composite_types.push(None);
+        }
+    }
+
+    let count_expr: proc_macro2::TokenStream = if has_composites {
+        let addends: Vec<proc_macro2::TokenStream> = composite_types.iter().map(|ct| {
+            match ct {
+                Some(ty) => quote! { <#ty as AccountCount>::COUNT },
+                None => quote! { 1usize },
+            }
+        }).collect();
+        quote! { #(#addends)+* }
+    } else {
+        let field_count = field_names.len();
+        quote! { #field_count }
+    };
+
+    let mut parse_steps: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut buf_offset = quote! { 0usize };
+    for fi in 0..fields.len() {
+        if composite_types[fi].is_some() {
+            let inner_ty = composite_types[fi].as_ref().unwrap();
+            let cur_offset = buf_offset.clone();
+            parse_steps.push(quote! {
+                {
+                    let mut __inner_buf = core::mem::MaybeUninit::<
+                        [quasar_core::__private::AccountView; <#inner_ty as AccountCount>::COUNT]
+                    >::uninit();
+                    input = <#inner_ty>::parse_accounts(input, &mut __inner_buf);
+                    let __inner = unsafe { __inner_buf.assume_init() };
+                    let mut __j = 0usize;
+                    while __j < <#inner_ty as AccountCount>::COUNT {
+                        unsafe { core::ptr::write(base.add(#cur_offset + __j), *__inner.as_ptr().add(__j)); }
+                        __j += 1;
                     }
                 }
-            }
+            });
+            buf_offset = quote! { #buf_offset + <#inner_ty as AccountCount>::COUNT };
+        } else {
+            let cur_offset = buf_offset.clone();
+            parse_steps.push(quote! {
+                {
+                    let raw = input as *mut quasar_core::__private::RuntimeAccount;
+                    if unsafe { (*raw).borrow_state } == quasar_core::__private::NOT_BORROWED {
+                        unsafe {
+                            core::ptr::write(base.add(#cur_offset), quasar_core::__private::AccountView::new_unchecked(raw));
+                            input = input.add(__ACCOUNT_HEADER + (*raw).data_len as usize);
+                            let addr = input as usize;
+                            input = ((addr + 7) & !7) as *mut u8;
+                        }
+                    } else {
+                        unsafe {
+                            let idx = (*raw).borrow_state as usize;
+                            core::ptr::write(base.add(#cur_offset), core::ptr::read(base.add(idx)));
+                            input = input.add(core::mem::size_of::<u64>());
+                        }
+                    }
+                }
+            });
+            buf_offset = quote! { #buf_offset + 1usize };
         }
-    }).collect();
+    }
 
     let has_pda_fields = !bump_struct_fields.is_empty();
 
@@ -325,7 +485,79 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         || !mut_checks.is_empty()
         || !pda_checks.is_empty();
 
-    let parse_body = if has_any_checks {
+    let parse_body = if has_composites {
+        let mut field_lets: Vec<proc_macro2::TokenStream> = Vec::new();
+        let mut idx_offset = quote! { 0usize };
+        for (fi, field) in fields.iter().enumerate() {
+            let field_name = field.ident.as_ref().unwrap();
+            if composite_types[fi].is_some() {
+                let inner_ty = composite_types[fi].as_ref().unwrap();
+                let bumps_var = format_ident!("__composite_bumps_{}", field_name);
+                let cur_offset = idx_offset.clone();
+                field_lets.push(quote! {
+                    let (#field_name, #bumps_var) = <#inner_ty as ParseAccounts>::parse(
+                        &accounts[#cur_offset..#cur_offset + <#inner_ty as AccountCount>::COUNT]
+                    )?;
+                });
+                bump_struct_fields.push(quote! { pub #field_name: <#inner_ty as ParseAccounts>::Bumps });
+                bump_struct_inits.push(quote! { #field_name: #bumps_var });
+                idx_offset = quote! { #idx_offset + <#inner_ty as AccountCount>::COUNT };
+            } else {
+                let cur_offset = idx_offset.clone();
+                field_lets.push(quote! {
+                    let #field_name = &accounts[#cur_offset];
+                });
+                idx_offset = quote! { #idx_offset + 1usize };
+            }
+        }
+
+        let non_composite_constructs: Vec<proc_macro2::TokenStream> = fields.iter().enumerate()
+            .map(|(fi, field)| {
+                let field_name = field.ident.as_ref().unwrap();
+                if composite_types[fi].is_some() {
+                    quote! { #field_name }
+                } else {
+                    field_constructs[fi].clone()
+                }
+            }).collect();
+
+        if has_any_checks {
+            quote! {
+                if accounts.len() < Self::COUNT {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
+                #(#field_lets)*
+                #(#seed_addr_captures)*
+
+                let result = Self {
+                    #(#non_composite_constructs,)*
+                };
+
+                #(#bump_init_vars)*
+
+                {
+                    let Self { #(ref #field_names,)* } = result;
+                    #(#mut_checks)*
+                    #(#has_one_checks)*
+                    #(#constraint_checks)*
+                    #(#pda_checks)*
+                }
+
+                Ok((result, #bumps_init))
+            }
+        } else {
+            quote! {
+                if accounts.len() < Self::COUNT {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
+                #(#field_lets)*
+
+                Ok((Self {
+                    #(#non_composite_constructs,)*
+                }, #bumps_init))
+            }
+        }
+    } else if has_any_checks {
         quote! {
             let [#(#field_names),*] = accounts else {
                 return Err(ProgramError::NotEnoughAccountKeys);
@@ -382,10 +614,9 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         format!("pub {}: solana_address::Address,", field_name)
     }).collect::<Vec<_>>().join("\n                ");
 
-    let account_metas_str: String = fields.iter().map(|f| {
+    let account_metas_str: String = fields.iter().enumerate().map(|(fi, f)| {
         let field_name = f.ident.as_ref().unwrap().to_string();
-        let attrs = parse_field_attrs(f);
-        let writable = attrs.is_mut || matches!(&f.ty, Type::Reference(r) if r.mutability.is_some());
+        let writable = field_attrs[fi].is_mut || matches!(&f.ty, Type::Reference(r) if r.mutability.is_some());
         let signer = is_signer_type(&f.ty);
         if writable {
             format!("quasar_core::client::AccountMeta::new(ix.{}, {}),", field_name, signer)
@@ -448,14 +679,14 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         #seeds_impl
 
         impl<'info> AccountCount for #name<'info> {
-            const COUNT: usize = #field_count;
+            const COUNT: usize = #count_expr;
         }
 
         impl<'info> #name<'info> {
             #[inline(always)]
             pub unsafe fn parse_accounts(
                 mut input: *mut u8,
-                buf: &mut core::mem::MaybeUninit<[quasar_core::__private::AccountView; #field_count]>,
+                buf: &mut core::mem::MaybeUninit<[quasar_core::__private::AccountView; #count_expr]>,
             ) -> *mut u8 {
                 const __ACCOUNT_HEADER: usize =
                     core::mem::size_of::<quasar_core::__private::RuntimeAccount>()

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -1,10 +1,31 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, FnArg, Ident, ItemFn, Pat,
+    parse_macro_input, FnArg, GenericArgument, Ident, ItemFn, Pat, PathArguments, ReturnType, Type,
 };
 
 use crate::helpers::{InstructionArgs, map_to_pod_type, zc_deserialize_expr};
+
+fn extract_result_ok_type(output: &ReturnType) -> Option<&Type> {
+    if let ReturnType::Type(_, ty) = output {
+        if let Type::Path(type_path) = ty.as_ref() {
+            if let Some(last) = type_path.path.segments.last() {
+                if last.ident == "Result" {
+                    if let PathArguments::AngleBracketed(args) = &last.arguments {
+                        if let Some(GenericArgument::Type(ok_ty)) = args.args.first() {
+                            return Some(ok_ty);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_unit_type(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(t) if t.elems.is_empty())
+}
 
 pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as InstructionArgs);
@@ -23,6 +44,14 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
         _ => panic!("#[instruction] ctx parameter must be an identifier"),
     };
     let param_type = &first_arg.ty;
+
+    let has_return_data = extract_result_ok_type(&func.sig.output)
+        .is_some_and(|ok_ty| !is_unit_type(ok_ty));
+    let return_ok_type = extract_result_ok_type(&func.sig.output).cloned();
+
+    if has_return_data {
+        func.sig.output = syn::parse_quote!(-> Result<(), ProgramError>);
+    }
 
     let remaining: Vec<_> = func.sig.inputs.iter().skip(1).filter_map(|arg| {
         match arg {
@@ -58,7 +87,7 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
         }).collect();
 
         let zc_field_types: Vec<proc_macro2::TokenStream> = remaining.iter().map(|pt| {
-            map_to_pod_type(&*pt.ty)
+            map_to_pod_type(&pt.ty)
         }).collect();
 
         new_stmts.push(syn::parse_quote!(
@@ -87,14 +116,44 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
         ));
 
         for (i, name) in field_names.iter().enumerate() {
-            let expr = zc_deserialize_expr(name, &*remaining[i].ty);
+            let expr = zc_deserialize_expr(name, &remaining[i].ty);
             new_stmts.push(syn::parse_quote!(
                 let #name = #expr;
             ));
         }
     }
 
-    func.block.stmts = new_stmts.into_iter().chain(stmts).collect();
+    if has_return_data {
+        let ok_ty = return_ok_type.unwrap();
+        let user_body: proc_macro2::TokenStream = stmts.iter().map(|s| quote!(#s)).collect();
+        new_stmts.push(syn::parse_quote!(
+            const _: () = assert!(
+                core::mem::align_of::<#ok_ty>() == 1,
+                "return data type must have alignment 1 (use Pod types)"
+            );
+        ));
+        new_stmts.push(syn::parse_quote!(
+            {
+                let __result: Result<#ok_ty, ProgramError> = (|| { #user_body })();
+                match __result {
+                    Ok(ref __val) => {
+                        let __bytes = unsafe {
+                            core::slice::from_raw_parts(
+                                __val as *const #ok_ty as *const u8,
+                                core::mem::size_of::<#ok_ty>(),
+                            )
+                        };
+                        quasar_core::return_data::set_return_data(__bytes);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        ));
+        func.block.stmts = new_stmts;
+    } else {
+        func.block.stmts = new_stmts.into_iter().chain(stmts).collect();
+    }
 
     quote!(#func).into()
 }


### PR DESCRIPTION
## Summary

Adds six features to Quasar: zero-cost remaining accounts, optional accounts, composite account structs, `address` directive, custom error codes on constraints, and instruction return data auto-serialization. All features follow the framework's zero-allocation, stack-only philosophy. Remaining accounts overhead is ~8 CU per instruction — zero reads, zero arithmetic in the dispatch hot path.

## Remaining Accounts (`core/src/remaining.rs`, `core/src/context.rs`, `core/src/entrypoint.rs`)

The dispatch macro stores only the `remaining_ptr` (the return value of `parse_accounts()` — already computed, free) in `Context`. No `num_accounts` read, no struct construction, no buffer allocation in the dispatch path.

`Ctx::remaining_accounts()` constructs a `RemainingAccounts` on demand using a boundary pointer derived from `self.data.as_ptr() - 8` (the `ix_data_len` field in the SVM buffer sits immediately after the last account). The iterator builds a `MaybeUninit<[AccountView; 64]>` cache as it yields items — duplicate resolution is O(1) via this cache, same pattern as the declared accounts parser in the entrypoint. The cache only exists on the stack during iteration.

API:
```rust
let remaining = ctx.remaining_accounts();
remaining.is_empty()  // O(1) — pointer comparison
remaining.get(i)      // O(i) — walks to index, boundary-checked
remaining.iter()      // O(1) per item, O(1) dup resolution
```

The boundary pointer replaces a count — `get(n)` and `iter()` stop when `ptr >= boundary`, so out-of-bounds access is impossible without storing a count field.

## Optional Accounts (`derive/src/accounts.rs`)

Fields declared as `Option<&'info T>` are detected via `extract_option_inner()`. The program's own ID (`crate::ID`) is the sentinel for "not provided" — if an account's address matches the program ID, the field is set to `None` and all validation (mut, has_one, constraint, address) is skipped via `if let Some(ref field) = field { ... }` guards.

```rust
pub struct MyAccounts<'info> {
    #[account(mut)]
    pub optional_account: Option<&'info mut TokenAccount>,
}
```

## Composite Accounts (`derive/src/accounts.rs`)

Composite accounts are auto-detected by type syntax — no annotation needed. Any non-reference, non-Option `Type::Path` with a lifetime parameter is treated as a composite (e.g., `InnerAccounts<'info>`). This works because all "normal" account fields are references (`&'info Account<T>`), while composite structs are bare types with lifetimes.

The generated `parse_accounts()` delegates to the inner type's `parse_accounts()`, and `COUNT` becomes a sum expression (`1usize + <Inner as AccountCount>::COUNT + 1usize`). Buffer offsets are tracked as accumulated token expressions that LLVM folds at compile time.

The composite copy loop uses `*__inner.as_ptr().add(__j)` instead of `__inner[__j]` to avoid generating panic paths in the SBF binary.

```rust
pub struct MyAccounts<'info> {
    pub inner: InnerAccounts<'info>,  // auto-detected as composite
    pub other: &'info TokenAccount,
}
```

## Custom Error Codes (`derive/src/accounts.rs`)

`has_one`, `constraint`, and `address` directives support `@ ErrorExpr` syntax for custom errors, matching Anchor's convention:

```rust
#[account(has_one = authority @ MyError::Unauthorized)]
#[account(constraint = amount > 0 @ MyError::ZeroAmount)]
#[account(address = EXPECTED_ADDR @ MyError::WrongAddress)]
```

Default errors: `HasOneMismatch` for `has_one`, `ConstraintViolation` for `constraint`, `AddressMismatch` (new variant) for `address`.

## Address Directive (`derive/src/accounts.rs`, `core/src/error.rs`)

New `#[account(address = <expr>)]` directive checks that an account's address matches a compile-time or runtime expression. Adds `QuasarError::AddressMismatch` as the default error.

## Instruction Return Data (`derive/src/instruction.rs`, `core/src/return_data.rs`)

If an `#[instruction]` function returns `Result<T, ProgramError>` where `T` is not `()`, the macro:
1. Asserts `align_of::<T>() == 1` at compile time (Pod types only)
2. Wraps the user body in a closure
3. Serializes the `Ok` value as raw bytes via `sol_set_return_data`
4. Rewrites the function signature to `Result<(), ProgramError>`

```rust
#[instruction(discriminator = [4])]
fn query_price(ctx: Ctx<QueryAccounts>) -> Result<PodU64, ProgramError> {
    Ok(PodU64::from(42))
    // return data is automatically set via sol_set_return_data syscall
}
```

`set_return_data` is cfg-gated for `target_os = "solana"` only.

## Derive Consolidation (`derive/src/accounts.rs`)

`parse_field_attrs` was being called 3x per field (main loop, `has_composites` check, `composite_types` loop, client macro). Consolidated into a single-pass `field_attrs: Vec<AccountFieldAttrs>` built once and indexed throughout.

## CU Measurements

| Instruction | Before | After | Delta |
|-------------|--------|-------|-------|
| Make        | 10,330 | 10,338 | +8   |
| Take        | 18,772 | 18,781 | +9   |
| Refund      | 12,961 | 12,970 | +9   |

~8-9 CU overhead for full remaining accounts support. The overhead is purely from storing one extra pointer field in `Context` and `Ctx`. All remaining accounts logic (boundary computation, struct construction, iteration, dup resolution) is deferred to `ctx.remaining_accounts()`.

## What It Looks Like

```rust
#[derive(Accounts)]
pub struct Transfer<'info> {
    #[account(mut, has_one = authority @ MyError::Unauthorized)]
    pub vault: &'info mut TokenAccount,
    #[account(address = ADMIN_PUBKEY @ MyError::NotAdmin)]
    pub authority: Signer,
    pub fee_accounts: FeeAccounts<'info>,  // auto-detected composite
    pub optional_refund: Option<&'info mut TokenAccount>,
}

#[instruction(discriminator = [1])]
fn transfer(ctx: Ctx<Transfer>, amount: u64) -> Result<PodU64, ProgramError> {
    let remaining = ctx.remaining_accounts();
    for extra in remaining.iter() {
        // process extra accounts
    }
    Ok(PodU64::from(amount))
}
```