### PR TITLE
cli: create initial commit after init

### DIFF
--- a/cli/Readme.md
+++ b/cli/Readme.md
@@ -18,13 +18,14 @@ Scaffold a new Quasar project. When a name is provided, uses saved defaults and 
 - **Toolchain** — `solana` (cargo build-sbf) or `upstream` (cargo +nightly build-bpf)
 - **Testing framework** — None, Mollusk, QuasarSVM/Rust, QuasarSVM/Web3.js, or QuasarSVM/Kit
 - **Template** — Minimal (single instruction) or Full (state, events, instruction files)
+- **Git setup** — Initialize + Commit, Initialize, or Skip
 
-The wizard generates a complete project directory with `Cargo.toml`, `Quasar.toml`, source files, test scaffolding, a program keypair, and runs `git init`. Preferences are saved to `~/.quasar/config.toml` and used as defaults for future runs.
+The wizard generates a complete project directory with `Cargo.toml`, `Quasar.toml`, source files, test scaffolding, a program keypair, and optional git setup. Preferences are saved to `~/.quasar/config.toml` and used as defaults for future runs.
 
 | Flag | Effect |
 |------|--------|
 | `-y, --yes` | Explicitly skip prompts (same as providing a name) |
-| `--no-git` | Skip `git init` |
+| `--no-git` | Skip git repo setup |
 
 ```bash
 quasar init                  # Interactive wizard
@@ -180,9 +181,9 @@ Preferences that apply across all projects:
 toolchain = "solana"
 framework = "mollusk"
 template = "minimal"
+git = "commit"      # "commit", "init", or "skip"
 
 [ui]
 animation = true   # Animated banner on `quasar init`
 color = true       # Colored terminal output
-timing = true      # Show build timing
 ```

--- a/cli/src/cfg.rs
+++ b/cli/src/cfg.rs
@@ -54,7 +54,7 @@ fn unknown_key(key: &str) -> ! {
     eprintln!("  {}", style::fail(&format!("unknown config key: {key}")));
     eprintln!();
     eprintln!("  Available keys:");
-    eprintln!("    defaults.toolchain, defaults.framework, defaults.template");
+    eprintln!("    defaults.toolchain, defaults.framework, defaults.template, defaults.git");
     eprintln!("    ui.animation, ui.color");
     std::process::exit(1);
 }
@@ -75,6 +75,10 @@ fn print_all(config: &GlobalConfig) {
     println!(
         "    template   = {}",
         config.defaults.template.as_deref().unwrap_or("(not set)")
+    );
+    println!(
+        "    git        = {}",
+        config.defaults.git.as_deref().unwrap_or("(not set)")
     );
     println!();
     println!("  [ui]");
@@ -118,6 +122,11 @@ const ITEMS: &[ConfigItem] = &[
         key: "defaults.template",
         label: "Default template",
         kind: ConfigKind::Choice(&["minimal", "full"]),
+    },
+    ConfigItem {
+        key: "defaults.git",
+        label: "Default git setup",
+        kind: ConfigKind::Choice(&["commit", "init", "skip"]),
     },
     ConfigItem {
         key: "ui.animation",
@@ -257,6 +266,14 @@ fn get_value(config: &GlobalConfig, key: &str) -> Option<String> {
                 .unwrap_or("(not set)")
                 .to_string(),
         ),
+        "defaults.git" => Some(
+            config
+                .defaults
+                .git
+                .as_deref()
+                .unwrap_or("(not set)")
+                .to_string(),
+        ),
         "ui.animation" => Some(config.ui.animation.to_string()),
         "ui.color" => Some(config.ui.color.to_string()),
         _ => None,
@@ -268,6 +285,7 @@ fn set_value(config: &mut GlobalConfig, key: &str, value: &str) -> bool {
         "defaults.toolchain" => config.defaults.toolchain = some_or_none(value),
         "defaults.framework" => config.defaults.framework = some_or_none(value),
         "defaults.template" => config.defaults.template = some_or_none(value),
+        "defaults.git" => config.defaults.git = some_or_none(value),
         "ui.animation" => config.ui.animation = parse_bool(value),
         "ui.color" => config.ui.color = parse_bool(value),
         _ => return false,
@@ -306,6 +324,13 @@ fn validate_value(key: &str, value: &str) -> Result<(), &'static str> {
                 Ok(())
             } else {
                 Err("minimal, full")
+            }
+        }
+        "defaults.git" => {
+            if matches!(value, "commit" | "init" | "skip" | "none" | "null" | "") {
+                Ok(())
+            } else {
+                Err("commit, init, skip")
             }
         }
         "ui.animation" | "ui.color" => {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -109,6 +109,7 @@ pub struct GlobalDefaults {
     pub toolchain: Option<String>,
     pub framework: Option<String>,
     pub template: Option<String>,
+    pub git: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -212,6 +213,7 @@ mod tests {
                 toolchain: Some("solana".into()),
                 framework: Some("quasarsvm-rust".into()),
                 template: Some("minimal".into()),
+                git: Some("commit".into()),
             },
             ui: UiConfig {
                 animation: false,
@@ -222,5 +224,6 @@ mod tests {
         let reloaded = GlobalConfig::load_from_str(&toml_str);
         assert!(!reloaded.ui.animation);
         assert_eq!(reloaded.defaults.toolchain.as_deref(), Some("solana"));
+        assert_eq!(reloaded.defaults.git.as_deref(), Some("commit"));
     }
 }

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -6,7 +6,7 @@ use {
     },
     dialoguer::{theme::ColorfulTheme, Input, Select},
     serde::Serialize,
-    std::{fmt, fs, path::Path},
+    std::{fmt, fs, path::Path, process::Command},
 };
 
 // ---------------------------------------------------------------------------
@@ -74,6 +74,65 @@ impl fmt::Display for Template {
         match self {
             Template::Minimal => write!(f, "minimal"),
             Template::Full => write!(f, "full"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GitSetup {
+    InitializeAndCommit,
+    Initialize,
+    Skip,
+}
+
+impl GitSetup {
+    fn from_config(value: Option<&str>) -> Self {
+        match value {
+            Some("init") => GitSetup::Initialize,
+            Some("skip") => GitSetup::Skip,
+            _ => GitSetup::InitializeAndCommit,
+        }
+    }
+
+    fn from_index(idx: usize) -> Self {
+        match idx {
+            1 => GitSetup::Initialize,
+            2 => GitSetup::Skip,
+            _ => GitSetup::InitializeAndCommit,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            GitSetup::InitializeAndCommit => 0,
+            GitSetup::Initialize => 1,
+            GitSetup::Skip => 2,
+        }
+    }
+
+    fn prompt_label(self) -> &'static str {
+        match self {
+            GitSetup::InitializeAndCommit => "Initialize + Commit",
+            GitSetup::Initialize => "Initialize",
+            GitSetup::Skip => "Skip",
+        }
+    }
+
+    fn summary_label(self) -> &'static str {
+        match self {
+            GitSetup::InitializeAndCommit => "git: init + commit",
+            GitSetup::Initialize => "git: init",
+            GitSetup::Skip => "git: skip",
+        }
+    }
+}
+
+impl fmt::Display for GitSetup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GitSetup::InitializeAndCommit => write!(f, "commit"),
+            GitSetup::Initialize => write!(f, "init"),
+            GitSetup::Skip => write!(f, "skip"),
         }
     }
 }
@@ -533,42 +592,58 @@ pub fn run(
         _ => Template::Full,
     };
 
+    // Git setup
+    let git_default = GitSetup::from_config(globals.defaults.git.as_deref());
+    let git_setup = if no_git {
+        GitSetup::Skip
+    } else if skip_prompts {
+        git_default
+    } else {
+        let git_items = &[
+            GitSetup::InitializeAndCommit.prompt_label(),
+            GitSetup::Initialize.prompt_label(),
+            GitSetup::Skip.prompt_label(),
+        ];
+        let git_idx = Select::with_theme(&theme)
+            .with_prompt("Initialize a new git repo?")
+            .items(git_items)
+            .default(git_default.index())
+            .interact()
+            .map_err(anyhow::Error::from)?;
+        GitSetup::from_index(git_idx)
+    };
+
     if skip_prompts {
         println!();
         println!(
-            "  {} {} {} {} {}",
+            "  {} {} {} {} {} {} {}",
             dim("Using:"),
             bold(&toolchain.to_string()),
             dim("+"),
             bold(&framework.to_string()),
             bold(&template.to_string()),
+            dim("+"),
+            bold(git_setup.summary_label()),
         );
     }
 
     scaffold(&name, &crate_name, toolchain, framework, template)?;
 
-    // git init (unless --no-git or already in a git repo)
-    if !no_git {
-        let root = Path::new(&name);
-        let already_git = if name == "." {
-            Path::new(".git").exists()
-        } else {
-            root.join(".git").exists()
-        };
-        if !already_git {
-            let _ = std::process::Command::new("git")
-                .args(["init", "--quiet"])
-                .current_dir(root)
-                .status();
-        }
-    }
+    // Optional git setup (unless already in a git repo)
+    maybe_initialize_git_repo(&name, git_setup);
 
     // Save preferences for next time (disable animation after first run)
+    let saved_git_default = if no_git {
+        globals.defaults.git.clone()
+    } else {
+        Some(git_setup.to_string())
+    };
     let new_globals = GlobalConfig {
         defaults: GlobalDefaults {
             toolchain: Some(toolchain.to_string()),
             framework: Some(framework.to_string()),
             template: Some(template.to_string()),
+            git: saved_git_default,
         },
         ui: UiConfig {
             animation: false,
@@ -607,6 +682,43 @@ pub fn run(
     println!();
 
     Ok(())
+}
+
+fn maybe_initialize_git_repo(name: &str, git_setup: GitSetup) {
+    if matches!(git_setup, GitSetup::Skip) {
+        return;
+    }
+
+    let root = Path::new(name);
+    let already_git = if name == "." {
+        Path::new(".git").exists()
+    } else {
+        root.join(".git").exists()
+    };
+
+    if !already_git {
+        let _ = initialize_git_repo(root, git_setup);
+    }
+}
+
+fn initialize_git_repo(root: &Path, git_setup: GitSetup) -> bool {
+    run_git(root, &["init", "--quiet"])
+        && match git_setup {
+            GitSetup::InitializeAndCommit => {
+                run_git(root, &["add", "."])
+                    && run_git(root, &["commit", "-am", "chore: initial commit", "--quiet"])
+            }
+            GitSetup::Initialize | GitSetup::Skip => true,
+        }
+}
+
+fn run_git(root: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .status()
+        .ok()
+        .is_some_and(|status| status.success())
 }
 
 fn scaffold(
@@ -1116,6 +1228,172 @@ fn test_initialize() {
 }
 "#
         .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        env,
+        path::PathBuf,
+        sync::Mutex,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static PATH_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn initialize_git_repo_runs_init_add_and_commit() {
+        let _guard = PATH_LOCK.lock().unwrap();
+        let sandbox = create_test_sandbox("success");
+        let _env = TestGitEnv::new(&sandbox, None);
+        let root = sandbox.join("repo");
+        fs::create_dir_all(&root).unwrap();
+
+        let ok = initialize_git_repo(&root, GitSetup::InitializeAndCommit);
+
+        assert!(ok);
+        assert_eq!(
+            read_git_log(&sandbox),
+            vec![
+                "init --quiet",
+                "add .",
+                "commit -am chore: initial commit --quiet",
+            ]
+        );
+    }
+
+    #[test]
+    fn initialize_git_repo_can_skip_initial_commit() {
+        let _guard = PATH_LOCK.lock().unwrap();
+        let sandbox = create_test_sandbox("init-only");
+        let _env = TestGitEnv::new(&sandbox, None);
+        let root = sandbox.join("repo");
+        fs::create_dir_all(&root).unwrap();
+
+        let ok = initialize_git_repo(&root, GitSetup::Initialize);
+
+        assert!(ok);
+        assert_eq!(read_git_log(&sandbox), vec!["init --quiet"]);
+    }
+
+    #[test]
+    fn initialize_git_repo_stops_when_git_init_fails() {
+        let _guard = PATH_LOCK.lock().unwrap();
+        let sandbox = create_test_sandbox("fail-init");
+        let _env = TestGitEnv::new(&sandbox, Some("init"));
+        let root = sandbox.join("repo");
+        fs::create_dir_all(&root).unwrap();
+
+        let ok = initialize_git_repo(&root, GitSetup::InitializeAndCommit);
+
+        assert!(!ok);
+        assert_eq!(read_git_log(&sandbox), vec!["init --quiet"]);
+    }
+
+    fn create_test_sandbox(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!(
+            "quasar-init-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(dir.join("bin")).unwrap();
+        dir
+    }
+
+    fn read_git_log(sandbox: &Path) -> Vec<String> {
+        fs::read_to_string(sandbox.join("git.log"))
+            .unwrap_or_default()
+            .lines()
+            .map(|line| line.to_string())
+            .collect()
+    }
+
+    struct TestGitEnv {
+        old_path: Option<std::ffi::OsString>,
+        old_log: Option<std::ffi::OsString>,
+        old_fail_on: Option<std::ffi::OsString>,
+    }
+
+    impl TestGitEnv {
+        fn new(sandbox: &Path, fail_on: Option<&str>) -> Self {
+            let bin_dir = sandbox.join("bin");
+            let log_path = sandbox.join("git.log");
+            write_fake_git(&bin_dir.join("git"));
+
+            let old_path = env::var_os("PATH");
+            let old_log = env::var_os("QUASAR_TEST_GIT_LOG");
+            let old_fail_on = env::var_os("QUASAR_TEST_GIT_FAIL_ON");
+
+            let mut path = std::ffi::OsString::new();
+            path.push(bin_dir.as_os_str());
+            path.push(":");
+            if let Some(existing) = &old_path {
+                path.push(existing);
+            }
+
+            // Safety: tests hold PATH_LOCK, so process-global env mutation stays serialized.
+            unsafe {
+                env::set_var("PATH", path);
+                env::set_var("QUASAR_TEST_GIT_LOG", &log_path);
+            }
+            if let Some(cmd) = fail_on {
+                // Safety: tests hold PATH_LOCK, so process-global env mutation stays serialized.
+                unsafe {
+                    env::set_var("QUASAR_TEST_GIT_FAIL_ON", cmd);
+                }
+            } else {
+                // Safety: tests hold PATH_LOCK, so process-global env mutation stays serialized.
+                unsafe {
+                    env::remove_var("QUASAR_TEST_GIT_FAIL_ON");
+                }
+            }
+
+            Self {
+                old_path,
+                old_log,
+                old_fail_on,
+            }
+        }
+    }
+
+    impl Drop for TestGitEnv {
+        fn drop(&mut self) {
+            // Safety: tests hold PATH_LOCK, so process-global env mutation stays serialized.
+            unsafe {
+                restore_env_var("PATH", self.old_path.as_ref());
+                restore_env_var("QUASAR_TEST_GIT_LOG", self.old_log.as_ref());
+                restore_env_var("QUASAR_TEST_GIT_FAIL_ON", self.old_fail_on.as_ref());
+            }
+        }
+    }
+
+    unsafe fn restore_env_var(key: &str, value: Option<&std::ffi::OsString>) {
+        if let Some(value) = value {
+            env::set_var(key, value);
+        } else {
+            env::remove_var(key);
+        }
+    }
+
+    fn write_fake_git(path: &Path) {
+        fs::write(
+            path,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$QUASAR_TEST_GIT_LOG\"\nif [ \"$1\" = \"$QUASAR_TEST_GIT_FAIL_ON\" ]; then\n  exit 1\nfi\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut perms = fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).unwrap();
+        }
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -71,7 +71,7 @@ pub struct InitCommand {
     #[arg(long, short, action = ArgAction::SetTrue)]
     pub yes: bool,
 
-    /// Skip git init
+    /// Skip git init and the initial commit
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_git: bool,
 
@@ -182,7 +182,7 @@ pub struct ConfigCommand {
 pub enum ConfigAction {
     /// Read a single config value
     Get {
-        /// Config key (e.g. ui.animation, defaults.toolchain)
+        /// Config key (e.g. ui.animation, defaults.toolchain, defaults.git)
         #[arg(value_name = "KEY")]
         key: String,
     },


### PR DESCRIPTION
Initialize new repos with git, stage the generated scaffold, and create the first commit automatically.

Update the init help text and README to match the new behavior, and add targeted tests for the git command sequence.

Proof of Commit:

<img width="484" height="313" alt="image" src="https://github.com/user-attachments/assets/68435082-7fd8-496e-9a77-47b34d05f914" />
