### PR TITLE
fix: update TypeScript init scaffold for ESM tooling

### DIFF
--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -365,7 +365,9 @@ fn generate_package_json(name: &str, ts_sdk: TypeScriptSdk) -> String {
   "name": "{name}",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {{
+    "check-types": "tsc --noEmit",
     "test": "vitest run"
   }},
   "dependencies": {{
@@ -376,7 +378,7 @@ fn generate_package_json(name: &str, ts_sdk: TypeScriptSdk) -> String {
   "devDependencies": {{
     "@types/node": "^22.13.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.1.0"
+    "vitest": "^4.1.1"
   }}
 }}
 "#

--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -76,13 +76,13 @@ pub enum MyError {
 
 pub(super) const TS_TEST_TSCONFIG: &str = r#"{
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "module": "preserve",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
     "types": ["node"]
   },
   "include": ["tests/*.test.ts"]


### PR DESCRIPTION
Generate ESM package metadata and a typecheck script for TypeScript test projects.

Also switch the generated tsconfig to bundler-style module resolution and refresh the Node and Vitest dev dependency versions.
