### PR TITLE
Dynamic account View types, CPI error propagation, IDL dynamic fields, and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quasar-multisig"
+version = "0.1.0"
+dependencies = [
+ "mollusk-svm",
+ "quasar-core",
+ "solana-account",
+ "solana-address 2.2.0",
+ "solana-instruction",
+]
+
+[[package]]
 name = "quasar-pod"
 version = "0.1.0"
 
@@ -1939,6 +1950,17 @@ dependencies = [
  "solana-account-view",
  "solana-address 2.2.0",
  "solana-program-error",
+]
+
+[[package]]
+name = "quasar-vault"
+version = "0.1.0"
+dependencies = [
+ "mollusk-svm",
+ "quasar-core",
+ "solana-account",
+ "solana-address 2.2.0",
+ "solana-instruction",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -520,9 +520,9 @@ Both programs implement the same escrow logic and run against the same test harn
 
 | Instruction | Quasar | Pinocchio (hand-written) | Delta |
 |-------------|--------|--------------------------|-------|
-| Make        | 9,409  | 9,853                    | -444   |
-| Take        | 17,800 | 17,862                   | -62    |
-| Refund      | 11,945 | 12,033                   | -88    |
+| Make        | 9,415  | 9,853                    | -438   |
+| Take        | 17,804 | 17,862                   | -58    |
+| Refund      | 11,952 | 12,033                   | -81    |
 
 The codegen advantages come from decisions that are tedious to make by hand: byte-level discriminator checks instead of slice comparisons, eliding borrow tracking when the access pattern is statically known, and folding account header arithmetic at compile time.
 

--- a/core/src/accounts/account.rs
+++ b/core/src/accounts/account.rs
@@ -3,6 +3,35 @@ use crate::prelude::*;
 use crate::sysvars::Sysvar;
 use core::marker::PhantomData;
 
+/// Realloc an account to `new_space` bytes, transferring lamports to/from `payer`
+/// to maintain rent-exemption. Used by `Account::realloc` and generated View types.
+#[inline(always)]
+pub fn realloc_account(
+    view: &AccountView,
+    new_space: usize,
+    payer: &AccountView,
+    rent: Option<&crate::accounts::Rent>,
+) -> Result<(), ProgramError> {
+    let rent_exempt_lamports = match rent {
+        Some(rent_account) => rent_account.get()?.try_minimum_balance(new_space)?,
+        None => crate::sysvars::rent::Rent::get()?.try_minimum_balance(new_space)?,
+    };
+
+    let current_lamports = view.lamports();
+
+    if rent_exempt_lamports > current_lamports {
+        crate::cpi::system::transfer(payer, view, rent_exempt_lamports - current_lamports)
+            .invoke()?;
+    } else if current_lamports > rent_exempt_lamports {
+        let excess = current_lamports - rent_exempt_lamports;
+        view.set_lamports(rent_exempt_lamports);
+        payer.set_lamports(payer.lamports() + excess);
+    }
+
+    view.resize(new_space)?;
+    Ok(())
+}
+
 #[repr(transparent)]
 pub struct Account<T: Owner> {
     view: AccountView,
@@ -39,26 +68,7 @@ impl<T: Owner> Account<T> {
         payer: &AccountView,
         rent: Option<&crate::accounts::Rent>,
     ) -> Result<(), ProgramError> {
-        let view = self.to_account_view();
-
-        let rent_exempt_lamports = match rent {
-            Some(rent_account) => rent_account.get()?.try_minimum_balance(new_space)?,
-            None => crate::sysvars::rent::Rent::get()?.try_minimum_balance(new_space)?,
-        };
-
-        let current_lamports = view.lamports();
-
-        if rent_exempt_lamports > current_lamports {
-            crate::cpi::system::transfer(payer, view, rent_exempt_lamports - current_lamports)
-                .invoke()?;
-        } else if current_lamports > rent_exempt_lamports {
-            let excess = current_lamports - rent_exempt_lamports;
-            view.set_lamports(rent_exempt_lamports);
-            payer.set_lamports(payer.lamports() + excess);
-        }
-
-        view.resize(new_space)?;
-        Ok(())
+        realloc_account(self.to_account_view(), new_space, payer, rent)
     }
 }
 
@@ -116,18 +126,18 @@ impl<T: ZeroCopyDeref> core::ops::Deref for Account<T> {
     type Target = T::Target;
 
     /// SAFETY: Bounds validated by `AccountCheck::check` during `from_account_view`.
-    /// ZC companion structs have compile-time `assert!(align_of::<Zc>() == 1)`,
-    /// so the cast from account data pointer (align 1) is always well-aligned.
+    /// For fixed accounts, the target is a ZC companion struct with alignment 1.
+    /// For dynamic accounts, the target is a `#[repr(transparent)]` View over AccountView.
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        unsafe { &*(self.to_account_view().data_ptr().add(T::DATA_OFFSET) as *const T::Target) }
+        T::deref_from(&self.view)
     }
 }
 
 impl<T: ZeroCopyDeref> core::ops::DerefMut for Account<T> {
-    /// SAFETY: Same as Deref — bounds checked upstream, alignment 1 guaranteed.
+    /// SAFETY: Same as Deref — bounds checked upstream.
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *(self.to_account_view().data_ptr().add(T::DATA_OFFSET) as *mut T::Target) }
+        T::deref_from_mut(&self.view)
     }
 }

--- a/core/src/accounts/initialize.rs
+++ b/core/src/accounts/initialize.rs
@@ -2,19 +2,19 @@ use crate::prelude::*;
 use core::marker::PhantomData;
 
 #[repr(transparent)]
-pub struct Initialize<T: QuasarAccount> {
+pub struct Initialize<T: Discriminator> {
     view: AccountView,
     _marker: PhantomData<T>,
 }
 
-impl<T: QuasarAccount> AsAccountView for Initialize<T> {
+impl<T: Discriminator> AsAccountView for Initialize<T> {
     #[inline(always)]
     fn to_account_view(&self) -> &AccountView {
         &self.view
     }
 }
 
-impl<T: QuasarAccount> Initialize<T> {
+impl<T: Discriminator> Initialize<T> {
     #[inline(always)]
     pub fn from_account_view(view: &AccountView) -> Result<&Self, ProgramError> {
         Ok(unsafe { &*(view as *const AccountView as *const Self) })

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -36,6 +36,13 @@ impl WriteBytes for solana_address::Address {
     }
 }
 
+impl<const N: usize> WriteBytes for [u8; N] {
+    #[inline(always)]
+    fn write_bytes(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self);
+    }
+}
+
 #[inline(always)]
 pub fn build_instruction_data(disc: &[u8], write_args: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
     let mut data = Vec::from(disc);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -7,6 +7,10 @@ pub struct Context<'info> {
     pub accounts: &'info [AccountView],
     pub remaining_ptr: *mut u8,
     pub data: &'info [u8],
+    /// Boundary pointer marking end of accounts region in the SVM buffer.
+    /// Computed from the original instruction data pointer (before discriminator
+    /// stripping) as `ix_data_ptr - sizeof(u64)`.
+    pub accounts_boundary: *const u8,
 }
 
 /// Parsed instruction context with typed accounts and PDA bumps.
@@ -17,6 +21,7 @@ pub struct Ctx<'info, T: ParseAccounts<'info> + AccountCount> {
     pub data: &'info [u8],
     remaining_ptr: *mut u8,
     declared: &'info [AccountView],
+    accounts_boundary: *const u8,
 }
 
 impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
@@ -30,13 +35,13 @@ impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
             data: ctx.data,
             remaining_ptr: ctx.remaining_ptr,
             declared: ctx.accounts,
+            accounts_boundary: ctx.accounts_boundary,
         })
     }
 
     /// Access remaining accounts. Zero cost until called.
     #[inline(always)]
     pub fn remaining_accounts(&self) -> RemainingAccounts<'info> {
-        let boundary = unsafe { self.data.as_ptr().sub(core::mem::size_of::<u64>()) };
-        RemainingAccounts::new(self.remaining_ptr, boundary, self.declared)
+        RemainingAccounts::new(self.remaining_ptr, self.accounts_boundary, self.declared)
     }
 }

--- a/core/src/cpi/mod.rs
+++ b/core/src/cpi/mod.rs
@@ -6,7 +6,7 @@ pub use solana_instruction_view::InstructionAccount;
 use core::marker::PhantomData;
 use solana_account_view::{AccountView, RuntimeAccount};
 use solana_address::Address;
-use solana_program_error::ProgramResult;
+use solana_program_error::{ProgramError, ProgramResult};
 
 // --- Raw CPI account (layout-compatible with CpiAccount, uses u8 flags) ---
 
@@ -79,7 +79,7 @@ pub(crate) unsafe fn invoke_raw(
     _cpi_accounts: *const RawCpiAccount,
     _cpi_accounts_len: usize,
     _signers: &[Signer],
-) {
+) -> u64 {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     {
         use solana_define_syscall::definitions::sol_invoke_signed_c;
@@ -98,8 +98,11 @@ pub(crate) unsafe fn invoke_raw(
             _cpi_accounts_len as u64,
             _signers as *const _ as *const u8,
             _signers.len() as u64,
-        );
+        )
     }
+
+    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+    0
 }
 
 // --- CpiCall ---
@@ -154,7 +157,7 @@ impl<'a, const ACCTS: usize, const DATA: usize> CpiCall<'a, ACCTS, DATA> {
 
     #[inline(always)]
     fn invoke_inner(&self, signers: &[Signer]) -> ProgramResult {
-        unsafe {
+        let result = unsafe {
             invoke_raw(
                 self.program_id,
                 self.accounts.as_ptr(),
@@ -164,8 +167,12 @@ impl<'a, const ACCTS: usize, const DATA: usize> CpiCall<'a, ACCTS, DATA> {
                 self.cpi_accounts.as_ptr(),
                 ACCTS,
                 signers,
-            );
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(ProgramError::from(result))
         }
-        Ok(())
     }
 }

--- a/core/src/entrypoint.rs
+++ b/core/src/entrypoint.rs
@@ -33,6 +33,7 @@ macro_rules! dispatch {
                         accounts: &__accounts,
                         remaining_ptr: __remaining_ptr,
                         data: $ix_data,
+                        accounts_boundary: unsafe { $ix_data.as_ptr().sub(core::mem::size_of::<u64>()) },
                     })
                 }
             ),+

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -103,15 +103,22 @@ pub trait QuasarAccount: Sized + Discriminator + Space {
 /// Zero-copy deref target for `#[repr(C)]` account types.
 ///
 /// When an account type implements `ZeroCopyDeref`, `Account<T>` provides
-/// `Deref`/`DerefMut` to `T::Target` — a `#[repr(C)]` companion struct
-/// with alignment-1 Pod fields. No deserialization occurs; the account
-/// data pointer is cast directly.
+/// `Deref`/`DerefMut` to `T::Target` via `deref_from` / `deref_from_mut`.
 ///
-/// Implemented by: `#[account]` macro for `#[repr(C)]` types.
-/// `DATA_OFFSET` is typically the discriminator length.
+/// For fixed-size accounts, `Target` is the ZC companion struct and the
+/// methods perform a pointer cast past the discriminator.
+///
+/// For dynamic accounts, `Target` is a generated View type (`{Name}View`)
+/// that is `#[repr(transparent)]` over `AccountView`. The View type
+/// provides accessors for dynamic fields and derefs further to the ZC
+/// struct for fixed field access.
+///
+/// Implemented by: `#[account]` macro.
 pub trait ZeroCopyDeref: Owner {
     type Target;
-    const DATA_OFFSET: usize;
+    fn deref_from(view: &AccountView) -> &Self::Target;
+    #[allow(clippy::mut_from_ref)]
+    fn deref_from_mut(view: &AccountView) -> &mut Self::Target;
 }
 
 /// On-chain event with a discriminator, fixed-size data, and emission logic.

--- a/core/tests/miri.rs
+++ b/core/tests/miri.rs
@@ -291,7 +291,16 @@ impl AccountCheck for TestAccountType {
 
 impl ZeroCopyDeref for TestAccountType {
     type Target = TestZcData;
-    const DATA_OFFSET: usize = 4; // discriminator length
+
+    #[inline(always)]
+    fn deref_from(view: &AccountView) -> &Self::Target {
+        unsafe { &*(view.data_ptr().add(4) as *const TestZcData) }
+    }
+
+    #[inline(always)]
+    fn deref_from_mut(view: &AccountView) -> &mut Self::Target {
+        unsafe { &mut *(view.data_ptr().add(4) as *mut TestZcData) }
+    }
 }
 
 // ===========================================================================

--- a/derive/src/account.rs
+++ b/derive/src/account.rs
@@ -199,7 +199,16 @@ fn generate_fixed_account(
 
         impl ZeroCopyDeref for #name {
             type Target = #zc_name;
-            const DATA_OFFSET: usize = Self::DISCRIMINATOR.len();
+
+            #[inline(always)]
+            fn deref_from(view: &AccountView) -> &Self::Target {
+                unsafe { &*(view.data_ptr().add(Self::DISCRIMINATOR.len()) as *const #zc_name) }
+            }
+
+            #[inline(always)]
+            fn deref_from_mut(view: &AccountView) -> &mut Self::Target {
+                unsafe { &mut *(view.data_ptr().add(Self::DISCRIMINATOR.len()) as *mut #zc_name) }
+            }
         }
 
         impl QuasarAccount for #name {
@@ -287,6 +296,7 @@ fn generate_dynamic_account(
     let generics = &input.generics;
     let lt = &input.generics.lifetimes().next().unwrap().lifetime;
     let zc_name = format_ident!("{}Zc", name);
+    let view_name = format_ident!("{}View", name);
 
     // --- 1. Transformed struct fields ---
     let transformed_fields: Vec<proc_macro2::TokenStream> = fields_data
@@ -909,18 +919,38 @@ fn generate_dynamic_account(
             }
         }
 
-        impl ZeroCopyDeref for #name<'_> {
-            type Target = #zc_name;
-            const DATA_OFFSET: usize = #disc_len;
+        /// View type for dynamic account — sits in the deref chain between
+        /// `Account<#name<'_>>` and `#zc_name`. Provides zero-copy accessors
+        /// for dynamic fields and derefs to the ZC struct for fixed fields.
+        #[repr(transparent)]
+        #vis struct #view_name {
+            __view: AccountView,
         }
 
-        impl Account<#name<'_>> {
+        impl AsAccountView for #view_name {
+            #[inline(always)]
+            fn to_account_view(&self) -> &AccountView {
+                &self.__view
+            }
+        }
+
+        impl #view_name {
+            #[inline(always)]
+            pub fn realloc(
+                &self,
+                new_space: usize,
+                payer: &AccountView,
+                rent: Option<&Rent>,
+            ) -> Result<(), ProgramError> {
+                quasar_core::accounts::account::realloc_account(&self.__view, new_space, payer, rent)
+            }
+
             #(#accessor_methods)*
             #(#write_methods)*
 
             #[inline(always)]
             pub fn dynamic_fields(&self) -> #fields_name<'_> {
-                let __data = unsafe { self.to_account_view().borrow_unchecked() };
+                let __data = unsafe { self.__view.borrow_unchecked() };
                 let __zc = unsafe { &*(__data[#disc_len..].as_ptr() as *const #zc_name) };
                 let mut __offset = #disc_len + core::mem::size_of::<#zc_name>();
                 #(#fields_extract_stmts)*
@@ -930,7 +960,7 @@ fn generate_dynamic_account(
 
             #[inline(always)]
             pub fn set_dynamic_fields(&self, __payer: &impl AsAccountView, #(#set_dyn_params),*) -> Result<(), ProgramError> {
-                let __view = self.to_account_view();
+                let __view = &self.__view;
                 let __data = unsafe { __view.borrow_unchecked() };
                 let __zc = unsafe { &*(__data[#disc_len..].as_ptr() as *const #zc_name) };
 
@@ -964,6 +994,38 @@ fn generate_dynamic_account(
             }
         }
 
+        impl core::ops::Deref for #view_name {
+            type Target = #zc_name;
+
+            /// SAFETY: Bounds validated by AccountCheck::check. ZC struct has alignment 1.
+            #[inline(always)]
+            fn deref(&self) -> &Self::Target {
+                unsafe { &*(self.__view.data_ptr().add(#disc_len) as *const #zc_name) }
+            }
+        }
+
+        impl core::ops::DerefMut for #view_name {
+            #[inline(always)]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                unsafe { &mut *(self.__view.data_ptr().add(#disc_len) as *mut #zc_name) }
+            }
+        }
+
+        impl ZeroCopyDeref for #name<'_> {
+            type Target = #view_name;
+
+            /// SAFETY: #view_name is #[repr(transparent)] over AccountView.
+            #[inline(always)]
+            fn deref_from(view: &AccountView) -> &Self::Target {
+                unsafe { &*(view as *const AccountView as *const #view_name) }
+            }
+
+            #[inline(always)]
+            fn deref_from_mut(view: &AccountView) -> &mut Self::Target {
+                unsafe { &mut *(view as *const AccountView as *mut #view_name) }
+            }
+        }
+
         impl #name<'_> {
             pub const MIN_SPACE: usize = #disc_len + core::mem::size_of::<#zc_name>();
             pub const MAX_SPACE: usize = Self::MIN_SPACE #(#max_space_terms)*;
@@ -983,12 +1045,12 @@ fn generate_dynamic_account(
             }
 
             #[inline(always)]
-            pub fn init(self, account: &mut Initialize<Self>, payer: &AccountView, rent: Option<&Rent>) -> Result<(), ProgramError> {
+            pub fn init<'__init>(self, account: &mut Initialize<#name<'__init>>, payer: &AccountView, rent: Option<&Rent>) -> Result<(), ProgramError> {
                 self.init_signed(account, payer, rent, &[])
             }
 
             #[inline(always)]
-            pub fn init_signed(self, account: &mut Initialize<Self>, payer: &AccountView, rent: Option<&Rent>, signers: &[quasar_core::cpi::Signer]) -> Result<(), ProgramError> {
+            pub fn init_signed<'__init>(self, account: &mut Initialize<#name<'__init>>, payer: &AccountView, rent: Option<&Rent>, signers: &[quasar_core::cpi::Signer]) -> Result<(), ProgramError> {
                 #(#max_checks)*
 
                 let view = account.to_account_view();

--- a/examples/escrow/src/client.rs
+++ b/examples/escrow/src/client.rs
@@ -1,0 +1,98 @@
+use alloc::vec;
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+pub struct MakeInstruction {
+    pub maker: Address,
+    pub escrow: Address,
+    pub maker_ta_a: Address,
+    pub maker_ta_b: Address,
+    pub vault_ta_a: Address,
+    pub rent: Address,
+    pub token_program: Address,
+    pub system_program: Address,
+    pub deposit: u64,
+    pub receive: u64,
+}
+
+impl From<MakeInstruction> for Instruction {
+    fn from(ix: MakeInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.maker, true),
+            AccountMeta::new(ix.escrow, false),
+            AccountMeta::new(ix.maker_ta_a, false),
+            AccountMeta::new_readonly(ix.maker_ta_b, false),
+            AccountMeta::new(ix.vault_ta_a, false),
+            AccountMeta::new_readonly(ix.rent, false),
+            AccountMeta::new_readonly(ix.token_program, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![0];
+        data.extend_from_slice(&ix.deposit.to_le_bytes());
+        data.extend_from_slice(&ix.receive.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct TakeInstruction {
+    pub taker: Address,
+    pub escrow: Address,
+    pub maker: Address,
+    pub taker_ta_a: Address,
+    pub taker_ta_b: Address,
+    pub maker_ta_b: Address,
+    pub vault_ta_a: Address,
+    pub token_program: Address,
+}
+
+impl From<TakeInstruction> for Instruction {
+    fn from(ix: TakeInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.taker, true),
+            AccountMeta::new(ix.escrow, false),
+            AccountMeta::new(ix.maker, false),
+            AccountMeta::new(ix.taker_ta_a, false),
+            AccountMeta::new(ix.taker_ta_b, false),
+            AccountMeta::new(ix.maker_ta_b, false),
+            AccountMeta::new(ix.vault_ta_a, false),
+            AccountMeta::new_readonly(ix.token_program, false),
+        ];
+        let data = vec![1];
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct RefundInstruction {
+    pub maker: Address,
+    pub escrow: Address,
+    pub maker_ta_a: Address,
+    pub vault_ta_a: Address,
+    pub token_program: Address,
+}
+
+impl From<RefundInstruction> for Instruction {
+    fn from(ix: RefundInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.maker, true),
+            AccountMeta::new(ix.escrow, false),
+            AccountMeta::new(ix.maker_ta_a, false),
+            AccountMeta::new(ix.vault_ta_a, false),
+            AccountMeta::new_readonly(ix.token_program, false),
+        ];
+        let data = vec![2];
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+

--- a/examples/escrow/src/lib.rs
+++ b/examples/escrow/src/lib.rs
@@ -1,4 +1,9 @@
 #![no_std]
+
+#[cfg(feature = "client")]
+extern crate alloc;
+#[cfg(feature = "client")]
+pub mod client;
 use quasar_core::prelude::*;
 
 mod instructions;

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quasar-multisig"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+] }
+
+[dependencies]
+quasar-core = { path = "../../core" }
+solana-address = { version = "2.2.0" }
+solana-instruction = { version = "3.2.0" }
+
+[dev-dependencies]
+mollusk-svm = "0.10.3"
+solana-account = { version = "3.4.0" }
+solana-address = { version = "2.2.0", features = ["decode"] }
+solana-instruction = { version = "3.2.0", features = ["bincode"] }

--- a/examples/multisig/src/client.rs
+++ b/examples/multisig/src/client.rs
@@ -1,0 +1,110 @@
+use alloc::vec;
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+pub struct CreateInstruction {
+    pub creator: Address,
+    pub config: Address,
+    pub rent: Address,
+    pub system_program: Address,
+    pub threshold: u8,
+}
+
+impl From<CreateInstruction> for Instruction {
+    fn from(ix: CreateInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.creator, true),
+            AccountMeta::new(ix.config, false),
+            AccountMeta::new_readonly(ix.rent, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![0];
+        data.push(ix.threshold as u8);
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct DepositInstruction {
+    pub depositor: Address,
+    pub config: Address,
+    pub vault: Address,
+    pub system_program: Address,
+    pub amount: u64,
+}
+
+impl From<DepositInstruction> for Instruction {
+    fn from(ix: DepositInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.depositor, true),
+            AccountMeta::new_readonly(ix.config, false),
+            AccountMeta::new(ix.vault, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![1];
+        data.extend_from_slice(&ix.amount.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct SetLabelInstruction {
+    pub creator: Address,
+    pub config: Address,
+    pub system_program: Address,
+    pub label_len: u8,
+    pub label_bytes: [u8],
+}
+
+impl From<SetLabelInstruction> for Instruction {
+    fn from(ix: SetLabelInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.creator, true),
+            AccountMeta::new(ix.config, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![2];
+        data.push(ix.label_len as u8);
+        data.extend_from_slice(&ix.label_bytes.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct ExecuteTransferInstruction {
+    pub config: Address,
+    pub creator: Address,
+    pub vault: Address,
+    pub recipient: Address,
+    pub system_program: Address,
+    pub amount: u64,
+}
+
+impl From<ExecuteTransferInstruction> for Instruction {
+    fn from(ix: ExecuteTransferInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new_readonly(ix.config, false),
+            AccountMeta::new_readonly(ix.creator, false),
+            AccountMeta::new(ix.vault, false),
+            AccountMeta::new(ix.recipient, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![3];
+        data.extend_from_slice(&ix.amount.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+

--- a/examples/multisig/src/instructions/create.rs
+++ b/examples/multisig/src/instructions/create.rs
@@ -1,0 +1,57 @@
+use quasar_core::prelude::*;
+use quasar_core::remaining::RemainingAccounts;
+
+use crate::state::MultisigConfig;
+
+#[derive(Accounts)]
+pub struct Create<'info> {
+    pub creator: &'info mut Signer,
+    #[account(seeds = [b"multisig", creator], bump)]
+    pub config: &'info mut Initialize<MultisigConfig<'info>>,
+    pub rent: &'info Rent,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> Create<'info> {
+    #[inline(always)]
+    pub fn create_multisig(
+        &mut self,
+        threshold: u8,
+        bumps: &CreateBumps,
+        remaining: RemainingAccounts,
+    ) -> Result<(), ProgramError> {
+        let mut addrs = [Address::default(); 10];
+        let mut count = 0usize;
+
+        for account in remaining.iter() {
+            if count >= 10 {
+                return Err(ProgramError::InvalidArgument);
+            }
+            if !account.is_signer() {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+            addrs[count] = *account.address();
+            count += 1;
+        }
+
+        if threshold == 0 || threshold as usize > count {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        let seeds = bumps.config_seeds();
+
+        MultisigConfig {
+            creator: *self.creator.address(),
+            threshold,
+            bump: bumps.config,
+            label: "",
+            signers: &addrs[..count],
+        }
+        .init_signed(
+            self.config,
+            self.creator.to_account_view(),
+            Some(self.rent),
+            &[quasar_core::cpi::Signer::from(&seeds)],
+        )
+    }
+}

--- a/examples/multisig/src/instructions/deposit.rs
+++ b/examples/multisig/src/instructions/deposit.rs
@@ -1,0 +1,21 @@
+use quasar_core::prelude::*;
+
+use crate::state::MultisigConfig;
+
+#[derive(Accounts)]
+pub struct Deposit<'info> {
+    pub depositor: &'info mut Signer,
+    pub config: &'info Account<MultisigConfig<'info>>,
+    #[account(mut, seeds = [b"vault", config], bump)]
+    pub vault: &'info mut UncheckedAccount,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> Deposit<'info> {
+    #[inline(always)]
+    pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
+        self.system_program
+            .transfer(self.depositor, self.vault, amount)
+            .invoke()
+    }
+}

--- a/examples/multisig/src/instructions/execute_transfer.rs
+++ b/examples/multisig/src/instructions/execute_transfer.rs
@@ -1,0 +1,55 @@
+use quasar_core::prelude::*;
+use quasar_core::remaining::RemainingAccounts;
+
+use crate::state::MultisigConfig;
+
+#[derive(Accounts)]
+pub struct ExecuteTransfer<'info> {
+    #[account(
+        has_one = creator,
+        seeds = [b"multisig", creator],
+        bump = config.bump
+    )]
+    pub config: &'info Account<MultisigConfig<'info>>,
+    pub creator: &'info UncheckedAccount,
+    #[account(mut, seeds = [b"vault", config], bump)]
+    pub vault: &'info mut UncheckedAccount,
+    pub recipient: &'info mut UncheckedAccount,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> ExecuteTransfer<'info> {
+    #[inline(always)]
+    pub fn verify_and_transfer(
+        &self,
+        amount: u64,
+        bumps: &ExecuteTransferBumps,
+        remaining: RemainingAccounts,
+    ) -> Result<(), ProgramError> {
+        let stored_signers = self.config.signers();
+        let threshold = self.config.threshold;
+
+        let mut approvals = 0u8;
+        for account in remaining.iter() {
+            if !account.is_signer() {
+                continue;
+            }
+            let addr = account.address();
+            for stored in stored_signers {
+                if addr == stored {
+                    approvals += 1;
+                    break;
+                }
+            }
+        }
+
+        if approvals < threshold {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        let seeds = bumps.vault_seeds();
+        self.system_program
+            .transfer(self.vault, self.recipient, amount)
+            .invoke_signed(&seeds)
+    }
+}

--- a/examples/multisig/src/instructions/mod.rs
+++ b/examples/multisig/src/instructions/mod.rs
@@ -1,0 +1,11 @@
+pub mod create;
+pub use create::*;
+
+pub mod deposit;
+pub use deposit::*;
+
+pub mod set_label;
+pub use set_label::*;
+
+pub mod execute_transfer;
+pub use execute_transfer::*;

--- a/examples/multisig/src/instructions/set_label.rs
+++ b/examples/multisig/src/instructions/set_label.rs
@@ -1,0 +1,26 @@
+use quasar_core::prelude::*;
+
+use crate::state::MultisigConfig;
+
+#[derive(Accounts)]
+pub struct SetLabel<'info> {
+    pub creator: &'info mut Signer,
+    #[account(
+        mut,
+        has_one = creator,
+        seeds = [b"multisig", creator],
+        bump = config.bump
+    )]
+    pub config: &'info mut Account<MultisigConfig<'info>>,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> SetLabel<'info> {
+    #[inline(always)]
+    pub fn update_label(&self, label_len: u8, label_bytes: &[u8; 32]) -> Result<(), ProgramError> {
+        let label = core::str::from_utf8(&label_bytes[..label_len as usize])
+            .map_err(|_| ProgramError::InvalidArgument)?;
+
+        self.config.set_label(self.creator, label)
+    }
+}

--- a/examples/multisig/src/lib.rs
+++ b/examples/multisig/src/lib.rs
@@ -1,0 +1,40 @@
+#![no_std]
+
+#[cfg(feature = "client")]
+extern crate alloc;
+#[cfg(feature = "client")]
+pub mod client;
+use quasar_core::prelude::*;
+
+mod instructions;
+use instructions::*;
+mod state;
+#[cfg(test)]
+mod tests;
+
+declare_id!("44444444444444444444444444444444444444444444");
+
+#[program]
+mod quasar_multisig {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn create(ctx: Ctx<Create>, threshold: u8) -> Result<(), ProgramError> {
+        ctx.accounts.create_multisig(threshold, &ctx.bumps, ctx.remaining_accounts())
+    }
+
+    #[instruction(discriminator = 1)]
+    pub fn deposit(ctx: Ctx<Deposit>, amount: u64) -> Result<(), ProgramError> {
+        ctx.accounts.deposit(amount)
+    }
+
+    #[instruction(discriminator = 2)]
+    pub fn set_label(ctx: Ctx<SetLabel>, label_len: u8, label_bytes: [u8; 32]) -> Result<(), ProgramError> {
+        ctx.accounts.update_label(label_len, &label_bytes)
+    }
+
+    #[instruction(discriminator = 3)]
+    pub fn execute_transfer(ctx: Ctx<ExecuteTransfer>, amount: u64) -> Result<(), ProgramError> {
+        ctx.accounts.verify_and_transfer(amount, &ctx.bumps, ctx.remaining_accounts())
+    }
+}

--- a/examples/multisig/src/state.rs
+++ b/examples/multisig/src/state.rs
@@ -1,0 +1,10 @@
+use quasar_core::prelude::*;
+
+#[account(discriminator = 1)]
+pub struct MultisigConfig<'a> {
+    pub creator: Address,
+    pub threshold: u8,
+    pub bump: u8,
+    pub label: String<'a, 32>,
+    pub signers: Vec<'a, Address, 10>,
+}

--- a/examples/multisig/src/tests.rs
+++ b/examples/multisig/src/tests.rs
@@ -1,0 +1,422 @@
+extern crate std;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use mollusk_svm::{program::keyed_account_for_system_program, Mollusk};
+
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+use crate::client::{
+    CreateInstruction, DepositInstruction, ExecuteTransferInstruction, SetLabelInstruction,
+};
+
+fn setup() -> Mollusk {
+    Mollusk::new(&crate::ID, "../../target/deploy/quasar_multisig")
+}
+
+fn build_config_data(
+    creator: Address,
+    threshold: u8,
+    bump: u8,
+    label: &str,
+    signers: &[Address],
+) -> Vec<u8> {
+    let zc_header_size = 32 + 1 + 1 + 2 + 2; // creator + threshold + bump + label_len + signers_count
+    let total = 1 + zc_header_size + label.len() + signers.len() * 32;
+    let mut data = vec![0u8; total];
+
+    // Discriminator
+    data[0] = 1;
+
+    // ZC header starts at offset 1
+    let header = &mut data[1..];
+
+    // creator (32 bytes)
+    header[..32].copy_from_slice(creator.as_ref());
+    // threshold (1 byte)
+    header[32] = threshold;
+    // bump (1 byte)
+    header[33] = bump;
+    // label_len (2 bytes LE)
+    header[34..36].copy_from_slice(&(label.len() as u16).to_le_bytes());
+    // signers_count (2 bytes LE)
+    header[36..38].copy_from_slice(&(signers.len() as u16).to_le_bytes());
+
+    // Variable tail: label bytes, then signer addresses
+    let tail_start = 1 + zc_header_size;
+    data[tail_start..tail_start + label.len()].copy_from_slice(label.as_bytes());
+    let signers_start = tail_start + label.len();
+    for (i, signer) in signers.iter().enumerate() {
+        data[signers_start + i * 32..signers_start + (i + 1) * 32]
+            .copy_from_slice(signer.as_ref());
+    }
+
+    data
+}
+
+#[test]
+fn test_create() {
+    let mollusk = setup();
+
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+    let (rent, rent_account) = mollusk.sysvars.keyed_account_for_rent_sysvar();
+
+    let creator = Address::new_unique();
+    let creator_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let (config, _config_bump) =
+        Address::find_program_address(&[b"multisig", creator.as_ref()], &crate::ID);
+    let config_account = Account::default();
+
+    let signer1 = Address::new_unique();
+    let signer1_account = Account::default();
+    let signer2 = Address::new_unique();
+    let signer2_account = Account::default();
+    let signer3 = Address::new_unique();
+    let signer3_account = Account::default();
+
+    let threshold: u8 = 2;
+
+    // Build instruction with remaining accounts for signers
+    let mut instruction: Instruction = CreateInstruction {
+        creator,
+        config,
+        rent,
+        system_program,
+        threshold,
+    }
+    .into();
+
+    // Add remaining accounts (signers)
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer1, true));
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer2, true));
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer3, true));
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (creator, creator_account),
+            (config, config_account),
+            (rent, rent_account),
+            (system_program, system_program_account),
+            (signer1, signer1_account),
+            (signer2, signer2_account),
+            (signer3, signer3_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "create failed: {:?}",
+        result.program_result
+    );
+
+    // Verify config account data
+    let config_data = &result.resulting_accounts[1].1.data;
+    assert_eq!(config_data[0], 1, "discriminator should be 1");
+
+    // Verify threshold (offset: disc(1) + creator(32) = 33)
+    assert_eq!(config_data[33], threshold, "threshold mismatch");
+
+    // Verify signers count (offset: disc(1) + creator(32) + threshold(1) + bump(1) + label_len(2) = 37)
+    let signers_count = u16::from_le_bytes([config_data[37], config_data[38]]);
+    assert_eq!(signers_count, 3, "signers count should be 3");
+
+    std::println!("\n========================================");
+    std::println!("  CREATE CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}
+
+#[test]
+fn test_deposit() {
+    let mollusk = setup();
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let creator = Address::new_unique();
+    let signer1 = Address::new_unique();
+    let signer2 = Address::new_unique();
+
+    let (config, config_bump) =
+        Address::find_program_address(&[b"multisig", creator.as_ref()], &crate::ID);
+    let config_data = build_config_data(creator, 2, config_bump, "", &[signer1, signer2]);
+    let config_account = Account {
+        lamports: 1_000_000,
+        data: config_data,
+        owner: crate::ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (vault, _vault_bump) =
+        Address::find_program_address(&[b"vault", config.as_ref()], &crate::ID);
+    let vault_account = Account::new(0, 0, &system_program);
+
+    let depositor = Address::new_unique();
+    let depositor_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let deposit_amount: u64 = 1_000_000_000;
+
+    let instruction: Instruction = DepositInstruction {
+        depositor,
+        config,
+        vault,
+        system_program,
+        amount: deposit_amount,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (depositor, depositor_account),
+            (config, config_account),
+            (vault, vault_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "deposit failed: {:?}",
+        result.program_result
+    );
+
+    let vault_after = result.resulting_accounts[2].1.lamports;
+    assert_eq!(vault_after, deposit_amount, "vault lamports after deposit");
+
+    std::println!("\n========================================");
+    std::println!("  DEPOSIT CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}
+
+#[test]
+fn test_set_label() {
+    let mollusk = setup();
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let creator = Address::new_unique();
+    let creator_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let signer1 = Address::new_unique();
+
+    let (config, config_bump) =
+        Address::find_program_address(&[b"multisig", creator.as_ref()], &crate::ID);
+    let config_data = build_config_data(creator, 1, config_bump, "", &[signer1]);
+    let config_account = Account {
+        lamports: 1_000_000,
+        data: config_data,
+        owner: crate::ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let label = "Treasury";
+    let mut label_bytes = [0u8; 32];
+    label_bytes[..label.len()].copy_from_slice(label.as_bytes());
+
+    let instruction: Instruction = SetLabelInstruction {
+        creator,
+        config,
+        system_program,
+        label_len: label.len() as u8,
+        label_bytes,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (creator, creator_account),
+            (config, config_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "set_label failed: {:?}",
+        result.program_result
+    );
+
+    // Verify label was stored
+    let config_data = &result.resulting_accounts[1].1.data;
+    let label_len = u16::from_le_bytes([config_data[35], config_data[36]]) as usize;
+    assert_eq!(label_len, label.len(), "label length mismatch");
+
+    let zc_header_size = 32 + 1 + 1 + 2 + 2; // 38
+    let label_start = 1 + zc_header_size;
+    let stored_label = core::str::from_utf8(&config_data[label_start..label_start + label_len])
+        .expect("invalid UTF-8");
+    assert_eq!(stored_label, label, "label content mismatch");
+
+    std::println!("\n========================================");
+    std::println!("  SET_LABEL CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}
+
+#[test]
+fn test_execute_transfer() {
+    let mollusk = setup();
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let creator = Address::new_unique();
+    let creator_account = Account::default();
+
+    let signer1 = Address::new_unique();
+    let signer1_account = Account::default();
+    let signer2 = Address::new_unique();
+    let signer2_account = Account::default();
+    let signer3 = Address::new_unique();
+
+    let (config, config_bump) =
+        Address::find_program_address(&[b"multisig", creator.as_ref()], &crate::ID);
+    let config_data =
+        build_config_data(creator, 2, config_bump, "", &[signer1, signer2, signer3]);
+    let config_account = Account {
+        lamports: 1_000_000,
+        data: config_data,
+        owner: crate::ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (vault, _vault_bump) =
+        Address::find_program_address(&[b"vault", config.as_ref()], &crate::ID);
+    let vault_account = Account::new(5_000_000_000, 0, &system_program);
+
+    let recipient = Address::new_unique();
+    let recipient_account = Account::new(0, 0, &system_program);
+
+    let transfer_amount: u64 = 1_000_000_000;
+
+    // Build instruction with 2 signers as remaining accounts (meets threshold of 2)
+    let mut instruction: Instruction = ExecuteTransferInstruction {
+        config,
+        creator,
+        vault,
+        recipient,
+        system_program,
+        amount: transfer_amount,
+    }
+    .into();
+
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer1, true));
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer2, true));
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (config, config_account),
+            (creator, creator_account),
+            (vault, vault_account),
+            (recipient, recipient_account),
+            (system_program, system_program_account.clone()),
+            (signer1, signer1_account),
+            (signer2, signer2_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "execute_transfer failed: {:?}",
+        result.program_result
+    );
+
+    let vault_after = result.resulting_accounts[2].1.lamports;
+    let recipient_after = result.resulting_accounts[3].1.lamports;
+
+    assert_eq!(
+        vault_after,
+        5_000_000_000 - transfer_amount,
+        "vault lamports after transfer"
+    );
+    assert_eq!(
+        recipient_after, transfer_amount,
+        "recipient lamports after transfer"
+    );
+
+    std::println!("\n========================================");
+    std::println!("  EXECUTE_TRANSFER CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}
+
+#[test]
+fn test_execute_transfer_insufficient_signers() {
+    let mollusk = setup();
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let creator = Address::new_unique();
+    let creator_account = Account::default();
+
+    let signer1 = Address::new_unique();
+    let signer1_account = Account::default();
+    let signer2 = Address::new_unique();
+    let signer3 = Address::new_unique();
+
+    let (config, config_bump) =
+        Address::find_program_address(&[b"multisig", creator.as_ref()], &crate::ID);
+    let config_data =
+        build_config_data(creator, 2, config_bump, "", &[signer1, signer2, signer3]);
+    let config_account = Account {
+        lamports: 1_000_000,
+        data: config_data,
+        owner: crate::ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (vault, _vault_bump) =
+        Address::find_program_address(&[b"vault", config.as_ref()], &crate::ID);
+    let vault_account = Account::new(5_000_000_000, 0, &system_program);
+
+    let recipient = Address::new_unique();
+    let recipient_account = Account::new(0, 0, &system_program);
+
+    // Only 1 signer — threshold is 2, should fail
+    let mut instruction: Instruction = ExecuteTransferInstruction {
+        config,
+        creator,
+        vault,
+        recipient,
+        system_program,
+        amount: 1_000_000_000,
+    }
+    .into();
+
+    instruction
+        .accounts
+        .push(AccountMeta::new_readonly(signer1, true));
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (config, config_account),
+            (creator, creator_account),
+            (vault, vault_account),
+            (recipient, recipient_account),
+            (system_program, system_program_account),
+            (signer1, signer1_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "should fail with insufficient signers"
+    );
+
+    std::println!("\n========================================");
+    std::println!("  INSUFFICIENT_SIGNERS: correctly rejected");
+    std::println!("========================================\n");
+}

--- a/examples/vault/Cargo.toml
+++ b/examples/vault/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quasar-vault"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+] }
+
+[dependencies]
+quasar-core = { path = "../../core" }
+solana-address = { version = "2.2.0" }
+solana-instruction = { version = "3.2.0" }
+
+[dev-dependencies]
+mollusk-svm = "0.10.3"
+solana-account = { version = "3.4.0" }
+solana-address = { version = "2.2.0", features = ["decode"] }
+solana-instruction = { version = "3.2.0", features = ["bincode"] }

--- a/examples/vault/src/client.rs
+++ b/examples/vault/src/client.rs
@@ -1,0 +1,52 @@
+use alloc::vec;
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+pub struct DepositInstruction {
+    pub user: Address,
+    pub vault: Address,
+    pub system_program: Address,
+    pub amount: u64,
+}
+
+impl From<DepositInstruction> for Instruction {
+    fn from(ix: DepositInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.user, true),
+            AccountMeta::new(ix.vault, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![0];
+        data.extend_from_slice(&ix.amount.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+
+pub struct WithdrawInstruction {
+    pub user: Address,
+    pub vault: Address,
+    pub system_program: Address,
+    pub amount: u64,
+}
+
+impl From<WithdrawInstruction> for Instruction {
+    fn from(ix: WithdrawInstruction) -> Instruction {
+        let accounts = vec![
+            AccountMeta::new(ix.user, true),
+            AccountMeta::new(ix.vault, false),
+            AccountMeta::new_readonly(ix.system_program, false),
+        ];
+        let mut data = vec![1];
+        data.extend_from_slice(&ix.amount.to_le_bytes());
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data,
+        }
+    }
+}
+

--- a/examples/vault/src/instructions/deposit.rs
+++ b/examples/vault/src/instructions/deposit.rs
@@ -1,0 +1,18 @@
+use quasar_core::prelude::*;
+
+#[derive(Accounts)]
+pub struct Deposit<'info> {
+    pub user: &'info mut Signer,
+    #[account(mut, seeds = [b"vault", user], bump)]
+    pub vault: &'info mut UncheckedAccount,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> Deposit<'info> {
+    #[inline(always)]
+    pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
+        self.system_program
+            .transfer(self.user, self.vault, amount)
+            .invoke()
+    }
+}

--- a/examples/vault/src/instructions/mod.rs
+++ b/examples/vault/src/instructions/mod.rs
@@ -1,0 +1,5 @@
+pub mod deposit;
+pub use deposit::*;
+
+pub mod withdraw;
+pub use withdraw::*;

--- a/examples/vault/src/instructions/withdraw.rs
+++ b/examples/vault/src/instructions/withdraw.rs
@@ -1,0 +1,19 @@
+use quasar_core::prelude::*;
+
+#[derive(Accounts)]
+pub struct Withdraw<'info> {
+    pub user: &'info mut Signer,
+    #[account(mut, seeds = [b"vault", user], bump)]
+    pub vault: &'info mut UncheckedAccount,
+    pub system_program: &'info SystemProgram,
+}
+
+impl<'info> Withdraw<'info> {
+    #[inline(always)]
+    pub fn withdraw(&self, amount: u64, bumps: &WithdrawBumps) -> Result<(), ProgramError> {
+        let seeds = bumps.vault_seeds();
+        self.system_program
+            .transfer(self.vault, self.user, amount)
+            .invoke_signed(&seeds)
+    }
+}

--- a/examples/vault/src/lib.rs
+++ b/examples/vault/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+#[cfg(feature = "client")]
+extern crate alloc;
+#[cfg(feature = "client")]
+pub mod client;
+use quasar_core::prelude::*;
+
+mod instructions;
+use instructions::*;
+#[cfg(test)]
+mod tests;
+
+declare_id!("33333333333333333333333333333333333333333333");
+
+#[program]
+mod quasar_vault {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn deposit(ctx: Ctx<Deposit>, amount: u64) -> Result<(), ProgramError> {
+        ctx.accounts.deposit(amount)
+    }
+
+    #[instruction(discriminator = 1)]
+    pub fn withdraw(ctx: Ctx<Withdraw>, amount: u64) -> Result<(), ProgramError> {
+        ctx.accounts.withdraw(amount, &ctx.bumps)
+    }
+}

--- a/examples/vault/src/tests.rs
+++ b/examples/vault/src/tests.rs
@@ -1,0 +1,152 @@
+extern crate std;
+
+use mollusk_svm::{program::keyed_account_for_system_program, Mollusk};
+
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::Instruction;
+
+use crate::client::{DepositInstruction, WithdrawInstruction};
+
+fn setup() -> Mollusk {
+    Mollusk::new(&crate::ID, "../../target/deploy/quasar_vault")
+}
+
+#[test]
+fn test_deposit() {
+    let mollusk = setup();
+
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let user = Address::new_unique();
+    let user_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let (vault, _vault_bump) =
+        Address::find_program_address(&[b"vault", user.as_ref()], &crate::ID);
+    let vault_account = Account::new(0, 0, &system_program);
+
+    let deposit_amount: u64 = 1_000_000_000;
+
+    let instruction: Instruction = DepositInstruction {
+        user,
+        vault,
+        system_program,
+        amount: deposit_amount,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (user, user_account.clone()),
+            (vault, vault_account.clone()),
+            (system_program, system_program_account.clone()),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "deposit failed: {:?}",
+        result.program_result
+    );
+
+    let user_after = result.resulting_accounts[0].1.lamports;
+    let vault_after = result.resulting_accounts[1].1.lamports;
+
+    assert_eq!(
+        user_after,
+        10_000_000_000 - deposit_amount,
+        "user lamports after deposit"
+    );
+    assert_eq!(vault_after, deposit_amount, "vault lamports after deposit");
+
+    std::println!("\n========================================");
+    std::println!("  DEPOSIT CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}
+
+#[test]
+fn test_withdraw() {
+    let mollusk = setup();
+
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let user = Address::new_unique();
+    let user_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let (vault, _vault_bump) =
+        Address::find_program_address(&[b"vault", user.as_ref()], &crate::ID);
+    let vault_account = Account::new(0, 0, &system_program);
+
+    let deposit_amount: u64 = 1_000_000_000;
+
+    // First deposit
+    let deposit_ix: Instruction = DepositInstruction {
+        user,
+        vault,
+        system_program,
+        amount: deposit_amount,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &deposit_ix,
+        &[
+            (user, user_account),
+            (vault, vault_account),
+            (system_program, system_program_account.clone()),
+        ],
+    );
+    assert!(
+        result.program_result.is_ok(),
+        "deposit failed: {:?}",
+        result.program_result
+    );
+
+    let user_after_deposit = result.resulting_accounts[0].1.clone();
+    let vault_after_deposit = result.resulting_accounts[1].1.clone();
+
+    // Now withdraw
+    let withdraw_amount: u64 = 500_000_000;
+
+    let withdraw_ix: Instruction = WithdrawInstruction {
+        user,
+        vault,
+        system_program,
+        amount: withdraw_amount,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &withdraw_ix,
+        &[
+            (user, user_after_deposit.clone()),
+            (vault, vault_after_deposit),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "withdraw failed: {:?}",
+        result.program_result
+    );
+
+    let user_final = result.resulting_accounts[0].1.lamports;
+    let vault_final = result.resulting_accounts[1].1.lamports;
+
+    assert_eq!(
+        user_final,
+        user_after_deposit.lamports + withdraw_amount,
+        "user lamports after withdraw"
+    );
+    assert_eq!(
+        vault_final,
+        deposit_amount - withdraw_amount,
+        "vault lamports after withdraw"
+    );
+
+    std::println!("\n========================================");
+    std::println!("  WITHDRAW CU: {}", result.compute_units_consumed);
+    std::println!("========================================\n");
+}

--- a/idl/src/parser/events.rs
+++ b/idl/src/parser/events.rs
@@ -95,12 +95,9 @@ pub fn to_idl_type_def(raw: &RawEvent) -> IdlTypeDef {
     let fields = raw
         .fields
         .iter()
-        .map(|(name, ty)| {
-            let type_name = helpers::simple_type_name(ty);
-            IdlField {
-                name: helpers::to_camel_case(name),
-                ty: helpers::map_type(&type_name),
-            }
+        .map(|(name, ty)| IdlField {
+            name: helpers::to_camel_case(name),
+            ty: helpers::map_type_from_syn(ty),
         })
         .collect();
 

--- a/idl/src/parser/helpers.rs
+++ b/idl/src/parser/helpers.rs
@@ -1,4 +1,4 @@
-use crate::types::IdlType;
+use crate::types::{IdlDynString, IdlDynVec, IdlType};
 
 /// Convert `snake_case` to `camelCase`.
 pub fn to_camel_case(s: &str) -> String {
@@ -31,6 +31,71 @@ pub fn map_type(rust_type: &str) -> IdlType {
             defined: other.to_string(),
         },
     }
+}
+
+/// Map a `syn::Type` to an `IdlType`, detecting dynamic fields:
+///
+/// - `String<'a, N>` / `String<N>` → `IdlType::DynString { maxLength: N }`
+/// - `Vec<'a, T, N>` / `Vec<T, N>` → `IdlType::DynVec { items: T, maxLength: N }`
+///
+/// Falls back to `simple_type_name + map_type` for everything else.
+pub fn map_type_from_syn(ty: &syn::Type) -> IdlType {
+    let inner = match ty {
+        syn::Type::Reference(r) => &*r.elem,
+        other => other,
+    };
+
+    if let syn::Type::Path(type_path) = inner {
+        if let Some(seg) = type_path.path.segments.last() {
+            if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                let ident = seg.ident.to_string();
+                let mut iter = args.args.iter();
+
+                // Skip leading lifetime if present
+                let first = iter.next();
+                let has_lifetime = matches!(first, Some(syn::GenericArgument::Lifetime(_)));
+
+                if ident == "String" {
+                    // String<'a, N> or String<N>
+                    let const_arg = if has_lifetime { iter.next() } else { first };
+                    if let Some(syn::GenericArgument::Const(syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Int(lit_int),
+                        ..
+                    }))) = const_arg
+                    {
+                        if let Ok(max_length) = lit_int.base10_parse::<usize>() {
+                            return IdlType::DynString {
+                                string: IdlDynString { max_length },
+                            };
+                        }
+                    }
+                } else if ident == "Vec" {
+                    // Vec<'a, T, N> or Vec<T, N>
+                    let type_arg = if has_lifetime { iter.next() } else { first };
+                    if let Some(syn::GenericArgument::Type(elem_ty)) = type_arg {
+                        if let Some(syn::GenericArgument::Const(syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Int(lit_int),
+                            ..
+                        }))) = iter.next()
+                        {
+                            if let Ok(max_length) = lit_int.base10_parse::<usize>() {
+                                let items = map_type_from_syn(elem_ty);
+                                return IdlType::DynVec {
+                                    vec: IdlDynVec {
+                                        items: Box::new(items),
+                                        max_length,
+                                    },
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let type_name = simple_type_name(ty);
+    map_type(&type_name)
 }
 
 /// Extract the last segment identifier from a syn::Type.

--- a/idl/src/parser/mod.rs
+++ b/idl/src/parser/mod.rs
@@ -100,12 +100,9 @@ pub fn build_idl(parsed: ParsedProgram) -> Idl {
             let args: Vec<IdlField> = ix
                 .args
                 .iter()
-                .map(|(name, ty)| {
-                    let type_name = helpers::simple_type_name(ty);
-                    IdlField {
-                        name: helpers::to_camel_case(name),
-                        ty: helpers::map_type(&type_name),
-                    }
+                .map(|(name, ty)| IdlField {
+                    name: helpers::to_camel_case(name),
+                    ty: helpers::map_type_from_syn(ty),
                 })
                 .collect();
 

--- a/idl/src/parser/state.rs
+++ b/idl/src/parser/state.rs
@@ -100,12 +100,9 @@ pub fn to_idl_type_def(raw: &RawStateAccount) -> IdlTypeDef {
     let fields = raw
         .fields
         .iter()
-        .map(|(name, ty)| {
-            let type_name = helpers::simple_type_name(ty);
-            IdlField {
-                name: helpers::to_camel_case(name),
-                ty: helpers::map_type(&type_name),
-            }
+        .map(|(name, ty)| IdlField {
+            name: helpers::to_camel_case(name),
+            ty: helpers::map_type_from_syn(ty),
         })
         .collect();
 

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -63,10 +63,25 @@ pub struct IdlField {
 }
 
 #[derive(Serialize)]
+pub struct IdlDynString {
+    #[serde(rename = "maxLength")]
+    pub max_length: usize,
+}
+
+#[derive(Serialize)]
+pub struct IdlDynVec {
+    pub items: Box<IdlType>,
+    #[serde(rename = "maxLength")]
+    pub max_length: usize,
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum IdlType {
     Primitive(String),
     Defined { defined: String },
+    DynString { string: IdlDynString },
+    DynVec { vec: IdlDynVec },
 }
 
 #[derive(Serialize)]

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -66,7 +66,16 @@ impl Owner for TokenAccount {
 
 impl ZeroCopyDeref for TokenAccount {
     type Target = TokenAccountState;
-    const DATA_OFFSET: usize = 0;
+
+    #[inline(always)]
+    fn deref_from(view: &AccountView) -> &Self::Target {
+        unsafe { &*(view.data_ptr() as *const TokenAccountState) }
+    }
+
+    #[inline(always)]
+    fn deref_from_mut(view: &AccountView) -> &mut Self::Target {
+        unsafe { &mut *(view.data_ptr() as *mut TokenAccountState) }
+    }
 }
 
 // --- CPI Methods ---


### PR DESCRIPTION
## Summary

Dynamic accounts (`String<'a, N>`, `Vec<'a, T, N>`) lacked a proper deref chain — dynamic field accessors lived directly on `Account<T>`, meaning the framework couldn't express `Account → View → Zc` layering. CPI silently swallowed errors from failed cross-program invocations. The IDL generator dropped type information for dynamic fields. Two new examples (multisig, vault) exercise dynamic data and PDA-signed SOL transfers end-to-end.

## Dynamic Account View Types

### Before

`Account<T>` for dynamic accounts deref'd directly to the ZC companion struct via a `DATA_OFFSET` const on `ZeroCopyDeref`. Dynamic field accessors (`name()`, `tags()`, `set_name()`, `set_dynamic_fields()`, `realloc()`) were implemented on `Account<T>` itself. This conflated two concerns — fixed field access (via ZC pointer cast) and dynamic field access (offset computation from length descriptors) — on the same type.

### After

The `#[account]` macro generates a `{Name}View` type that is `#[repr(transparent)]` over `AccountView`. The deref chain is:

```
Account<MultisigConfig<'_>>  →  MultisigConfigView  →  MultisigConfigZc
                              (dynamic accessors)     (fixed field access)
```

`ZeroCopyDeref` changes from a const offset to two methods:

```rust
pub trait ZeroCopyDeref: Owner {
    type Target;
    fn deref_from(view: &AccountView) -> &Self::Target;
    fn deref_from_mut(view: &AccountView) -> &mut Self::Target;
}
```

For fixed accounts, `deref_from` casts past the discriminator (same as before). For dynamic accounts, `deref_from` returns a `&View` — a transparent wrapper over `AccountView` that carries all the dynamic accessors and itself derefs to the ZC struct for fixed fields.

This also means `realloc()` moves from `Account<T>` to the View type, backed by a shared `realloc_account()` free function in `core::accounts::account`.

The `Initialize<T>` trait bound relaxes from `QuasarAccount` to `Discriminator` — dynamic accounts implement `Discriminator` + `Space` but not `QuasarAccount` (which requires `Sized`, and View types are DST-like in their usage pattern).

## CPI Error Propagation

### Before

`invoke_raw` returned `()`. CPI failures were silently ignored — `invoke_inner` always returned `Ok(())`.

### After

`invoke_raw` returns `u64` (the syscall return code). `invoke_inner` checks the result and converts non-zero to `ProgramError`:

```rust
let result = unsafe { invoke_raw(...) };
if result == 0 {
    Ok(())
} else {
    Err(ProgramError::from(result))
}
```

The off-SBF stub returns `0` (success) for test compatibility.

## Context Boundary Pointer

### Before

`Ctx::remaining_accounts()` computed the accounts boundary from the instruction data pointer: `self.data.as_ptr().sub(sizeof::<u64>())`. This broke when the data slice was stripped of its discriminator prefix — the pointer no longer pointed at the original boundary.

### After

The boundary pointer is computed once in the `dispatch!` macro (before discriminator stripping) and stored on `Context` and `Ctx`:

```rust
pub struct Context<'info> {
    // ...
    pub accounts_boundary: *const u8,
}
```

`remaining_accounts()` uses the stored pointer directly.

## IDL Dynamic Field Support

The IDL generator mapped all types through `simple_type_name()` → `map_type()`, which strips generics. `String<'a, 32>` became `"string"` and `Vec<'a, Address, 10>` became `{"defined": "Vec"}` — dropping max-length and element type.

`map_type_from_syn(ty: &syn::Type) -> IdlType` detects dynamic fields by matching the syn AST directly — same pattern as `derive/src/helpers.rs`. Handles both lifetime (`String<'a, N>`) and no-lifetime (`String<N>`) variants.

IDL output format:

```json
{ "type": { "string": { "maxLength": 32 } } }
{ "type": { "vec": { "items": "publicKey", "maxLength": 10 } } }
```

Element types are mapped recursively for nested dynamic types.

## Multisig Example

`examples/multisig/` — a multisig wallet demonstrating dynamic account fields:

- `MultisigConfig` with `String<'a, 32>` label and `Vec<'a, Address, 10>` signers
- `create` — initialize config PDA with threshold
- `set_label` — dynamic string write with realloc
- `deposit` — SOL transfer to PDA vault
- `execute_transfer` — PDA-signed SOL withdrawal with threshold validation

## Vault Example

`examples/vault/` — minimal SOL vault demonstrating PDA-signed system transfers:

- `deposit` — transfer SOL from user to PDA vault
- `withdraw` — PDA-signed transfer from vault back to user using reconstructed seeds

## Client Module Generation

The IDL generator now emits a `client.rs` module for each program with typed instruction builders. The escrow, multisig, and vault examples all include generated client modules gated behind `#[cfg(feature = "client")]`.

## CU Measurements

| Instruction | Before | After | Delta |
|-------------|--------|-------|-------|
| Make        | 9,409  | 9,415 | +6    |
| Take        | 17,800 | 17,804| +4    |
| Refund      | 11,945 | 11,952| +7    |

Small increases from `ZeroCopyDeref` changing from a const offset to method dispatch and CPI error checking. Both are necessary — the const offset couldn't express the View indirection, and swallowing CPI errors is a correctness bug.

## What It Looks Like

Dynamic account with View deref chain:

```rust
#[account(discriminator = 1)]
pub struct MultisigConfig<'a> {
    pub creator: Address,
    pub threshold: u8,
    pub bump: u8,
    pub label: String<'a, 32>,
    pub signers: Vec<'a, Address, 10>,
}

// Usage — fixed fields through auto-deref:
let threshold = account.threshold;       // Account → View → Zc

// Dynamic fields on the View:
let label: &str = account.label();       // Account → View accessor
let signers: &[Address] = account.signers();

// Batch write:
account.set_dynamic_fields(&payer, Some("new-label"), None)?;
```

PDA-signed vault withdrawal:

```rust
pub fn withdraw(&self, amount: u64, bumps: &WithdrawBumps) -> Result<(), ProgramError> {
    let seeds = bumps.vault_seeds();
    self.system_program
        .transfer(self.vault, self.user, amount)
        .invoke_signed(&seeds)
}
```