### PR TITLE
fix: panic handler and  add solana program log in the prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-view",
  "solana-program-error",
+ "solana-program-log",
 ]
 
 [[package]]
@@ -2858,6 +2859,27 @@ name = "solana-program-error"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+
+[[package]]
+name = "solana-program-log"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26115ff9ec592bb4407379c82e7f00b9d0ae4e3fac80c3fd28c932aec852dc6"
+dependencies = [
+ "solana-define-syscall 4.0.1",
+ "solana-program-log-macro",
+]
+
+[[package]]
+name = "solana-program-log-macro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2b224806ef141865d2f4b4614179089e3b80ba7311fc3bb28742c1d8323946"
+dependencies = [
+ "quote",
+ "regex",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "solana-program-memory"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ solana-program-error = "3.0.0"
 solana-account-view = "1.0.0"
 solana-address = { version = "2.2.0", features = ["wincode", "decode", "copy"] }
 solana-instruction-view = { version = "1.0.0", features = ["cpi"] }
+solana-program-log = "1.0.0"
 
 [target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
 solana-define-syscall = { version = "5.0.0", features = ["unstable-static-syscalls"] }

--- a/core/src/entrypoint.rs
+++ b/core/src/entrypoint.rs
@@ -70,8 +70,10 @@ macro_rules! no_alloc {
 macro_rules! panic_handler {
     () => {
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-        fn panic(_info: &core::panic::PanicInfo<'_>) {
-            solana_program_log::log("PANIC");
+        #[panic_handler]
+        fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+            $crate::prelude::log("PANIC");
+            loop {}
         }
     };
 }

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -35,3 +35,4 @@ pub use quasar_derive::{account, emit_cpi, error_code, event, instruction, progr
 pub use solana_account_view::AccountView;
 pub use solana_address::{declare_id, Address};
 pub use solana_program_error::ProgramError;
+pub use solana_program_log::log;


### PR DESCRIPTION
# Problem

- Previously the panic handler was missing the `#[panic_handler]` handler macro that was causing fails in the compile process from programs that require it.
- The `panic_handler` macro was depending on the `sol_log` syscall but the crate for accessing it was missing


# Solution

Fix the entrypoint macro with the expansion needed and also import the `solana-program-log` crate in the prelude to expose for clients and use it in the entrypoint 