### PR TITLE
fix: use real cfg gates instead of faking target_os="solana"

### DIFF
--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -22,7 +22,6 @@ build-std = ["core", "alloc"]
 
 [target.bpfel-unknown-none]
 rustflags = [
-"--cfg", "target_os=\"solana\"",
 "--cfg", "feature=\"mem_unaligned\"",
 "-C", "linker=sbpf-linker",
 "-C", "panic=abort",

--- a/derive/src/account/accessors.rs
+++ b/derive/src/account/accessors.rs
@@ -63,9 +63,9 @@ pub(super) fn generate_accessors(
                             let __len = #read;
                             let __start = __offset + #pb;
                             let __bytes = &__data[__start..__start + __len];
-                            #[cfg(target_os = "solana")]
+                            #[cfg(any(target_os = "solana", target_arch = "bpf"))]
                             { unsafe { core::str::from_utf8_unchecked(__bytes) } }
-                            #[cfg(not(target_os = "solana"))]
+                            #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                             { core::str::from_utf8(__bytes).expect("account string field contains invalid UTF-8") }
                         }
                     }
@@ -93,9 +93,9 @@ pub(super) fn generate_accessors(
                                     let __data = unsafe { self.__view.borrow_unchecked() };
                                     let __offset = #off_expr;
                                     let __bytes = &__data[__offset..];
-                                    #[cfg(target_os = "solana")]
+                                    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
                                     { unsafe { core::str::from_utf8_unchecked(__bytes) } }
-                                    #[cfg(not(target_os = "solana"))]
+                                    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                                     { core::str::from_utf8(__bytes).expect("account tail field contains invalid UTF-8") }
                                 }
                             }

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -260,7 +260,7 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         items.push(syn::parse_quote! {
             #[unsafe(no_mangle)]
-            #[cfg(target_os = "solana")]
+            #[cfg(any(target_os = "solana", target_arch = "bpf"))]
             #[allow(unexpected_cfgs)]
             pub unsafe extern "C" fn entrypoint(ptr: *mut u8, instruction_data: *const u8) -> u64 {
                 // SAFETY: Initialize bump allocator cursor. The SVM maps and zero-inits the heap

--- a/lang/src/sysvars/mod.rs
+++ b/lang/src/sysvars/mod.rs
@@ -46,7 +46,7 @@ macro_rules! impl_sysvar_get {
             let mut var = core::mem::MaybeUninit::<Self>::uninit();
             let var_addr = var.as_mut_ptr() as *mut _ as *mut u8;
 
-            #[cfg(target_os = "solana")]
+            #[cfg(any(target_os = "solana", target_arch = "bpf"))]
             // SAFETY: `var_addr` points to `MaybeUninit<Self>` which has
             // enough space. The syscall writes `length` bytes; we zero the
             // trailing `$padding` bytes so the full struct is initialized.
@@ -61,7 +61,7 @@ macro_rules! impl_sysvar_get {
                 )
             };
 
-            #[cfg(not(target_os = "solana"))]
+            #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
             let result = {
                 // SAFETY: Zero-init the full struct for off-chain use.
                 unsafe { var_addr.write_bytes(0, core::mem::size_of::<Self>()) };


### PR DESCRIPTION
## Summary

- Gate entrypoint, sysvar macro, and string accessors on `any(target_os = "solana", target_arch = "bpf")` instead of just `target_os = "solana"`
- Remove `--cfg target_os="solana"` from the scaffold template — no longer needed since `target_arch = "bpf"` is the real cfg for `bpfel-unknown-none`
- Matches the pattern already used in ~30 other cfg sites across the codebase

This covers both build paths using real cfg values:

| Build path | Real cfg that matches |
|---|---|
| `cargo build-sbf` (`sbf-solana-solana`) | `target_os = "solana"` |
| `cargo build-bpf` (`bpfel-unknown-none`) | `target_arch = "bpf"` |

Closes #95
Closes #96