### PR TITLE
fix: safer directory-exists checks during init

### DIFF
--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -22,20 +22,48 @@ pub(super) fn scaffold(
     let root = Path::new(dir);
 
     if dir == "." {
-        // Scaffold into current directory — check it doesn't already have a project
-        if root.join("Cargo.toml").exists() || root.join("Quasar.toml").exists() {
+        if root.join("Quasar.toml").exists() {
             eprintln!(
                 "  {}",
-                crate::style::fail("current directory already contains a project")
+                crate::style::fail("current directory is already a Quasar project")
             );
             std::process::exit(1);
         }
+        if root.join("Cargo.toml").exists() {
+            eprintln!(
+                "  {}",
+                crate::style::fail("current directory already contains a Rust project")
+            );
+            std::process::exit(1);
+        }
+        if fs::read_dir(root).is_ok_and(|mut d| d.next().is_some()) {
+            eprintln!("  {}", crate::style::fail("current directory is not empty"));
+            std::process::exit(1);
+        }
     } else if root.exists() {
-        eprintln!(
-            "  {}",
-            crate::style::fail(&format!("directory '{dir}' already exists"))
-        );
-        std::process::exit(1);
+        if !root.is_dir() {
+            eprintln!(
+                "  {}",
+                crate::style::fail(&format!("path '{dir}' exists and is not a directory"))
+            );
+            std::process::exit(1);
+        }
+        if root.join("Quasar.toml").exists() {
+            eprintln!(
+                "  {}",
+                crate::style::fail(&format!("directory '{dir}' is already a Quasar project"))
+            );
+            std::process::exit(1);
+        }
+        if fs::read_dir(root).is_ok_and(|mut d| d.next().is_some()) {
+            eprintln!(
+                "  {}",
+                crate::style::fail(&format!(
+                    "directory '{dir}' already exists and is not empty"
+                ))
+            );
+            std::process::exit(1);
+        }
     }
 
     let src = root.join("src");


### PR DESCRIPTION
## Summary

Replaces the blanket "directory already exists" error with graduated safety checks for both `quasar init <name>` and `quasar init .`:

| Condition | Error |
|-----------|-------|
| Path exists but is not a directory | `path '<name>' exists and is not a directory` |
| Directory has `Quasar.toml` | `directory '<name>' is already a Quasar project` |
| Directory has `Cargo.toml` (`.` only) | `current directory already contains a Rust project` |
| Directory is non-empty | `directory '<name>' already exists and is not empty` |
| Directory is empty | Proceed safely |

Never deletes or overwrites existing user files. No `--force` flag, no `remove_dir_all`, no interactive prompts.

Based on #69 — same branch name, beeman as commit author. Supersedes #69 which targeted pre-refactor code.