### PR TITLE
refactor: build flamegraph tree directly from stack counts

### DIFF
--- a/profile/src/aggregate.rs
+++ b/profile/src/aggregate.rs
@@ -4,7 +4,7 @@ use {
 };
 
 pub struct ProfileResult {
-    pub folded_stacks: String,
+    pub stack_counts: Vec<(Vec<String>, u64)>,
     pub total_cus: u64,
     /// (function_name, self_cu_count) sorted descending
     pub function_cus: Vec<(String, u64)>,
@@ -19,7 +19,7 @@ pub fn profile(mmap: &[u8], info: &ElfInfo, resolver: &Resolver) -> ProfileResul
     let mut total_cus: u64 = 0;
 
     for (addr, _opcode) in walker {
-        let mut stack = resolver.resolve(addr);
+        let stack = resolver.resolve(addr);
         total_cus += 1;
 
         // Attribute to leaf function (innermost frame)
@@ -28,29 +28,18 @@ pub fn profile(mmap: &[u8], info: &ElfInfo, resolver: &Resolver) -> ProfileResul
             *leaf_counts.entry(leaf.clone()).or_insert(0) += 1;
         }
 
-        // Reverse to outermost-first order for folded stack format
-        stack.reverse();
         *stack_counts.entry(stack).or_insert(0) += 1;
-    }
-
-    // Build folded stacks string, sorted for determinism
-    let mut entries: Vec<_> = stack_counts.into_iter().collect();
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut folded = String::new();
-    for (stack, count) in &entries {
-        folded.push_str(&stack.join(";"));
-        folded.push(' ');
-        folded.push_str(&count.to_string());
-        folded.push('\n');
     }
 
     // Build sorted function CU table
     let mut function_cus: Vec<_> = leaf_counts.into_iter().collect();
     function_cus.sort_by_key(|b| std::cmp::Reverse(b.1));
 
+    let mut stack_counts: Vec<_> = stack_counts.into_iter().collect();
+    stack_counts.sort_by(|a, b| a.0.iter().cmp(b.0.iter()));
+
     ProfileResult {
-        folded_stacks: folded,
+        stack_counts,
         total_cus,
         function_cus,
     }

--- a/profile/src/output.rs
+++ b/profile/src/output.rs
@@ -408,7 +408,7 @@ pub fn write_json(
     binary_size: u64,
     binary_hash: &str,
 ) {
-    let root = frame_tree_from_folded(&result.folded_stacks, result.total_cus);
+    let root = frame_tree_from_stacks(result);
     let profile = ProfileData {
         program: program_name.to_string(),
         version: version.to_string(),
@@ -430,25 +430,14 @@ pub fn write_json(
     writer.flush().unwrap();
 }
 
-fn frame_tree_from_folded(folded: &str, total: u64) -> FrameNode {
+fn frame_tree_from_stacks(result: &ProfileResult) -> FrameNode {
     let mut synthetic = BuildNode::default();
 
-    for line in folded.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let Some((stack, count_str)) = trimmed.rsplit_once(' ') else {
-            continue;
-        };
-        let Ok(count) = count_str.parse::<u64>() else {
-            continue;
-        };
-
+    for (stack, count) in &result.stack_counts {
         let mut cursor = &mut synthetic;
-        for part in stack.split(';') {
-            let node = cursor.children.entry(part.to_string()).or_default();
-            node.value += count;
+        for part in stack.iter().rev() {
+            let node = cursor.children.entry(part.clone()).or_default();
+            node.value += *count;
             cursor = node;
         }
     }
@@ -466,7 +455,7 @@ fn frame_tree_from_folded(folded: &str, total: u64) -> FrameNode {
     children.sort_by(|a, b| b.value.cmp(&a.value).then_with(|| a.name.cmp(&b.name)));
     FrameNode {
         name: "all".to_string(),
-        value: total,
+        value: result.total_cus,
         children,
     }
 }


### PR DESCRIPTION
# Problem
Previously the profile pipeline was converting stacks to folded text and reparsing them.

# Solution
This changes the profiler output pipeline to build the flamegraph tree directly from aggregated stacks


# Results
instructions retired: 288.9M(after) vs 295.6M(before)
cycles: 89.2M(after) vs earlier 93.1M(before)
peak memory: 2.85 MB(after) vs earlier 3.28 MB(before)
