### PR TITLE
feat: split Ctx into Ctx + CtxWithRemaining, instruction dynamic strings

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -43,6 +43,14 @@ impl<const N: usize> WriteBytes for [u8; N] {
     }
 }
 
+impl WriteBytes for Vec<u8> {
+    #[inline(always)]
+    fn write_bytes(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.len() as u16).to_le_bytes());
+        buf.extend_from_slice(self);
+    }
+}
+
 #[inline(always)]
 pub fn build_instruction_data(disc: &[u8], write_args: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
     let mut data = Vec::from(disc);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -14,7 +14,30 @@ pub struct Context<'info> {
 }
 
 /// Parsed instruction context with typed accounts and PDA bumps.
+/// Use [`CtxWithRemaining`] for instructions that need `remaining_accounts()`.
 pub struct Ctx<'info, T: ParseAccounts<'info> + AccountCount> {
+    pub accounts: T,
+    pub bumps: T::Bumps,
+    pub program_id: &'info [u8; 32],
+    pub data: &'info [u8],
+}
+
+impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
+    #[inline(always)]
+    pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
+        let (accounts, bumps) = T::parse(ctx.accounts)?;
+        Ok(Self {
+            accounts,
+            bumps,
+            program_id: ctx.program_id,
+            data: ctx.data,
+        })
+    }
+}
+
+/// Like [`Ctx`] but also captures the remaining accounts region.
+/// Use this for instructions that call `remaining_accounts()`.
+pub struct CtxWithRemaining<'info, T: ParseAccounts<'info> + AccountCount> {
     pub accounts: T,
     pub bumps: T::Bumps,
     pub program_id: &'info [u8; 32],
@@ -24,7 +47,7 @@ pub struct Ctx<'info, T: ParseAccounts<'info> + AccountCount> {
     accounts_boundary: *const u8,
 }
 
-impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
+impl<'info, T: ParseAccounts<'info> + AccountCount> CtxWithRemaining<'info, T> {
     #[inline(always)]
     pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
         let (accounts, bumps) = T::parse(ctx.accounts)?;
@@ -39,7 +62,6 @@ impl<'info, T: ParseAccounts<'info> + AccountCount> Ctx<'info, T> {
         })
     }
 
-    /// Access remaining accounts. Zero cost until called.
     #[inline(always)]
     pub fn remaining_accounts(&self) -> RemainingAccounts<'info> {
         RemainingAccounts::new(self.remaining_ptr, self.accounts_boundary, self.declared)

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -3,7 +3,7 @@ pub use crate::accounts::*;
 pub use crate::checks;
 
 // Context & parsing
-pub use crate::context::{Context, Ctx};
+pub use crate::context::{Context, Ctx, CtxWithRemaining};
 pub use crate::traits::{
     AccountCheck, AccountCount, AsAccountView, Discriminator, Event, Owner, ParseAccounts, Program,
     QuasarAccount, Space, ZeroCopyDeref,

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -82,7 +82,7 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
             context.data = &context.data[#disc_len..];
         ),
         syn::parse_quote!(
-            let mut #param_name: #param_type = Ctx::new(context)?;
+            let mut #param_name: #param_type = <#param_type>::new(context)?;
         ),
     ];
 
@@ -215,9 +215,11 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                             }
                         ));
                         new_stmts.push(syn::parse_quote!(
-                            let #name: &str = core::str::from_utf8(
-                                &__tail[__offset..__offset + __dyn_len]
-                            ).map_err(|_| ProgramError::InvalidInstructionData)?;
+                            let #name: &str = unsafe {
+                                core::str::from_utf8_unchecked(
+                                    &__tail[__offset..__offset + __dyn_len]
+                                )
+                            };
                         ));
                         if dyn_idx < dyn_count {
                             new_stmts.push(syn::parse_quote!(
@@ -267,6 +269,11 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let _ = __offset;
             ));
         }
+
+        // Clear ctx.data after extraction — prevents accidental access to raw bytes
+        new_stmts.push(syn::parse_quote!(
+            #param_ident.data = &[];
+        ));
     }
 
     if has_return_data {

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, FnArg, Ident, Item, ItemMod, Pat, Type};
 
-use crate::helpers::{pascal_to_snake, snake_to_pascal, InstructionArgs};
+use crate::helpers::{is_ix_dynamic_string, pascal_to_snake, snake_to_pascal, InstructionArgs};
 
 /// Extracts the inner type `T` from a `Ctx<T>` first parameter.
 fn extract_ctx_inner_type(sig: &syn::Signature) -> proc_macro2::TokenStream {
@@ -119,7 +119,12 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
                                     Pat::Ident(pi) => pi.ident.clone(),
                                     _ => return None,
                                 };
-                                Some((name, (*pt.ty).clone()))
+                                let ty = if is_ix_dynamic_string(&pt.ty).is_some() {
+                                    syn::parse_quote!(alloc::vec::Vec<u8>)
+                                } else {
+                                    (*pt.ty).clone()
+                                };
+                                Some((name, ty))
                             }
                             _ => None,
                         })

--- a/examples/multisig/src/client.rs
+++ b/examples/multisig/src/client.rs
@@ -54,24 +54,23 @@ impl From<DepositInstruction> for Instruction {
     }
 }
 
-pub struct SetLabelInstruction {
+pub struct SetLabelInstruction<'a> {
     pub creator: Address,
     pub config: Address,
     pub system_program: Address,
-    pub label_len: u8,
-    pub label_bytes: [u8],
+    pub label: &'a [u8],
 }
 
-impl From<SetLabelInstruction> for Instruction {
-    fn from(ix: SetLabelInstruction) -> Instruction {
+impl<'a> From<SetLabelInstruction<'a>> for Instruction {
+    fn from(ix: SetLabelInstruction<'a>) -> Instruction {
         let accounts = vec![
             AccountMeta::new(ix.creator, true),
             AccountMeta::new(ix.config, false),
             AccountMeta::new_readonly(ix.system_program, false),
         ];
         let mut data = vec![2];
-        data.push(ix.label_len as u8);
-        data.extend_from_slice(&ix.label_bytes.to_le_bytes());
+        data.extend_from_slice(&(ix.label.len() as u16).to_le_bytes());
+        data.extend_from_slice(ix.label);
         Instruction {
             program_id: crate::ID,
             accounts,

--- a/examples/multisig/src/instructions/set_label.rs
+++ b/examples/multisig/src/instructions/set_label.rs
@@ -17,10 +17,7 @@ pub struct SetLabel<'info> {
 
 impl<'info> SetLabel<'info> {
     #[inline(always)]
-    pub fn update_label(&mut self, label_len: u8, label_bytes: &[u8; 32]) -> Result<(), ProgramError> {
-        let label = core::str::from_utf8(&label_bytes[..label_len as usize])
-            .map_err(|_| ProgramError::InvalidArgument)?;
-
+    pub fn update_label(&mut self, label: &str) -> Result<(), ProgramError> {
         self.config.set_label(self.creator, label)
     }
 }

--- a/examples/multisig/src/lib.rs
+++ b/examples/multisig/src/lib.rs
@@ -19,7 +19,7 @@ mod quasar_multisig {
     use super::*;
 
     #[instruction(discriminator = 0)]
-    pub fn create(ctx: Ctx<Create>, threshold: u8) -> Result<(), ProgramError> {
+    pub fn create(ctx: CtxWithRemaining<Create>, threshold: u8) -> Result<(), ProgramError> {
         ctx.accounts.create_multisig(threshold, &ctx.bumps, ctx.remaining_accounts())
     }
 
@@ -29,12 +29,12 @@ mod quasar_multisig {
     }
 
     #[instruction(discriminator = 2)]
-    pub fn set_label(ctx: Ctx<SetLabel>, label_len: u8, label_bytes: [u8; 32]) -> Result<(), ProgramError> {
-        ctx.accounts.update_label(label_len, &label_bytes)
+    pub fn set_label(ctx: Ctx<SetLabel>, label: String<32>) -> Result<(), ProgramError> {
+        ctx.accounts.update_label(label)
     }
 
     #[instruction(discriminator = 3)]
-    pub fn execute_transfer(ctx: Ctx<ExecuteTransfer>, amount: u64) -> Result<(), ProgramError> {
+    pub fn execute_transfer(ctx: CtxWithRemaining<ExecuteTransfer>, amount: u64) -> Result<(), ProgramError> {
         ctx.accounts.verify_and_transfer(amount, &ctx.bumps, ctx.remaining_accounts())
     }
 }

--- a/examples/multisig/src/tests.rs
+++ b/examples/multisig/src/tests.rs
@@ -221,15 +221,12 @@ fn test_set_label() {
     };
 
     let label = "Treasury";
-    let mut label_bytes = [0u8; 32];
-    label_bytes[..label.len()].copy_from_slice(label.as_bytes());
 
     let instruction: Instruction = SetLabelInstruction {
         creator,
         config,
         system_program,
-        label_len: label.len() as u8,
-        label_bytes,
+        label: label.as_bytes().to_vec(),
     }
     .into();
 


### PR DESCRIPTION
## Summary

Split `Ctx<T>` into lean `Ctx<T>` (4 fields) and `CtxWithRemaining<T>` (7 fields) so instructions that don't use remaining accounts don't carry the extra pointers. Also adds `String<N>` as an instruction parameter type, with the multisig `set_label` instruction refactored to use it.

## Ctx Split

`Ctx<T>` carried 7 fields — 3 of which (`remaining_ptr`, `declared`, `accounts_boundary`) exist solely for `remaining_accounts()`. Only 2 of 10 instructions across all examples use remaining accounts.

`Ctx<T>` drops to 4 fields (accounts, bumps, program_id, data). `CtxWithRemaining<T>` keeps all 7 and owns `remaining_accounts()`. The `#[instruction]` macro uses qualified path syntax (`<Type>::new(context)`) so the correct `::new` resolves without a shared trait.

```rust
// Lean — remaining_accounts() is a compile error
pub fn deposit(ctx: Ctx<Deposit>, amount: u64) -> Result<(), ProgramError> { ... }

// Full — has remaining_accounts()
pub fn create(ctx: CtxWithRemaining<Create>, threshold: u8) -> Result<(), ProgramError> {
    ctx.accounts.create_multisig(threshold, &ctx.bumps, ctx.remaining_accounts())
}
```

CU-neutral at the SBF level — LLVM already eliminated dead stores for unused fields. The win is compile-time: calling `remaining_accounts()` on a lean `Ctx<T>` is a type error.

## Instruction Dynamic Strings

`String<N>` works as an instruction parameter. The `#[instruction]` macro generates a `PodU16` length descriptor in the ZC header and reads the variable-length tail as `&str` via `from_utf8_unchecked` (bounds-checked against max capacity `N` before access).

The `#[program]` macro maps `String<N>` params to `Vec<u8>` in generated client instruction structs. `WriteBytes` impl for `Vec<u8>` serializes as `u16 len || bytes`.

`set_label` before:
```rust
pub fn set_label(ctx: Ctx<SetLabel>, label_len: u8, label_bytes: [u8; 32]) -> ...
```

After:
```rust
pub fn set_label(ctx: Ctx<SetLabel>, label: String<32>) -> ...
```

`ctx.data` is cleared to `&[]` after instruction arg extraction to prevent accidental access to raw bytes.

## CU Measurements

| Instruction | CU |
|-------------|-----|
| Escrow Make | 9,415 |
| Escrow Take | 17,804 |
| Escrow Refund | 11,952 |
| Multisig Create | 4,826 |
| Multisig Deposit | 3,248 |
| Multisig SetLabel | 4,789 |
| Multisig ExecuteTransfer | 5,015 |