### PR TITLE
fix: validate account count and enforce payer mutability

### DIFF
--- a/derive/src/accounts/fields.rs
+++ b/derive/src/accounts/fields.rs
@@ -631,6 +631,32 @@ pub(super) fn process_fields(
         None
     };
 
+    // Validate payer writability: init and realloc payers must be mutable.
+    for (label, payer) in [("init", &payer_field), ("realloc", &realloc_payer_field)] {
+        if let Some(payer_ident) = payer {
+            let writable = fields
+                .iter()
+                .zip(field_attrs.iter())
+                .find(|(f, _)| f.ident.as_ref() == Some(payer_ident))
+                .map(|(f, attrs)| {
+                    let eff = extract_generic_inner_type(&f.ty, "Option").unwrap_or(&f.ty);
+                    attrs.is_mut || matches!(eff, Type::Reference(r) if r.mutability.is_some())
+                })
+                .unwrap_or(false);
+            if !writable {
+                return Err(syn::Error::new_spanned(
+                    payer_ident,
+                    format!(
+                        "`{}` payer `{}` must be `&mut` or `#[account(mut)]`",
+                        label, payer_ident
+                    ),
+                )
+                .to_compile_error()
+                .into());
+            }
+        }
+    }
+
     // Close on token/mint types requires a token program field for CPI close.
     let has_any_token_close = field_attrs
         .iter()

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -212,6 +212,10 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
         items.push(syn::parse_quote! {
             #[inline(always)]
             fn __handle_event(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
+                // SAFETY: The SVM places the account count (u64) at offset 0.
+                if unsafe { *(ptr as *const u64) } == 0 {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                }
                 // SAFETY: Pointer arithmetic follows the SVM input buffer layout. The u64 casts
                 // for address comparison are technically misaligned (Address is align 1), but SBF
                 // handles unaligned access natively — this 4×u64 compare saves ~20 CU vs memcmp.

--- a/lang/src/entrypoint.rs
+++ b/lang/src/entrypoint.rs
@@ -19,8 +19,9 @@ macro_rules! dispatch {
             &*($ix_data.as_ptr().add($ix_data.len()) as *const [u8; 32])
         };
         const __U64_SIZE: usize = core::mem::size_of::<u64>();
-        // SAFETY: The SVM places the account count (u64) at offset 0,
-        // followed by the account entries. Skip past the count.
+        // SAFETY: The SVM places the account count (u64) at offset 0.
+        let __num_accounts = unsafe { *($ptr as *const u64) };
+        // SAFETY: Skip past the count to reach the first account entry.
         let __accounts_start = unsafe { ($ptr as *mut u8).add(__U64_SIZE) };
 
         if $ix_data.len() < $disc_len {
@@ -33,6 +34,9 @@ macro_rules! dispatch {
         match __disc {
             $(
                 [$($disc_byte),+] => {
+                    if (__num_accounts as usize) < <$accounts_ty as AccountCount>::COUNT {
+                        return Err(ProgramError::NotEnoughAccountKeys);
+                    }
                     let mut __buf = core::mem::MaybeUninit::<
                         [AccountView; <$accounts_ty as AccountCount>::COUNT]
                     >::uninit();


### PR DESCRIPTION
## Context

The `dispatch!` macro and `__handle_event` both skip the `num_accounts` u64 at the start of the SVM input buffer without ever reading it. If a transaction provides fewer accounts than the instruction expects, `parse_accounts` walks past the valid account data into unmapped memory and the SBF VM traps with an access violation. Not a security vulnerability (the crash is safe — no state changes, no fund loss), but a correctness issue: programs should return `NotEnoughAccountKeys` instead of crashing.

Separately, there was no compile-time enforcement that payer accounts are writable. The Solana runtime catches this at execution time, but a build error is strictly better than a failed transaction on testnet.

Ref: #80 (QSR-01, QSR-04, QSR-05). QSR-02 is a compile-time-only footgun, QSR-03 is wrong (intentional SIMD-0321 entrypoint).

## Changes

**`lang/src/entrypoint.rs`** — Read `num_accounts` from offset 0 of the SVM buffer. Each `dispatch!` match arm now checks `num_accounts >= COUNT` before calling `parse_accounts`. ~2 CU cost.

**`derive/src/program.rs`** — `__handle_event` checks `num_accounts > 0` before dereferencing the first account for the event authority signer/address check.

**`derive/src/accounts/fields.rs`** — `process_fields` now rejects at compile time if the `init` or `realloc` payer field is not `&mut` or `#[account(mut)]`.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] Full test suite — 729 passed, 0 failed