### PR TITLE
fix: stop ignoring lockfiles in init scaffold

### DIFF
--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -6,13 +6,6 @@ pub(super) const GITIGNORE: &str = "\
 # Build artifacts
 /target
 
-# Lock files
-Cargo.lock
-package-lock.json
-pnpm-lock.yaml
-yarn.lock
-bun.lockb
-
 # Dependencies
 node_modules
 


### PR DESCRIPTION
Generated projects should default toward reproducible installs rather than hiding the files that make those installs possible.

Lockfiles are generally a bullish default because they:
- keep local development, CI, and production on the same dependency graph
- make dependency updates explicit in code review
- preserve a buildable historical state for bisects and maintenance
- reduce fresh-resolution drift and 'works on my machine' failures

That matches the current guidance from each ecosystem:
- npm recommends committing package-lock.json
- pnpm recommends always committing pnpm-lock.yaml
- Yarn recommends storing yarn.lock in the repository, even for libraries
- Bun recommends committing bun.lock
- Cargo now recommends doing what is best for the project, with committing Cargo.lock as the starting point when in doubt

If there are annoyances that made us ignore lockfiles in the scaffold, let's see if we can address those instead.
