### PR TITLE
fix: validate all declared fields in init_if_needed codepath

### DIFF
--- a/derive/src/accounts/fields.rs
+++ b/derive/src/accounts/fields.rs
@@ -124,6 +124,39 @@ fn extract_account_inner_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
     extract_generic_inner_type(deref_ty, "Account").map(|inner| quote!(#inner))
 }
 
+/// Generate the owner check for init_if_needed validation based on wrapper
+/// type.
+///
+/// - `Account<T>`: uses `CheckOwner` trait (single comparison against a
+///   compile-time constant — the most CU-efficient path).
+/// - `InterfaceAccount<T>`: exact match against `token_program.address()`. This
+///   subsumes the broader "is it SPL Token or Token-2022" check.
+fn gen_owner_check(
+    field_name: &Ident,
+    effective_ty: &Type,
+    tok_program_addr: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let underlying_ty = match effective_ty {
+        Type::Reference(r) => &*r.elem,
+        other => other,
+    };
+    if let Some(inner_ty) = extract_generic_inner_type(underlying_ty, "Account") {
+        let inner_base = strip_generics(inner_ty);
+        quote! {
+            <#inner_base as quasar_lang::traits::CheckOwner>::check_owner(#field_name)?;
+        }
+    } else {
+        // InterfaceAccount — exact token_program match
+        quote! {
+            if quasar_lang::utils::hint::unlikely(
+                !quasar_lang::keys_eq(#field_name.owner(), #tok_program_addr)
+            ) {
+                return Err(ProgramError::IllegalOwner);
+            }
+        }
+    }
+}
+
 /// Check if the inner type T of Account<T> has a lifetime parameter,
 /// indicating a dynamic account type (e.g., Account<Profile<'info>>).
 fn is_dynamic_account_type(ty: &Type) -> bool {
@@ -587,6 +620,18 @@ pub(super) fn process_fields(
 
         // Generate type-specific validation (owner, discriminator, address).
         // Flags are already validated via u32 header in parse_accounts.
+        //
+        // For init/init_if_needed fields with token/mint/ATA attrs, skip
+        // Account<T> and InterfaceAccount<T> checks here — the init block's
+        // inline validation handles everything (owner, data_len,
+        // is_initialized, field-specific). This avoids redundant key
+        // comparisons and saves CUs. For generic Account<T> init_if_needed
+        // (no token/mint attrs), keep mut_checks since the init block has
+        // no validate_existing and these are the only defense.
+        let has_inline_validation = attrs.token_mint.is_some()
+            || attrs.associated_token_mint.is_some()
+            || attrs.mint_decimals.is_some();
+        let skip_mut_checks = (attrs.is_init || attrs.init_if_needed) && has_inline_validation;
         let mut push_check = |check: proc_macro2::TokenStream| {
             if is_optional {
                 mut_checks.push(quote! { if let Some(ref #field_name) = #field_name { #check } });
@@ -596,24 +641,55 @@ pub(super) fn process_fields(
         };
 
         if let Some(inner_ty) = extract_generic_inner_type(underlying_ty, "Account") {
-            let field_name_str = field_name.to_string();
-            push_check(quote! {
-                #[cfg(feature = "debug")]
-                if let Err(e) = <#inner_ty as quasar_lang::traits::CheckOwner>::check_owner(#field_name.to_account_view()) {
-                    quasar_lang::prelude::log(&::alloc::format!("Owner check failed for account '{}'", #field_name_str));
-                    return Err(e);
-                }
-                #[cfg(not(feature = "debug"))]
-                <#inner_ty as quasar_lang::traits::CheckOwner>::check_owner(#field_name.to_account_view())?;
+            if !skip_mut_checks {
+                let field_name_str = field_name.to_string();
+                push_check(quote! {
+                    #[cfg(feature = "debug")]
+                    if let Err(e) = <#inner_ty as quasar_lang::traits::CheckOwner>::check_owner(#field_name.to_account_view()) {
+                        quasar_lang::prelude::log(&::alloc::format!("Owner check failed for account '{}'", #field_name_str));
+                        return Err(e);
+                    }
+                    #[cfg(not(feature = "debug"))]
+                    <#inner_ty as quasar_lang::traits::CheckOwner>::check_owner(#field_name.to_account_view())?;
 
-                #[cfg(feature = "debug")]
-                if let Err(e) = <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view()) {
-                    quasar_lang::prelude::log(&::alloc::format!("Discriminator check failed for account '{}': data may be uninitialized or corrupted", #field_name_str));
-                    return Err(e);
-                }
-                #[cfg(not(feature = "debug"))]
-                <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view())?;
-            });
+                    #[cfg(feature = "debug")]
+                    if let Err(e) = <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view()) {
+                        quasar_lang::prelude::log(&::alloc::format!("Discriminator check failed for account '{}': data may be uninitialized or corrupted", #field_name_str));
+                        return Err(e);
+                    }
+                    #[cfg(not(feature = "debug"))]
+                    <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view())?;
+                });
+            }
+        } else if let Some(inner_ty) = extract_generic_inner_type(underlying_ty, "InterfaceAccount")
+        {
+            if !skip_mut_checks {
+                let field_name_str = field_name.to_string();
+                push_check(quote! {
+                    {
+                        let __owner = #field_name.to_account_view().owner();
+                        if quasar_lang::utils::hint::unlikely(
+                            !quasar_lang::keys_eq(__owner, &quasar_spl::SPL_TOKEN_ID)
+                                && !quasar_lang::keys_eq(__owner, &quasar_spl::TOKEN_2022_ID)
+                        ) {
+                            #[cfg(feature = "debug")]
+                            quasar_lang::prelude::log(&::alloc::format!(
+                                "Owner check failed for interface account '{}': not owned by SPL Token or Token-2022",
+                                #field_name_str
+                            ));
+                            return Err(ProgramError::IllegalOwner);
+                        }
+                    }
+
+                    #[cfg(feature = "debug")]
+                    if let Err(e) = <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view()) {
+                        quasar_lang::prelude::log(&::alloc::format!("Account check failed for interface account '{}': data may be uninitialized or corrupted", #field_name_str));
+                        return Err(e);
+                    }
+                    #[cfg(not(feature = "debug"))]
+                    <#inner_ty as quasar_lang::traits::AccountCheck>::check(#field_name.to_account_view())?;
+                });
+            }
         } else if let Some(inner_ty) = extract_generic_inner_type(underlying_ty, "Sysvar") {
             let field_name_str = field_name.to_string();
             push_check(quote! {
@@ -968,10 +1044,42 @@ pub(super) fn process_fields(
                     }
                 };
 
+                let owner_check = gen_owner_check(field_name, effective_ty, &token_program_addr);
                 let validate = quote! {
-                    quasar_spl::validate_ata(
-                        #field_name, #auth_field.address(), #mint_field.address(), #token_program_addr,
-                    )?;
+                    {
+                        let (__expected_ata, _) = quasar_spl::get_associated_token_address_with_program(
+                            #auth_field.address(),
+                            #mint_field.address(),
+                            #token_program_addr,
+                        );
+                        if quasar_lang::utils::hint::unlikely(
+                            !quasar_lang::keys_eq(#field_name.address(), &__expected_ata)
+                        ) {
+                            return Err(ProgramError::InvalidSeeds);
+                        }
+                    }
+                    #owner_check
+                    if quasar_lang::utils::hint::unlikely(
+                        #field_name.data_len() < quasar_spl::TokenAccountState::LEN
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    let __state = unsafe {
+                        &*(#field_name.data_ptr() as *const quasar_spl::TokenAccountState)
+                    };
+                    if quasar_lang::utils::hint::unlikely(!__state.is_initialized()) {
+                        return Err(ProgramError::UninitializedAccount);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        !quasar_lang::keys_eq(__state.mint(), #mint_field.address())
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        !quasar_lang::keys_eq(__state.owner(), #auth_field.address())
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
                 };
                 // ATA: create_idempotent (1) for init_if_needed, create (0) for init
                 init_blocks.push(wrap_init_block(
@@ -999,10 +1107,31 @@ pub(super) fn process_fields(
                         #tok_field, #field_name, #mint_field, #auth_field.address(),
                     ).invoke()?;
                 };
+                let tok_addr = quote! { #tok_field.address() };
+                let owner_check = gen_owner_check(field_name, effective_ty, &tok_addr);
                 let validate = quote! {
-                    quasar_spl::validate_token_account(
-                        #field_name, #mint_field.address(), #auth_field.address(),
-                    )?;
+                    #owner_check
+                    if quasar_lang::utils::hint::unlikely(
+                        #field_name.data_len() < quasar_spl::TokenAccountState::LEN
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    let __state = unsafe {
+                        &*(#field_name.data_ptr() as *const quasar_spl::TokenAccountState)
+                    };
+                    if quasar_lang::utils::hint::unlikely(!__state.is_initialized()) {
+                        return Err(ProgramError::UninitializedAccount);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        !quasar_lang::keys_eq(__state.mint(), #mint_field.address())
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        !quasar_lang::keys_eq(__state.owner(), #auth_field.address())
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
                 };
                 init_blocks.push(wrap_init_block(
                     field_name,
@@ -1046,8 +1175,55 @@ pub(super) fn process_fields(
                         #freeze_expr,
                     ).invoke()?;
                 };
+                let tok_addr = quote! { #tok_field.address() };
+                let owner_check = gen_owner_check(field_name, effective_ty, &tok_addr);
+                let freeze_check = if let Some(freeze_field) = &attrs.mint_freeze_authority {
+                    quote! {
+                        if quasar_lang::utils::hint::unlikely(
+                            !__state.has_freeze_authority()
+                                || !quasar_lang::keys_eq(
+                                    __state.freeze_authority_unchecked(),
+                                    #freeze_field.address(),
+                                )
+                        ) {
+                            return Err(ProgramError::InvalidAccountData);
+                        }
+                    }
+                } else {
+                    quote! {
+                        if quasar_lang::utils::hint::unlikely(__state.has_freeze_authority()) {
+                            return Err(ProgramError::InvalidAccountData);
+                        }
+                    }
+                };
                 let validate = quote! {
-                    quasar_spl::validate_mint(#field_name, #auth_field.address())?;
+                    #owner_check
+                    if quasar_lang::utils::hint::unlikely(
+                        #field_name.data_len() < quasar_spl::MintAccountState::LEN
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    let __state = unsafe {
+                        &*(#field_name.data_ptr() as *const quasar_spl::MintAccountState)
+                    };
+                    if quasar_lang::utils::hint::unlikely(!__state.is_initialized()) {
+                        return Err(ProgramError::UninitializedAccount);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        !__state.has_mint_authority()
+                            || !quasar_lang::keys_eq(
+                                __state.mint_authority_unchecked(),
+                                #auth_field.address(),
+                            )
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    if quasar_lang::utils::hint::unlikely(
+                        __state.decimals() != (#decimals_expr) as u8
+                    ) {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    #freeze_check
                 };
                 init_blocks.push(wrap_init_block(
                     field_name,

--- a/spl/src/associated_token/init.rs
+++ b/spl/src/associated_token/init.rs
@@ -80,6 +80,7 @@ pub trait InitAssociatedToken: AsAccountView + Sized {
                 view,
                 mint.to_account_view().address(),
                 wallet.to_account_view().address(),
+                token_program.address(),
             )
         }
     }

--- a/spl/src/associated_token/validate.rs
+++ b/spl/src/associated_token/validate.rs
@@ -21,5 +21,5 @@ pub fn validate_ata(
     if !quasar_lang::keys_eq(view.address(), &expected) {
         return Err(ProgramError::InvalidSeeds);
     }
-    validate_token_account(view, mint, wallet)
+    validate_token_account(view, mint, wallet, token_program)
 }

--- a/spl/src/helpers/init.rs
+++ b/spl/src/helpers/init.rs
@@ -1,17 +1,10 @@
 use {
     crate::{
-        helpers::constants::{SPL_TOKEN_ID, TOKEN_2022_ID},
         instructions::TokenCpi,
         state::{MintAccountState, TokenAccountState},
     },
     quasar_lang::{prelude::*, utils::hint::unlikely},
 };
-
-#[inline(always)]
-fn is_token_program_owner(view: &AccountView) -> bool {
-    let owner = view.owner();
-    quasar_lang::keys_eq(owner, &SPL_TOKEN_ID) || quasar_lang::keys_eq(owner, &TOKEN_2022_ID)
-}
 
 /// Extension trait for token account initialization.
 ///
@@ -70,29 +63,12 @@ pub trait InitToken: AsAccountView + Sized {
         if quasar_lang::is_system_program(view.owner()) {
             self.init(system_program, payer, token_program, mint, owner, rent)
         } else {
-            if unlikely(!is_token_program_owner(view)) {
-                return Err(ProgramError::IllegalOwner);
-            }
-            if unlikely(view.data_len() < TokenAccountState::LEN) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            // SAFETY: Owner is a token program and `data_len >= LEN`
-            // checked above. `TokenAccountState` is `#[repr(C)]` with
-            // alignment 1.
-            let state = unsafe { &*(view.data_ptr() as *const TokenAccountState) };
-            if unlikely(!state.is_initialized()) {
-                return Err(ProgramError::UninitializedAccount);
-            }
-            if unlikely(!quasar_lang::keys_eq(
-                state.mint(),
+            validate_token_account(
+                view,
                 mint.to_account_view().address(),
-            )) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            if unlikely(!quasar_lang::keys_eq(state.owner(), owner)) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            Ok(())
+                owner,
+                token_program.address(),
+            )
         }
     }
 }
@@ -141,7 +117,8 @@ pub trait InitMint: AsAccountView + Sized {
     ///
     /// Checks `owner == system_program` to determine if the account needs
     /// initialization. When the account already exists, validates that its
-    /// mint authority matches the expected value.
+    /// mint authority, decimals, freeze authority, and token program ownership
+    /// match the expected values.
     #[inline(always)]
     #[allow(clippy::too_many_arguments)]
     fn init_if_needed(
@@ -166,31 +143,19 @@ pub trait InitMint: AsAccountView + Sized {
                 rent,
             )
         } else {
-            if unlikely(!is_token_program_owner(view)) {
-                return Err(ProgramError::IllegalOwner);
-            }
-            if unlikely(view.data_len() < MintAccountState::LEN) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            // SAFETY: Owner is a token program and `data_len >= LEN`
-            // checked above. `MintAccountState` is `#[repr(C)]` with
-            // alignment 1.
-            let state = unsafe { &*(view.data_ptr() as *const MintAccountState) };
-            if unlikely(!state.is_initialized()) {
-                return Err(ProgramError::UninitializedAccount);
-            }
-            if unlikely(
-                !state.has_mint_authority()
-                    || !quasar_lang::keys_eq(state.mint_authority_unchecked(), mint_authority),
-            ) {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            Ok(())
+            validate_mint(
+                view,
+                mint_authority,
+                decimals,
+                freeze_authority,
+                token_program.address(),
+            )
         }
     }
 }
 
-/// Validate that an existing token account has the expected mint and authority.
+/// Validate that an existing token account has the expected mint, authority,
+/// and token program ownership.
 ///
 /// Used by generated `#[account(init_if_needed, token::...)]` code when the
 /// account is already initialized.
@@ -199,8 +164,9 @@ pub fn validate_token_account(
     view: &AccountView,
     mint: &Address,
     authority: &Address,
+    token_program: &Address,
 ) -> Result<(), ProgramError> {
-    if unlikely(!is_token_program_owner(view)) {
+    if unlikely(!quasar_lang::keys_eq(view.owner(), token_program)) {
         return Err(ProgramError::IllegalOwner);
     }
     if unlikely(view.data_len() < TokenAccountState::LEN) {
@@ -221,13 +187,20 @@ pub fn validate_token_account(
     Ok(())
 }
 
-/// Validate that an existing mint account has the expected authority.
+/// Validate that an existing mint account matches the provided parameters.
 ///
 /// Used by generated `#[account(init_if_needed, mint::...)]` code when the
-/// account is already initialized.
+/// account is already initialized. `freeze_authority = None` asserts that the
+/// on-chain mint has no freeze authority set (matching Anchor's behavior).
 #[inline(always)]
-pub fn validate_mint(view: &AccountView, mint_authority: &Address) -> Result<(), ProgramError> {
-    if unlikely(!is_token_program_owner(view)) {
+pub fn validate_mint(
+    view: &AccountView,
+    mint_authority: &Address,
+    decimals: u8,
+    freeze_authority: Option<&Address>,
+    token_program: &Address,
+) -> Result<(), ProgramError> {
+    if unlikely(!quasar_lang::keys_eq(view.owner(), token_program)) {
         return Err(ProgramError::IllegalOwner);
     }
     if unlikely(view.data_len() < MintAccountState::LEN) {
@@ -244,6 +217,24 @@ pub fn validate_mint(view: &AccountView, mint_authority: &Address) -> Result<(),
             || !quasar_lang::keys_eq(state.mint_authority_unchecked(), mint_authority),
     ) {
         return Err(ProgramError::InvalidAccountData);
+    }
+    if unlikely(state.decimals() != decimals) {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    match freeze_authority {
+        Some(expected) => {
+            if unlikely(
+                !state.has_freeze_authority()
+                    || !quasar_lang::keys_eq(state.freeze_authority_unchecked(), expected),
+            ) {
+                return Err(ProgramError::InvalidAccountData);
+            }
+        }
+        None => {
+            if unlikely(state.has_freeze_authority()) {
+                return Err(ProgramError::InvalidAccountData);
+            }
+        }
     }
     Ok(())
 }

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint.rs
@@ -1,0 +1,21 @@
+use {
+    quasar_lang::prelude::*,
+    quasar_spl::{Mint, Token},
+};
+
+#[derive(Accounts)]
+pub struct InitIfNeededMint<'info> {
+    pub payer: &'info mut Signer,
+    #[account(init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: &'info mut Account<Mint>,
+    pub mint_authority: &'info Signer,
+    pub token_program: &'info Program<Token>,
+    pub system_program: &'info Program<System>,
+}
+
+impl<'info> InitIfNeededMint<'info> {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint_with_freeze.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint_with_freeze.rs
@@ -1,0 +1,27 @@
+use {
+    quasar_lang::prelude::*,
+    quasar_spl::{Mint, Token},
+};
+
+#[derive(Accounts)]
+pub struct InitIfNeededMintWithFreeze<'info> {
+    pub payer: &'info mut Signer,
+    #[account(
+        init_if_needed,
+        mint::decimals = 6,
+        mint::authority = mint_authority,
+        mint::freeze_authority = freeze_authority
+    )]
+    pub mint: &'info mut Account<Mint>,
+    pub mint_authority: &'info Signer,
+    pub freeze_authority: &'info UncheckedAccount,
+    pub token_program: &'info Program<Token>,
+    pub system_program: &'info Program<System>,
+}
+
+impl<'info> InitIfNeededMintWithFreeze<'info> {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-token-cpi/src/instructions/mod.rs
+++ b/tests/programs/test-token-cpi/src/instructions/mod.rs
@@ -37,5 +37,11 @@ pub use init_if_needed_ata::InitIfNeededAta;
 pub mod init_mint;
 pub use init_mint::InitMintAccount;
 
+pub mod init_if_needed_mint;
+pub use init_if_needed_mint::InitIfNeededMint;
+
+pub mod init_if_needed_mint_with_freeze;
+pub use init_if_needed_mint_with_freeze::InitIfNeededMintWithFreeze;
+
 pub mod init_mint_with_metadata;
 pub use init_mint_with_metadata::InitMintWithMetadata;

--- a/tests/programs/test-token-cpi/src/lib.rs
+++ b/tests/programs/test-token-cpi/src/lib.rs
@@ -86,4 +86,16 @@ mod quasar_test_token_cpi {
     pub fn init_mint_with_metadata(ctx: Ctx<InitMintWithMetadata>) -> Result<(), ProgramError> {
         ctx.accounts.handler()
     }
+
+    #[instruction(discriminator = 14)]
+    pub fn init_if_needed_mint(ctx: Ctx<InitIfNeededMint>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    #[instruction(discriminator = 15)]
+    pub fn init_if_needed_mint_with_freeze(
+        ctx: Ctx<InitIfNeededMintWithFreeze>,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
 }

--- a/tests/suite/src/token_cpi.rs
+++ b/tests/suite/src/token_cpi.rs
@@ -1325,6 +1325,917 @@ fn test_init_if_needed_token_wrong_mint() {
 }
 
 // ---------------------------------------------------------------------------
+// Init-if-needed token: wrong authority
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_token_wrong_authority() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(payer, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let wrong_authority = Address::new_unique();
+    let token_account = Address::new_unique();
+    // Existing token account with wrong_authority as owner (not payer)
+    let token_account_obj = Account {
+        lamports: 1_000_000,
+        data: pack_token(mint, wrong_authority, 500),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededTokenInstruction {
+        payer,
+        token_account,
+        mint,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (token_account, token_account_obj),
+            (mint, mint_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed should fail when existing account has wrong authority"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed token: wrong token program owner
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_token_wrong_token_program_owner() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(payer, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let token_account = Address::new_unique();
+    // Token account owned by Token-2022 instead of SPL Token
+    let token_account_obj = Account {
+        lamports: 1_000_000,
+        data: pack_token(mint, payer, 500),
+        owner: quasar_spl::TOKEN_2022_ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededTokenInstruction {
+        payer,
+        token_account,
+        mint,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (token_account, token_account_obj),
+            (mint, mint_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed should fail when existing account owned by wrong token program"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed mint (no freeze authority)
+// ---------------------------------------------------------------------------
+
+fn pack_mint_with_freeze(
+    authority: Address,
+    decimals: u8,
+    freeze_authority: Option<Address>,
+) -> Vec<u8> {
+    let mint = Mint {
+        mint_authority: Some(authority).into(),
+        supply: 1_000_000_000,
+        decimals,
+        is_initialized: true,
+        freeze_authority: freeze_authority.into(),
+    };
+    let mut data = vec![0u8; Mint::LEN];
+    Pack::pack(mint, &mut data).unwrap();
+    data
+}
+
+#[test]
+fn test_init_if_needed_mint_new_account() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let mint_account = Account::default();
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "init_if_needed_mint should succeed for new account: {:?}",
+        result.program_result
+    );
+
+    let data: Mint = Pack::unpack(&result.resulting_accounts[1].1.data).unwrap();
+    assert_eq!(data.decimals, 6, "mint decimals should be 6");
+    assert_eq!(
+        data.mint_authority,
+        Some(mint_authority).into(),
+        "mint authority should match"
+    );
+    assert!(data.is_initialized, "mint should be initialized");
+    assert_eq!(
+        Option::<Address>::from(data.freeze_authority),
+        None,
+        "freeze authority should be None"
+    );
+    println!(
+        "  init_if_needed_mint (new): OK (CU: {})",
+        result.compute_units_consumed
+    );
+}
+
+#[test]
+fn test_init_if_needed_mint_existing_valid() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(mint_authority, 6),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "init_if_needed_mint should pass for existing valid mint: {:?}",
+        result.program_result
+    );
+    println!("  init_if_needed_mint (existing valid): OK");
+}
+
+#[test]
+fn test_init_if_needed_mint_wrong_decimals() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    // Existing mint with decimals=9, but instruction expects 6
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(mint_authority, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint should fail when existing mint has wrong decimals"
+    );
+}
+
+#[test]
+fn test_init_if_needed_mint_wrong_authority() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+    let wrong_authority = Address::new_unique();
+
+    let mint = Address::new_unique();
+    // Existing mint with wrong_authority, but instruction expects mint_authority
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(wrong_authority, 6),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint should fail when existing mint has wrong authority"
+    );
+}
+
+#[test]
+fn test_init_if_needed_mint_wrong_token_program_owner() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    // Existing mint owned by Token-2022, but instruction uses SPL Token
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(mint_authority, 6),
+        owner: quasar_spl::TOKEN_2022_ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint should fail when existing mint owned by wrong token program"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed mint: unexpected freeze authority
+// (no freeze_authority declared, but on-chain mint has one)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_mint_unexpected_freeze_authority() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+    let surprise_freeze = Address::new_unique();
+
+    let mint = Address::new_unique();
+    // On-chain mint has a freeze authority, but the instruction (discriminator=14)
+    // does NOT declare mint::freeze_authority — so None means "assert no freeze"
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint_with_freeze(mint_authority, 6, Some(surprise_freeze)),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintInstruction {
+        payer,
+        mint,
+        mint_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint should fail when on-chain mint has unexpected freeze authority"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed mint WITH freeze authority
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_mint_with_freeze_new_account() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let freeze_authority = Address::new_unique();
+    let freeze_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let mint_account = Account::default();
+
+    let mut instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
+        payer,
+        mint,
+        mint_authority,
+        freeze_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (freeze_authority, freeze_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "init_if_needed_mint_with_freeze should succeed for new account: {:?}",
+        result.program_result
+    );
+
+    let data: Mint = Pack::unpack(&result.resulting_accounts[1].1.data).unwrap();
+    assert_eq!(data.decimals, 6);
+    assert_eq!(data.mint_authority, Some(mint_authority).into());
+    assert_eq!(
+        Option::<Address>::from(data.freeze_authority),
+        Some(freeze_authority),
+        "freeze authority should be set"
+    );
+    println!(
+        "  init_if_needed_mint_with_freeze (new): OK (CU: {})",
+        result.compute_units_consumed
+    );
+}
+
+#[test]
+fn test_init_if_needed_mint_with_freeze_existing_valid() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let freeze_authority = Address::new_unique();
+    let freeze_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint_with_freeze(mint_authority, 6, Some(freeze_authority)),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
+        payer,
+        mint,
+        mint_authority,
+        freeze_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (freeze_authority, freeze_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "init_if_needed_mint_with_freeze should pass for existing valid mint: {:?}",
+        result.program_result
+    );
+    println!("  init_if_needed_mint_with_freeze (existing valid): OK");
+}
+
+#[test]
+fn test_init_if_needed_mint_with_freeze_wrong_freeze_authority() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let freeze_authority = Address::new_unique();
+    let freeze_authority_account = Account::new(1_000_000, 0, &Address::default());
+    let wrong_freeze = Address::new_unique();
+
+    let mint = Address::new_unique();
+    // On-chain mint has wrong_freeze, but instruction expects freeze_authority
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint_with_freeze(mint_authority, 6, Some(wrong_freeze)),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
+        payer,
+        mint,
+        mint_authority,
+        freeze_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (freeze_authority, freeze_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint_with_freeze should fail when freeze authority doesn't match"
+    );
+}
+
+#[test]
+fn test_init_if_needed_mint_with_freeze_missing_on_chain() {
+    let mollusk = setup();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let mint_authority = Address::new_unique();
+    let mint_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let freeze_authority = Address::new_unique();
+    let freeze_authority_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    // On-chain mint has NO freeze authority, but instruction declares one
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(mint_authority, 6),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let mut instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
+        payer,
+        mint,
+        mint_authority,
+        freeze_authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    instruction.accounts[1].is_signer = true;
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (mint, mint_account),
+            (mint_authority, mint_authority_account),
+            (freeze_authority, freeze_authority_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_mint_with_freeze should fail when on-chain mint has no freeze authority"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed ATA: wrong authority (wallet)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_ata_wrong_authority() {
+    let mollusk = setup_with_ata();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+    let (ata_program, ata_program_account) = ata_program_account();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let wallet = Address::new_unique();
+    let wallet_account = Account::new(1_000_000, 0, &Address::default());
+    let wrong_wallet = Address::new_unique();
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(payer, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (ata_addr, _) = get_associated_token_address_const(&wallet, &mint);
+    // ATA exists but is owned by wrong_wallet instead of wallet
+    let ata_account = Account {
+        lamports: 1_000_000,
+        data: pack_token(mint, wrong_wallet, 200),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let instruction: Instruction = InitIfNeededAtaInstruction {
+        payer,
+        ata: ata_addr,
+        wallet,
+        mint,
+        token_program,
+        system_program,
+        ata_program,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (ata_addr, ata_account),
+            (wallet, wallet_account),
+            (mint, mint_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+            (ata_program, ata_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_ata should fail when existing ATA has wrong authority (wallet)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed ATA: wrong mint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_ata_wrong_mint() {
+    let mollusk = setup_with_ata();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+    let (ata_program, ata_program_account) = ata_program_account();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let wallet = Address::new_unique();
+    let wallet_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let wrong_mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(payer, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (ata_addr, _) = get_associated_token_address_const(&wallet, &mint);
+    // ATA exists but with wrong_mint
+    let ata_account = Account {
+        lamports: 1_000_000,
+        data: pack_token(wrong_mint, wallet, 200),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let instruction: Instruction = InitIfNeededAtaInstruction {
+        payer,
+        ata: ata_addr,
+        wallet,
+        mint,
+        token_program,
+        system_program,
+        ata_program,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (ata_addr, ata_account),
+            (wallet, wallet_account),
+            (mint, mint_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+            (ata_program, ata_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_ata should fail when existing ATA has wrong mint"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Init-if-needed ATA: wrong token program owner
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_if_needed_ata_wrong_token_program_owner() {
+    let mollusk = setup_with_ata();
+    let (token_program, token_program_account) = token_program_account();
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+    let (ata_program, ata_program_account) = ata_program_account();
+
+    let payer = Address::new_unique();
+    let payer_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let wallet = Address::new_unique();
+    let wallet_account = Account::new(1_000_000, 0, &Address::default());
+
+    let mint = Address::new_unique();
+    let mint_account = Account {
+        lamports: 1_000_000,
+        data: pack_mint(payer, 9),
+        owner: token_program,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let (ata_addr, _) = get_associated_token_address_const(&wallet, &mint);
+    // ATA exists but is owned by Token-2022 instead of SPL Token
+    let ata_account = Account {
+        lamports: 1_000_000,
+        data: pack_token(mint, wallet, 200),
+        owner: quasar_spl::TOKEN_2022_ID,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let instruction: Instruction = InitIfNeededAtaInstruction {
+        payer,
+        ata: ata_addr,
+        wallet,
+        mint,
+        token_program,
+        system_program,
+        ata_program,
+    }
+    .into();
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (payer, payer_account),
+            (ata_addr, ata_account),
+            (wallet, wallet_account),
+            (mint, mint_account),
+            (token_program, token_program_account),
+            (system_program, system_program_account),
+            (ata_program, ata_program_account),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_err(),
+        "init_if_needed_ata should fail when existing ATA owned by wrong token program"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Init ATA (#[account(init, associated_token::mint,
 // associated_token::authority)])
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #75.

## Problem

`validate_mint` only checked `mint_authority` in the `init_if_needed` else branch. Three attacker-controllable properties were ignored:

1. **decimals** — attacker passes a mint with correct authority but wrong decimals (e.g. 0 instead of 6), token amounts are misinterpreted
2. **freeze_authority** — mint with a rogue freeze authority passes validation, attacker can freeze token accounts at will
3. **token_program ownership** — `is_token_program_owner` accepted both SPL Token and Token-2022 indiscriminately. A Token-2022 mint passes in a context expecting SPL Token

`validate_token_account` had the same broad token program check. Non-init `InterfaceAccount<T>` fields had zero owner validation.

## Fix

### Runtime helpers (`spl/src/helpers/init.rs`)

`validate_mint` now takes `decimals`, `freeze_authority`, and `token_program`. Checks all four properties. `freeze_authority = None` asserts no freeze authority on-chain (matches Anchor). Removed `is_token_program_owner` — replaced with exact `token_program` comparison.

`validate_token_account` now takes `token_program` for exact program match.

These functions remain for the trait API (manual `InitToken`/`InitMint` usage). The derive codegen no longer calls them.

### ATA callers (`spl/src/associated_token/`)

`InitAssociatedToken::init_if_needed` and `validate_ata` both called `validate_token_account` — updated to pass `token_program.address()` through. Without this, the new `token_program` parameter would have been missing at these two call sites.

### Derive codegen (`derive/src/accounts/fields.rs`)

Replaced `quasar_spl::validate_*` calls with inline type-aware checks in `init_blocks`:

- **Owner check** via `gen_owner_check`: `Account<T>` uses `CheckOwner` (single comparison against compile-time constant), `InterfaceAccount<T>` uses exact `token_program.address()` match
- **Token accounts**: owner, data_len, is_initialized, mint, authority
- **Mint accounts**: owner, data_len, is_initialized, mint_authority, decimals, freeze_authority (compile-time decided based on whether `mint::freeze_authority` attr is present)
- **ATA accounts**: address derivation, owner, data_len, is_initialized, mint, authority

Since the inline validation covers everything, `mut_checks` are skipped for init/init_if_needed fields with token/mint/ATA attrs. This eliminates redundant key comparisons (~2 per field = 64 bytes memcmp saved). Generic `Account<T>` init_if_needed without these attrs keeps `mut_checks` as the only defense.

`InterfaceAccount<T>` non-init fields now get dual-owner check (SPL Token or Token-2022) + `AccountCheck` in `mut_checks`. Previously had zero validation.

### Tests (16 new)

Each test targets a specific inline validation check. Since `mut_checks` are skipped for these fields (`skip_mut_checks = true` when `has_inline_validation`), the inline code is the sole defense — removing any single check causes the corresponding test to incorrectly pass.

**Issue #75 core** (would have passed before this fix):
- `test_init_if_needed_mint_wrong_decimals`
- `test_init_if_needed_mint_unexpected_freeze_authority` — on-chain has freeze auth but none declared
- `test_init_if_needed_mint_with_freeze_wrong_freeze_authority`
- `test_init_if_needed_mint_with_freeze_missing_on_chain` — declared freeze but none on-chain

**Inline validation replacing skipped mut_checks:**
- `test_init_if_needed_token_wrong_authority`
- `test_init_if_needed_token_wrong_token_program_owner`
- `test_init_if_needed_mint_wrong_authority`
- `test_init_if_needed_mint_wrong_token_program_owner`
- `test_init_if_needed_ata_wrong_authority`
- `test_init_if_needed_ata_wrong_mint`
- `test_init_if_needed_ata_wrong_token_program_owner`

**Happy path:**
- `test_init_if_needed_mint_new_account`
- `test_init_if_needed_mint_existing_valid`
- `test_init_if_needed_mint_with_freeze_new_account`
- `test_init_if_needed_mint_with_freeze_existing_valid`

New test program instructions: `init_if_needed_mint` (discriminator 14) and `init_if_needed_mint_with_freeze` (discriminator 15).

All 729 workspace tests pass.