### PR TITLE
Remove implicit lifetimes

### DIFF
--- a/derive/src/accounts/fields_process.rs
+++ b/derive/src/accounts/fields_process.rs
@@ -590,7 +590,7 @@ pub(crate) fn process_fields(
         } else {
             let base_type = strip_generics(effective_ty);
             field_constructs.push(construct(
-                quote! { unsafe { #base_type::from_account_view_unchecked(#field_name) } },
+                quote! { unsafe { core::ptr::read(#base_type::from_account_view_unchecked(#field_name)) } },
             ));
         }
 

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -529,7 +529,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         quote! {}
     } else {
         quote! {
-            impl<'info> #name<'info> {
+            impl #name {
                 #(#seeds_methods)*
             }
         }
@@ -634,11 +634,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
     let parse_accounts_impl = if has_instruction_args {
         quote! {
-            impl<'info> ParseAccounts<'info> for #name<'info> {
+            impl ParseAccounts for #name {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &'info mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
@@ -651,8 +651,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 fn parse_with_instruction_data(
-                    accounts: &'info mut [AccountView],
-                    __ix_data: &'info [u8],
+                    accounts: &mut [AccountView],
+                    __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
@@ -668,9 +668,9 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl<'info> quasar_lang::traits::ParseAccountsUnchecked<'info> for #name<'info> {
+            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
                 #[inline(always)]
-                unsafe fn parse_unchecked(accounts: &'info mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                unsafe fn parse_unchecked(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
                         accounts,
                         &[],
@@ -680,8 +680,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 unsafe fn parse_with_instruction_data_unchecked(
-                    accounts: &'info mut [AccountView],
-                    __ix_data: &'info [u8],
+                    accounts: &mut [AccountView],
+                    __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #ix_arg_extraction
@@ -691,11 +691,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            impl<'info> ParseAccounts<'info> for #name<'info> {
+            impl ParseAccounts for #name {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &'info mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_unchecked(
@@ -708,10 +708,10 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl<'info> quasar_lang::traits::ParseAccountsUnchecked<'info> for #name<'info> {
+            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
                 #[inline(always)]
                 unsafe fn parse_unchecked(
-                    accounts: &'info mut [AccountView],
+                    accounts: &mut [AccountView],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #parse_body
@@ -727,11 +727,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
         #seeds_impl
 
-        impl<'info> AccountCount for #name<'info> {
+        impl AccountCount for #name {
             const COUNT: usize = #count_expr;
         }
 
-        impl<'info> #name<'info> {
+        impl #name {
             #[inline(always)]
             pub unsafe fn parse_accounts(
                 mut input: *mut u8,

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -15,13 +15,53 @@ use {
     instruction_args::{generate_instruction_arg_extraction, parse_struct_instruction_args},
     proc_macro::TokenStream,
     quote::{format_ident, quote},
-    syn::{parse_macro_input, Data, DeriveInput, Fields, Type},
+    syn::{parse_macro_input, parse_quote, Data, DeriveInput, Fields, GenericParam, Type},
 };
 
 pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let bumps_name = format_ident!("{}Bumps", name);
+
+    // Currently only custom lifetime parameters are supported, so validate that
+    // we don't have any type or const generics.
+    if let Some(param) = input
+        .generics
+        .params
+        .iter()
+        .find(|param| !matches!(param, GenericParam::Lifetime(_)))
+    {
+        let message = match param {
+            GenericParam::Type(_) => {
+                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not supported"
+            }
+            GenericParam::Const(_) => {
+                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not supported"
+            }
+            GenericParam::Lifetime(_) => unreachable!("filtered above"),
+        };
+        return syn::Error::new_spanned(param, message)
+            .to_compile_error()
+            .into();
+    }
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut parse_generics = input.generics.clone();
+    // 'input is the default lifetime used for account references in the generated traits, so
+    // we need to make sure that it lives longer than any user-defined lifetimes.
+    parse_generics.params.push(parse_quote!('input));
+    {
+        let parse_where = parse_generics.make_where_clause();
+        for lifetime in input.generics.lifetimes() {
+            let lifetime = &lifetime.lifetime;
+            parse_where
+                .predicates
+                .push(syn::parse_quote!('input: #lifetime));
+        }
+    }
+    // These generics are used for the ParseAccounts impl, which may have different lifetime
+    // requirements than the original struct.
+    let (parse_impl_generics, _, parse_where_clause) = parse_generics.split_for_impl();
 
     let fields = match &input.data {
         Data::Struct(data) => match &data.fields {
@@ -529,7 +569,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         quote! {}
     } else {
         quote! {
-            impl #name {
+            impl #impl_generics #name #ty_generics #where_clause {
                 #(#seeds_methods)*
             }
         }
@@ -634,11 +674,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
     let parse_accounts_impl = if has_instruction_args {
         quote! {
-            impl ParseAccounts for #name {
+            impl #parse_impl_generics ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &'input mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
@@ -651,7 +691,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 fn parse_with_instruction_data(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -668,9 +708,12 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
+            unsafe impl #parse_impl_generics quasar_lang::traits::ParseAccountsUnchecked<'input>
+                for #name #ty_generics
+                #parse_where_clause
+            {
                 #[inline(always)]
-                unsafe fn parse_unchecked(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                unsafe fn parse_unchecked(accounts: &'input mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
                         accounts,
                         &[],
@@ -680,7 +723,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 unsafe fn parse_with_instruction_data_unchecked(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -691,11 +734,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            impl ParseAccounts for #name {
+            impl #parse_impl_generics ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &'input mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_unchecked(
@@ -708,10 +751,13 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
+            unsafe impl #parse_impl_generics quasar_lang::traits::ParseAccountsUnchecked<'input>
+                for #name #ty_generics
+                #parse_where_clause
+            {
                 #[inline(always)]
                 unsafe fn parse_unchecked(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #parse_body
@@ -727,11 +773,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
         #seeds_impl
 
-        impl AccountCount for #name {
+        impl #impl_generics AccountCount for #name #ty_generics #where_clause {
             const COUNT: usize = #count_expr;
         }
 
-        impl #name {
+        impl #impl_generics #name #ty_generics #where_clause {
             #[inline(always)]
             pub unsafe fn parse_accounts(
                 mut input: *mut u8,

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -33,10 +33,12 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     {
         let message = match param {
             GenericParam::Type(_) => {
-                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not supported"
+                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not \
+                 supported"
             }
             GenericParam::Const(_) => {
-                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not supported"
+                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not \
+                 supported"
             }
             GenericParam::Lifetime(_) => unreachable!("filtered above"),
         };
@@ -47,8 +49,9 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let mut parse_generics = input.generics.clone();
-    // 'input is the default lifetime used for account references in the generated traits, so
-    // we need to make sure that it lives longer than any user-defined lifetimes.
+    // 'input is the default lifetime used for account references in the generated
+    // traits, so we need to make sure that it lives longer than any
+    // user-defined lifetimes.
     parse_generics.params.push(parse_quote!('input));
     {
         let parse_where = parse_generics.make_where_clause();
@@ -59,8 +62,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 .push(syn::parse_quote!('input: #lifetime));
         }
     }
-    // These generics are used for the ParseAccounts impl, which may have different lifetime
-    // requirements than the original struct.
+    // These generics are used for the ParseAccounts impl, which may have different
+    // lifetime requirements than the original struct.
     let (parse_impl_generics, _, parse_where_clause) = parse_generics.split_for_impl();
 
     let fields = match &input.data {

--- a/examples/vault/src/instructions/deposit.rs
+++ b/examples/vault/src/instructions/deposit.rs
@@ -1,18 +1,18 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Deposit<'info> {
-    pub user: &'info mut Signer,
+pub struct Deposit {
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub vault: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Deposit<'info> {
+impl Deposit {
     #[inline(always)]
     pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
         self.system_program
-            .transfer(self.user, self.vault, amount)
+            .transfer(&self.user, &self.vault, amount)
             .invoke()
     }
 }

--- a/examples/vault/src/instructions/deposit.rs
+++ b/examples/vault/src/instructions/deposit.rs
@@ -2,6 +2,7 @@ use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct Deposit {
+    #[account(mut)]
     pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
     pub vault: UncheckedAccount,

--- a/examples/vault/src/instructions/withdraw.rs
+++ b/examples/vault/src/instructions/withdraw.rs
@@ -2,6 +2,7 @@ use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct Withdraw {
+    #[account(mut)]
     pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
     pub vault: UncheckedAccount,

--- a/examples/vault/src/instructions/withdraw.rs
+++ b/examples/vault/src/instructions/withdraw.rs
@@ -1,13 +1,13 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Withdraw<'info> {
-    pub user: &'info mut Signer,
+pub struct Withdraw {
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
+    pub vault: UncheckedAccount,
 }
 
-impl<'info> Withdraw<'info> {
+impl Withdraw {
     #[inline(always)]
     pub fn withdraw(&self, amount: u64) -> Result<(), ProgramError> {
         let vault = self.vault.to_account_view();

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -17,7 +17,7 @@ use crate::{prelude::*, remaining::RemainingAccounts, traits::ParseAccountsUnche
 /// Cast `&[u8; 32]` to `&Address`.
 ///
 /// The entrypoint owns the original 32-byte program-id storage for the entire
-/// instruction, so the returned reference is valid for `'info`. This avoids
+/// instruction, so the returned reference is valid for `'input`. This avoids
 /// copying the program ID into a stack-local `Address` on every dispatch path.
 #[inline(always)]
 unsafe fn as_address(bytes: &[u8; 32]) -> &Address {
@@ -29,18 +29,18 @@ unsafe fn as_address(bytes: &[u8; 32]) -> &Address {
 /// Produced by the `dispatch!` macro from the entrypoint's raw pointers.
 /// Consumed by [`Ctx::new()`] or [`CtxWithRemaining::new()`] which parse
 /// and validate the accounts.
-pub struct Context<'info> {
+pub struct Context<'input> {
     /// 32-byte program ID passed by the runtime.
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Declared accounts (first `N` accounts deserialized from the input).
-    pub accounts: &'info mut [AccountView],
+    pub accounts: &'input mut [AccountView],
 
     /// Pointer to the first remaining account (past the declared accounts).
     pub remaining_ptr: *mut u8,
 
     /// Raw instruction data (discriminator already consumed by `dispatch!`).
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 
     /// End of accounts region: `ix_data_ptr - sizeof(u64)`.
     pub accounts_boundary: *const u8,
@@ -50,7 +50,7 @@ pub struct Context<'info> {
 ///
 /// Use [`CtxWithRemaining`] for instructions that need
 /// `remaining_accounts()`.
-pub struct Ctx<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount> {
+pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -58,15 +58,15 @@ pub struct Ctx<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + 
     pub bumps: T::Bumps,
 
     /// 32-byte program ID (raw bytes, not [`Address`]).
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Instruction data with discriminator already consumed.
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 }
 
-impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount> Ctx<'info, T> {
+impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'input, T> {
     #[inline(always)]
-    pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
+    pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
         let (accounts, bumps) = unsafe {
             T::parse_with_instruction_data_unchecked(ctx.accounts, ctx.data, program_id_addr)?
@@ -92,10 +92,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
 /// when inspecting trailing accounts in local logic, or
 /// `remaining_accounts_passthrough()` when forwarding a variable number of
 /// accounts to a downstream CPI.
-pub struct CtxWithRemaining<
-    'info,
-    T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount,
-> {
+pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -103,26 +100,24 @@ pub struct CtxWithRemaining<
     pub bumps: T::Bumps,
 
     /// 32-byte program ID (raw bytes).
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Instruction data with discriminator already consumed.
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 
     /// Pointer to the first remaining account in the input buffer.
     remaining_ptr: *mut u8,
 
     /// Declared accounts slice (for duplicate resolution in remaining).
-    declared: &'info [AccountView],
+    declared: &'input [AccountView],
 
     /// End-of-accounts boundary pointer.
     accounts_boundary: *const u8,
 }
 
-impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount>
-    CtxWithRemaining<'info, T>
-{
+impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> CtxWithRemaining<'input, T> {
     #[inline(always)]
-    pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
+    pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
         // Save slice metadata before parse consumes the &mut borrow.
         // The declared `AccountView`s are copied by value during parsing, so the
@@ -157,7 +152,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
     /// this for local program logic so each trailing account has a unique
     /// identity within the instruction context.
     #[inline(always)]
-    pub fn remaining_accounts(&self) -> RemainingAccounts<'info> {
+    pub fn remaining_accounts(&self) -> RemainingAccounts<'input> {
         RemainingAccounts::new(self.remaining_ptr, self.accounts_boundary, self.declared)
     }
 
@@ -167,7 +162,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
     /// for CPI forwarding scenarios. Prefer `remaining_accounts()` unless you
     /// explicitly need Solana's raw duplicate-meta behavior.
     #[inline(always)]
-    pub fn remaining_accounts_passthrough(&self) -> RemainingAccounts<'info> {
+    pub fn remaining_accounts_passthrough(&self) -> RemainingAccounts<'input> {
         RemainingAccounts::new_passthrough(
             self.remaining_ptr,
             self.accounts_boundary,

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -50,7 +50,7 @@ pub struct Context<'input> {
 ///
 /// Use [`CtxWithRemaining`] for instructions that need
 /// `remaining_accounts()`.
-pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
+pub struct Ctx<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -64,7 +64,9 @@ pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount>
     pub data: &'input [u8],
 }
 
-impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'input, T> {
+impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount>
+    Ctx<'input, T>
+{
     #[inline(always)]
     pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
@@ -92,7 +94,10 @@ impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'inpu
 /// when inspecting trailing accounts in local logic, or
 /// `remaining_accounts_passthrough()` when forwarding a variable number of
 /// accounts to a downstream CPI.
-pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
+pub struct CtxWithRemaining<
+    'input,
+    T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount,
+> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -115,7 +120,9 @@ pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + 
     accounts_boundary: *const u8,
 }
 
-impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> CtxWithRemaining<'input, T> {
+impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount>
+    CtxWithRemaining<'input, T>
+{
     #[inline(always)]
     pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -121,10 +121,10 @@ pub trait AccountCount {
 ///
 /// Returns the parsed struct and a `Bumps` companion containing any PDA bump
 /// seeds discovered during validation.
-pub trait ParseAccounts<'info>: Sized {
+pub trait ParseAccounts: Sized {
     type Bumps: Copy;
     fn parse(
-        accounts: &'info mut [AccountView],
+        accounts: &mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -137,8 +137,8 @@ pub trait ParseAccounts<'info>: Sized {
     /// The default implementation ignores `data` and delegates to `parse`.
     #[inline(always)]
     fn parse_with_instruction_data(
-        accounts: &'info mut [AccountView],
-        _data: &'info [u8],
+        accounts: &mut [AccountView],
+        _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
         Self::parse(accounts, program_id)
@@ -178,12 +178,12 @@ pub trait ParseAccounts<'info>: Sized {
 ///
 /// The caller must ensure `accounts.len() == Self::COUNT`.
 #[doc(hidden)]
-pub unsafe trait ParseAccountsUnchecked<'info>: ParseAccounts<'info> {
+pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
     /// # Safety
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
     unsafe fn parse_unchecked(
-        accounts: &'info mut [AccountView],
+        accounts: &mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -192,8 +192,8 @@ pub unsafe trait ParseAccountsUnchecked<'info>: ParseAccounts<'info> {
     /// `accounts.len()` must exactly match `Self::COUNT`.
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
-        accounts: &'info mut [AccountView],
-        _data: &'info [u8],
+        accounts: &mut [AccountView],
+        _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
         Self::parse_unchecked(accounts, program_id)

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -121,10 +121,10 @@ pub trait AccountCount {
 ///
 /// Returns the parsed struct and a `Bumps` companion containing any PDA bump
 /// seeds discovered during validation.
-pub trait ParseAccounts: Sized {
+pub trait ParseAccounts<'input>: Sized {
     type Bumps: Copy;
     fn parse(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -137,7 +137,7 @@ pub trait ParseAccounts: Sized {
     /// The default implementation ignores `data` and delegates to `parse`.
     #[inline(always)]
     fn parse_with_instruction_data(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -178,12 +178,12 @@ pub trait ParseAccounts: Sized {
 ///
 /// The caller must ensure `accounts.len() == Self::COUNT`.
 #[doc(hidden)]
-pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
+pub unsafe trait ParseAccountsUnchecked<'input>: ParseAccounts<'input> {
     /// # Safety
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
     unsafe fn parse_unchecked(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -192,7 +192,7 @@ pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
     /// `accounts.len()` must exactly match `Self::COUNT`.
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {

--- a/lang/tests/compile_fail/accounts_type_generic.rs
+++ b/lang/tests/compile_fail/accounts_type_generic.rs
@@ -1,0 +1,10 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct BadGenericAccount<'info, T> {
+    pub signer: &'info Signer,
+    pub _marker: core::marker::PhantomData<T>,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/accounts_type_generic.stderr
+++ b/lang/tests/compile_fail/accounts_type_generic.stderr
@@ -1,0 +1,5 @@
+error: #[derive(Accounts)] only supports lifetime parameters; type parameters are not supported
+ --> tests/compile_fail/accounts_type_generic.rs:5:37
+  |
+5 | pub struct BadGenericAccount<'info, T> {
+  |                                     ^

--- a/lang/tests/compile_fail/seeds_wrong_arity.stderr
+++ b/lang/tests/compile_fail/seeds_wrong_arity.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation panicked: Vault::seeds() argument count mismatch (check
   --> tests/compile_fail/seeds_wrong_arity.rs:14:10
    |
 14 | #[derive(Accounts)]
-   |          ^^^^^^^^ evaluation of `<Bad<'info> as quasar_lang::traits::ParseAccountsUnchecked<'info>>::parse_unchecked::_` failed here
+   |          ^^^^^^^^ evaluation of `<Bad<'info> as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_unchecked::_` failed here

--- a/lang/tests/parse_accounts.rs
+++ b/lang/tests/parse_accounts.rs
@@ -49,6 +49,12 @@ struct OnlySigner<'info> {
     signer: &'info mut Signer,
 }
 
+#[derive(Accounts)]
+struct MixedLifetimes<'signer, 'readonly> {
+    signer: &'signer mut Signer,
+    readonly_signer: &'readonly Signer,
+}
+
 #[test]
 fn parse_accounts_rejects_too_few_non_composite_accounts() {
     let mut accounts: [AccountView; 0] = [];
@@ -72,4 +78,25 @@ fn parse_accounts_rejects_extra_non_composite_accounts() {
         Err(err) => err,
     };
     assert_eq!(err, ProgramError::InvalidArgument);
+}
+
+#[test]
+fn parse_accounts_accepts_fields_with_different_lifetimes() {
+    let mut first = AccountBuffer::new();
+    first.init_signer(1);
+    let mut second = AccountBuffer::new();
+    second.init_signer(2);
+    let mut accounts = unsafe { [first.view(), second.view()] };
+
+    let (parsed, _) = MixedLifetimes::parse(&mut accounts, &Address::default())
+        .expect("parse should accept distinct field lifetimes");
+
+    assert_eq!(
+        parsed.signer.to_account_view().address(),
+        &Address::from([1; 32])
+    );
+    assert_eq!(
+        parsed.readonly_signer.to_account_view().address(),
+        &Address::from([2; 32])
+    );
 }


### PR DESCRIPTION
### Problem

Currently, the `Accounts` derive uses an implicit `'info` lifetime and expects accounts to be specified as references. This is not strictly necessary and the syntax can be simplified.

Current use of `#[derive(Accounts)]`:
```rust
#[derive(Accounts)]
pub struct Deposit<'info> {
    pub user: &'info mut Signer,
    #[account(mut, seeds = [b"vault", user], bump)]
    pub vault: &'info mut UncheckedAccount,
    pub system_program: &'info Program<System>,
}
```

### Solution

Allow account fields to be defined as owned types, which removes the need to use lifetimes. Since an `AccountView` holds a raw pointer, passing a reference or its value should be the same.

The `#[derive(Accounts)]` after the changes in this PR:
```rust
#[derive(Accounts)]
pub struct Deposit {
    #[account(mut)]
    pub user: Signer,
    #[account(mut, seeds = [b"vault", user], bump)]
    pub vault: UncheckedAccount,
    pub system_program: Program<System>,
}
```
