### PR TITLE
audit: comprehensive security, performance, and readability cleanup

### DIFF
--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -23,9 +23,8 @@ fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error
     let client_cargo_toml =
         codegen::rust::generate_cargo_toml(&parsed.crate_name, &parsed.version, pdas);
 
-    let idl = parser::build_idl(parsed).map_err(|errors| {
-        anyhow::anyhow!("{}", errors.join("\n"))
-    })?;
+    let idl =
+        parser::build_idl(parsed).map_err(|errors| anyhow::anyhow!("{}", errors.join("\n")))?;
 
     // Write IDL JSON
     let idl_dir = PathBuf::from("target").join("idl");

--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -23,7 +23,9 @@ fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error
     let client_cargo_toml =
         codegen::rust::generate_cargo_toml(&parsed.crate_name, &parsed.version, pdas);
 
-    let idl = parser::build_idl(parsed);
+    let idl = parser::build_idl(parsed).map_err(|errors| {
+        anyhow::anyhow!("{}", errors.join("\n"))
+    })?;
 
     // Write IDL JSON
     let idl_dir = PathBuf::from("target").join("idl");

--- a/derive/src/accounts/field_kind.rs
+++ b/derive/src/accounts/field_kind.rs
@@ -165,18 +165,32 @@ impl FieldFlags {
         }
     }
 
+    // RuntimeAccount header layout (u32 LE):
+    //   byte 0: borrow_state  (0xFF = NOT_BORROWED)
+    //   byte 1: is_signer     (0 or 1)
+    //   byte 2: is_writable   (0 or 1)
+    //   byte 3: executable    (0 or 1)
+    const BORROW_STATE_BYTE: u32 = 0xFF;
+    const SIGNER_BIT: u32 = 0x01 << 8;
+    const WRITABLE_BIT: u32 = 0x01 << 16;
+    const EXECUTABLE_BIT: u32 = 0x01 << 24;
+    const SIGNER_MASK: u32 = 0xFF << 8;
+    const WRITABLE_MASK: u32 = 0xFF << 16;
+    const EXECUTABLE_MASK: u32 = 0xFF << 24;
+    const FLAG_ONLY_MASK: u32 = 0xFFFFFF00;
+
     /// The expected u32 header value (little-endian: [borrow, signer, writable,
     /// exec]).
     pub fn header_constant(&self) -> u32 {
-        let mut h: u32 = 0xFF; // byte 0: NOT_BORROWED
+        let mut h: u32 = Self::BORROW_STATE_BYTE;
         if self.is_signer {
-            h |= 0x01 << 8;
+            h |= Self::SIGNER_BIT;
         }
         if self.is_writable {
-            h |= 0x01 << 16;
+            h |= Self::WRITABLE_BIT;
         }
         if self.is_executable {
-            h |= 0x01 << 24;
+            h |= Self::EXECUTABLE_BIT;
         }
         h
     }
@@ -187,15 +201,15 @@ impl FieldFlags {
     /// actually requires. Extra permissions are masked out so they don't
     /// cause a rejection.
     pub fn required_mask(&self) -> u32 {
-        let mut mask: u32 = 0xFF; // always check borrow_state
+        let mut mask: u32 = Self::BORROW_STATE_BYTE;
         if self.is_signer {
-            mask |= 0xFF << 8;
+            mask |= Self::SIGNER_MASK;
         }
         if self.is_writable {
-            mask |= 0xFF << 16;
+            mask |= Self::WRITABLE_MASK;
         }
         if self.is_executable {
-            mask |= 0xFF << 24;
+            mask |= Self::EXECUTABLE_MASK;
         }
         mask
     }
@@ -203,7 +217,7 @@ impl FieldFlags {
     /// Flag-only mask (excludes borrow_state byte).
     /// Used in the dup-aware path where borrow_state is already validated.
     pub fn required_flag_mask(&self) -> u32 {
-        self.required_mask() & 0xFFFFFF00
+        self.required_mask() & Self::FLAG_ONLY_MASK
     }
 }
 

--- a/derive/src/accounts/fields_process.rs
+++ b/derive/src/accounts/fields_process.rs
@@ -111,15 +111,16 @@ fn gen_bump_check(
                         {
                             #(#seed_len_checks)*
                             if let Some(__offset) = <#inner_ty as Discriminator>::BUMP_OFFSET {
-                                if quasar_lang::utils::hint::unlikely(__offset >= #view_access.data_len()) {
+                                let __bump_val: u8 = quasar_lang::pda::read_bump_from_account(
+                                    #view_access, __offset,
+                                ).map_err(|__e| {
                                     #[cfg(feature = "debug")]
                                     quasar_lang::prelude::log(concat!(
                                         "BUMP_OFFSET out of bounds for account '",
                                         stringify!(#field_name), "'"
                                     ));
-                                    return Err(ProgramError::AccountDataTooSmall);
-                                }
-                                let __bump_val: u8 = unsafe { *#view_access.data_ptr().add(__offset) };
+                                    __e
+                                })?;
                                 let __bump_ref: &[u8] = &[__bump_val];
                                 let __pda_seeds = [#(#seed_idents,)* __bump_ref];
                                 quasar_lang::pda::verify_program_address(&__pda_seeds, __program_id, &#addr_access)
@@ -599,14 +600,20 @@ pub(crate) fn process_fields(
                 None => quote! { QuasarError::HasOneMismatch.into() },
             };
             let target_str = target.to_string();
-            this_field_checks.push(debug_guard(
-                quote! { !quasar_lang::keys_eq(&#field_name.#target, #target.to_account_view().address()) },
-                quote! { ::alloc::format!(
-                    "has_one mismatch: '{}.{}' does not match account '{}'",
-                    #field_name_str, #target_str, #target_str,
-                ) },
-                quote! { #error },
-            ));
+            this_field_checks.push(quote! {
+                quasar_lang::validation::check_has_one(
+                    &#field_name.#target,
+                    #target.to_account_view().address(),
+                    #error,
+                ).map_err(|__e| {
+                    #[cfg(feature = "debug")]
+                    quasar_lang::prelude::log(&::alloc::format!(
+                        "has_one mismatch: '{}.{}' does not match account '{}'",
+                        #field_name_str, #target_str, #target_str,
+                    ));
+                    __e
+                })?;
+            });
         }
 
         for (expr, custom_error) in &attrs.constraints {
@@ -630,15 +637,21 @@ pub(crate) fn process_fields(
                 Some(err) => quote! { #err.into() },
                 None => quote! { QuasarError::AddressMismatch.into() },
             };
-            this_field_checks.push(debug_guard(
-                quote! { !quasar_lang::keys_eq(#field_name.to_account_view().address(), &#addr_expr) },
-                quote! { ::alloc::format!(
-                    "Address mismatch on '{}': got {}",
-                    #field_name_str,
+            this_field_checks.push(quote! {
+                quasar_lang::validation::check_address_match(
                     #field_name.to_account_view().address(),
-                ) },
-                quote! { #error },
-            ));
+                    &#addr_expr,
+                    #error,
+                ).map_err(|__e| {
+                    #[cfg(feature = "debug")]
+                    quasar_lang::prelude::log(&::alloc::format!(
+                        "Address mismatch on '{}': got {}",
+                        #field_name_str,
+                        #field_name.to_account_view().address(),
+                    ));
+                    __e
+                })?;
+            });
         }
 
         if let Some(dest) = &attrs.close {

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -40,7 +40,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 "#[derive(Accounts)] only supports lifetime parameters; const parameters are not \
                  supported"
             }
-            GenericParam::Lifetime(_) => unreachable!("filtered above"),
+            // Filtered by the `find` predicate above — lifetimes are skipped.
+            GenericParam::Lifetime(_) => "",
         };
         return syn::Error::new_spanned(param, message)
             .to_compile_error()

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -665,14 +665,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     // --- Final output ---
 
     let exact_len_guard = quote! {
-        let __account_count = accounts.len();
-        if quasar_lang::utils::hint::unlikely(__account_count != Self::COUNT) {
-            return Err(if __account_count < Self::COUNT {
-                ProgramError::NotEnoughAccountKeys
-            } else {
-                ProgramError::InvalidArgument
-            });
-        }
+        quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
     };
 
     let parse_accounts_impl = if has_instruction_args {

--- a/derive/src/declare_program.rs
+++ b/derive/src/declare_program.rs
@@ -288,19 +288,31 @@ pub fn declare_program(input: TokenStream) -> TokenStream {
             })
             .collect();
 
-        let arg_params: Vec<TokenStream2> = ix
+        let arg_params: Vec<TokenStream2> = match ix
             .args
             .iter()
             .map(|a| {
-                let info = map_idl_type(&a.ty).expect("failed to map IDL type to Rust type");
+                let info = map_idl_type(&a.ty).map_err(|msg| {
+                    syn::Error::new(Span::call_site(), format!("in instruction '{}', arg '{}': {}", ix.name, a.name, msg))
+                })?;
                 let name = Ident::new(&pascal_to_snake(&a.name), Span::call_site());
                 let ty = &info.rust_type;
-                quote! { #name: #ty }
+                Ok(quote! { #name: #ty })
             })
-            .collect();
+            .collect::<Result<Vec<_>, syn::Error>>()
+        {
+            Ok(v) => v,
+            Err(e) => return e.to_compile_error().into(),
+        };
 
-        let (data_write, data_size) = generate_data_write(&ix.args, &ix.discriminator)
-            .expect("failed to generate instruction data write code");
+        let (data_write, data_size) = match generate_data_write(&ix.args, &ix.discriminator) {
+            Ok(v) => v,
+            Err(msg) => {
+                return syn::Error::new(Span::call_site(), msg)
+                    .to_compile_error()
+                    .into()
+            }
+        };
 
         // Free function: accounts as &'a AccountView
         let free_acct_params: Vec<TokenStream2> = acct_idents

--- a/derive/src/declare_program.rs
+++ b/derive/src/declare_program.rs
@@ -293,7 +293,10 @@ pub fn declare_program(input: TokenStream) -> TokenStream {
             .iter()
             .map(|a| {
                 let info = map_idl_type(&a.ty).map_err(|msg| {
-                    syn::Error::new(Span::call_site(), format!("in instruction '{}', arg '{}': {}", ix.name, a.name, msg))
+                    syn::Error::new(
+                        Span::call_site(),
+                        format!("in instruction '{}', arg '{}': {}", ix.name, a.name, msg),
+                    )
                 })?;
                 let name = Ident::new(&pascal_to_snake(&a.name), Span::call_site());
                 let ty = &info.rust_type;

--- a/derive/src/error_code.rs
+++ b/derive/src/error_code.rs
@@ -52,7 +52,17 @@ pub(crate) fn error_code(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
         let value = next_discriminant;
-        next_discriminant += 1;
+        next_discriminant = match next_discriminant.checked_add(1) {
+            Some(n) => n,
+            None => {
+                return syn::Error::new_spanned(
+                    &v.ident,
+                    "error code overflow: discriminant exceeds u32::MAX",
+                )
+                .to_compile_error()
+                .into();
+            }
+        };
         match_arms.push(quote! { #value => Ok(#name::#ident) });
     }
 

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -543,9 +543,17 @@ pub(crate) fn strip_generics(ty: &Type) -> proc_macro2::TokenStream {
 /// Converts `PascalCase` to `snake_case` (e.g., `MakeEscrow` → `make_escrow`).
 pub(crate) fn pascal_to_snake(s: &str) -> String {
     let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
         if c.is_uppercase() && i > 0 {
-            result.push('_');
+            // Only insert underscore before an uppercase letter when the
+            // previous char is lowercase, OR the next char is lowercase
+            // (handles acronym runs like "HTTP" → "http" not "h_t_t_p").
+            let prev_lower = chars[i - 1].is_lowercase();
+            let next_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+            if prev_lower || next_lower {
+                result.push('_');
+            }
         }
         result.push(c.to_lowercase().next().unwrap());
     }

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -550,7 +550,7 @@ pub(crate) fn pascal_to_snake(s: &str) -> String {
             // previous char is lowercase, OR the next char is lowercase
             // (handles acronym runs like "HTTP" → "http" not "h_t_t_p").
             let prev_lower = chars[i - 1].is_lowercase();
-            let next_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+            let next_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
             if prev_lower || next_lower {
                 result.push('_');
             }

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -611,7 +611,9 @@ fn parse_prefix_type(ty: &Type) -> Option<PrefixType> {
 pub(crate) fn classify_dynamic_string(ty: &Type) -> Option<(PrefixType, usize)> {
     if let Type::Path(type_path) = ty {
         if let Some(seg) = type_path.path.segments.last() {
-            if seg.ident == "String" {
+            // Only match unqualified `String` (the Quasar import), not
+            // `std::string::String` or `my_crate::String`.
+            if seg.ident == "String" && type_path.path.segments.len() == 1 {
                 return match &seg.arguments {
                     PathArguments::None => Some((PrefixType::U32, 1024)),
                     PathArguments::AngleBracketed(args) => {
@@ -655,7 +657,7 @@ pub(crate) fn classify_dynamic_string(ty: &Type) -> Option<(PrefixType, usize)> 
 pub(crate) fn classify_dynamic_vec(ty: &Type) -> Option<(Type, PrefixType, usize)> {
     if let Type::Path(type_path) = ty {
         if let Some(seg) = type_path.path.segments.last() {
-            if seg.ident == "Vec" {
+            if seg.ident == "Vec" && type_path.path.segments.len() == 1 {
                 if let PathArguments::AngleBracketed(args) = &seg.arguments {
                     let mut iter = args.args.iter();
                     let first = iter.next()?;

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -27,6 +27,23 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let disc_len = disc_bytes.len();
 
+    // Reject multi-byte all-zero discriminators — zeroed instruction data could
+    // accidentally match. Single-byte discriminators are fine (the dispatch
+    // macro's length check rejects empty instruction data).
+    if disc_len > 1
+        && disc_bytes
+            .iter()
+            .all(|lit| matches!(lit.base10_parse::<u8>(), Ok(0)))
+    {
+        return syn::Error::new_spanned(
+            &disc_bytes[0],
+            "instruction discriminator must contain at least one non-zero byte; \
+             all-zero multi-byte discriminators are dangerous because zeroed instruction data would match",
+        )
+        .to_compile_error()
+        .into();
+    }
+
     let first_arg = match func.sig.inputs.first() {
         Some(FnArg::Typed(pt)) => pt.clone(),
         _ => {

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -37,8 +37,8 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
     {
         return syn::Error::new_spanned(
             &disc_bytes[0],
-            "instruction discriminator must contain at least one non-zero byte; \
-             all-zero multi-byte discriminators are dangerous because zeroed instruction data would match",
+            "instruction discriminator must contain at least one non-zero byte; all-zero \
+             multi-byte discriminators are dangerous because zeroed instruction data would match",
         )
         .to_compile_error()
         .into();
@@ -272,14 +272,20 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                         dyn_idx += 1;
                         let pb = prefix.bytes();
                         let max_lit = *max;
-                        new_stmts.push(syn::parse_quote!(
-                            let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_str::<#pb>(
-                                __data, __offset, #max_lit,
-                            )?;
-                        ));
                         if dyn_idx < dyn_count {
                             new_stmts.push(syn::parse_quote!(
+                                let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_str::<#pb>(
+                                    __data, __offset, #max_lit,
+                                )?;
+                            ));
+                            new_stmts.push(syn::parse_quote!(
                                 __offset = __new_offset;
+                            ));
+                        } else {
+                            new_stmts.push(syn::parse_quote!(
+                                let (#name, _) = quasar_lang::instruction_data::read_dynamic_str::<#pb>(
+                                    __data, __offset, #max_lit,
+                                )?;
                             ));
                         }
                     }
@@ -302,14 +308,20 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                         dyn_idx += 1;
                         let pb = prefix.bytes();
                         let max_lit = *max;
-                        new_stmts.push(syn::parse_quote!(
-                            let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_vec::<#elem, #pb>(
-                                __data, __offset, #max_lit,
-                            )?;
-                        ));
                         if dyn_idx < dyn_count {
                             new_stmts.push(syn::parse_quote!(
+                                let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_vec::<#elem, #pb>(
+                                    __data, __offset, #max_lit,
+                                )?;
+                            ));
+                            new_stmts.push(syn::parse_quote!(
                                 __offset = __new_offset;
+                            ));
+                        } else {
+                            new_stmts.push(syn::parse_quote!(
+                                let (#name, _) = quasar_lang::instruction_data::read_dynamic_vec::<#elem, #pb>(
+                                    __data, __offset, #max_lit,
+                                )?;
                             ));
                         }
                     }

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -272,107 +272,44 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                         dyn_idx += 1;
                         let pb = prefix.bytes();
                         let max_lit = *max;
-                        let read_len = prefix.gen_read_len();
                         new_stmts.push(syn::parse_quote!(
-                            if __data.len() < __offset + #pb {
-                                return Err(ProgramError::InvalidInstructionData);
-                            }
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            let __dyn_len = #read_len;
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            __offset += #pb;
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            if __dyn_len > #max_lit {
-                                return Err(ProgramError::InvalidInstructionData);
-                            }
-                        ));
-                        new_stmts.push(syn::parse_quote!(if __data.len() < __offset + __dyn_len {
-                            return Err(ProgramError::InvalidInstructionData);
-                        }));
-                        new_stmts.push(syn::parse_quote!(
-                            let #name: &str = {
-                                let __bytes = &__data[__offset..__offset + __dyn_len];
-                                match core::str::from_utf8(__bytes) {
-                                    Ok(__s) => __s,
-                                    Err(_) => return Err(ProgramError::InvalidInstructionData),
-                                }
-                            };
+                            let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_str::<#pb>(
+                                __data, __offset, #max_lit,
+                            )?;
                         ));
                         if dyn_idx < dyn_count {
                             new_stmts.push(syn::parse_quote!(
-                                __offset += __dyn_len;
+                                __offset = __new_offset;
                             ));
                         }
                     }
                     DynKind::Tail { element } => {
                         dyn_idx += 1;
-                        // Tail field: remaining data, no prefix
                         match element {
                             TailElement::Str => {
                                 new_stmts.push(syn::parse_quote!(
-                                    let #name: &str = {
-                                        let __bytes = &__data[__offset..];
-                                        match core::str::from_utf8(__bytes) {
-                                            Ok(__s) => __s,
-                                            Err(_) => return Err(ProgramError::InvalidInstructionData),
-                                        }
-                                    };
+                                    let #name: &str = quasar_lang::instruction_data::read_tail_str(__data, __offset)?;
                                 ));
                             }
                             TailElement::Bytes => {
                                 new_stmts.push(syn::parse_quote!(
-                                    let #name: &[u8] = &__data[__offset..];
+                                    let #name: &[u8] = quasar_lang::instruction_data::read_tail_bytes(__data, __offset);
                                 ));
                             }
                         }
-                        // Tail consumes all remaining data — no offset advance
-                        // needed
                     }
                     DynKind::Vec { elem, prefix, max } => {
                         dyn_idx += 1;
                         let pb = prefix.bytes();
                         let max_lit = *max;
-                        let read_len = prefix.gen_read_len();
                         new_stmts.push(syn::parse_quote!(
-                            if __data.len() < __offset + #pb {
-                                return Err(ProgramError::InvalidInstructionData);
-                            }
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            let __dyn_count = #read_len;
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            __offset += #pb;
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            if __dyn_count > #max_lit {
-                                return Err(ProgramError::InvalidInstructionData);
-                            }
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            let __dyn_byte_len = __dyn_count
-                                .checked_mul(core::mem::size_of::<#elem>())
-                                .ok_or(ProgramError::InvalidInstructionData)?;
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            if __data.len() < __offset + __dyn_byte_len {
-                                return Err(ProgramError::InvalidInstructionData);
-                            }
-                        ));
-                        new_stmts.push(syn::parse_quote!(
-                            let #name: &[#elem] = unsafe {
-                                core::slice::from_raw_parts(
-                                    __data.as_ptr().add(__offset) as *const #elem,
-                                    __dyn_count,
-                                )
-                            };
+                            let (#name, __new_offset) = quasar_lang::instruction_data::read_dynamic_vec::<#elem, #pb>(
+                                __data, __offset, #max_lit,
+                            )?;
                         ));
                         if dyn_idx < dyn_count {
                             new_stmts.push(syn::parse_quote!(
-                                __offset += __dyn_byte_len;
+                                __offset = __new_offset;
                             ));
                         }
                     }

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -247,9 +247,7 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 if unsafe { *(ptr as *const u64) } == 0 {
                     return Err(ProgramError::NotEnoughAccountKeys);
                 }
-                // SAFETY: Pointer arithmetic follows the SVM input buffer layout. The u64 casts
-                // for address comparison are technically misaligned (Address is align 1), but SBF
-                // handles unaligned access natively — this 4x u64 compare saves ~20 CU vs memcmp.
+                // SAFETY: Pointer arithmetic follows the SVM input buffer layout.
                 unsafe {
                     let raw = ptr.add(core::mem::size_of::<u64>()) as *const quasar_lang::__internal::RuntimeAccount;
 
@@ -257,13 +255,10 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         return Err(ProgramError::MissingRequiredSignature);
                     }
 
-                    let addr = &(*raw).address as *const _ as *const u64;
-                    let expected = super::EventAuthority::ADDRESS.as_ref().as_ptr() as *const u64;
-                    if *addr != *expected
-                        || *addr.add(1) != *expected.add(1)
-                        || *addr.add(2) != *expected.add(2)
-                        || *addr.add(3) != *expected.add(3)
-                    {
+                    if !quasar_lang::keys_eq(
+                        &(*raw).address,
+                        &super::EventAuthority::ADDRESS,
+                    ) {
                         return Err(ProgramError::InvalidSeeds);
                     }
                 }

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -243,11 +243,14 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
         items.push(syn::parse_quote! {
             #[inline(always)]
             fn __handle_event(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
-                quasar_lang::event::handle_event(
-                    ptr,
-                    instruction_data,
-                    &super::EventAuthority::ADDRESS,
-                )
+                // SAFETY: `ptr` is the SVM input buffer from the entrypoint.
+                unsafe {
+                    quasar_lang::event::handle_event(
+                        ptr,
+                        instruction_data,
+                        &super::EventAuthority::ADDRESS,
+                    )
+                }
             }
         });
 

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -243,32 +243,11 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
         items.push(syn::parse_quote! {
             #[inline(always)]
             fn __handle_event(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
-                // SAFETY: The SVM places the account count (u64) at offset 0.
-                if unsafe { *(ptr as *const u64) } == 0 {
-                    return Err(ProgramError::NotEnoughAccountKeys);
-                }
-                // SAFETY: Pointer arithmetic follows the SVM input buffer layout.
-                unsafe {
-                    let raw = ptr.add(core::mem::size_of::<u64>()) as *const quasar_lang::__internal::RuntimeAccount;
-
-                    if (*raw).is_signer == 0 {
-                        return Err(ProgramError::MissingRequiredSignature);
-                    }
-
-                    if !quasar_lang::keys_eq(
-                        &(*raw).address,
-                        &super::EventAuthority::ADDRESS,
-                    ) {
-                        return Err(ProgramError::InvalidSeeds);
-                    }
-                }
-
-                if instruction_data.len() <= 1 {
-                    return Err(ProgramError::InvalidInstructionData);
-                }
-
-                quasar_lang::log::log_data(&[&instruction_data[1..]]);
-                Ok(())
+                quasar_lang::event::handle_event(
+                    ptr,
+                    instruction_data,
+                    &super::EventAuthority::ADDRESS,
+                )
             }
         });
 

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -410,11 +410,23 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
             }
             _ => format!("\tdata = append(data, input.{}...)\n", name),
         },
-        IdlType::DynString { .. } => format!(
-            "\t{{ b := []byte(input.{n}); var buf [4]byte; binary.LittleEndian.PutUint32(buf[:], \
-             uint32(len(b))); data = append(data, buf[:]...); data = append(data, b...) }}\n",
-            n = name,
-        ),
+        IdlType::DynString { ref string } => match string.prefix_bytes {
+            1 => format!(
+                "\tdata = append(data, byte(len([]byte(input.{n}))))\n\tdata = append(data, \
+                 []byte(input.{n})...)\n",
+                n = name,
+            ),
+            2 => format!(
+                "\t{{ b := []byte(input.{n}); var buf [2]byte; binary.LittleEndian.PutUint16(buf[:], \
+                 uint16(len(b))); data = append(data, buf[:]...); data = append(data, b...) }}\n",
+                n = name,
+            ),
+            _ => format!(
+                "\t{{ b := []byte(input.{n}); var buf [4]byte; binary.LittleEndian.PutUint32(buf[:], \
+                 uint32(len(b))); data = append(data, buf[:]...); data = append(data, b...) }}\n",
+                n = name,
+            ),
+        },
         IdlType::Defined { defined } => {
             if let Some(td) = types.iter().find(|t| t.name == *defined) {
                 let mut result = String::new();
@@ -510,14 +522,12 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 n = name,
             ),
             "f32" => format!(
-                "{t}{n} := math.Float32frombits(binary.LittleEndian.Uint32(data[offset:]))\\
-                 n{t}offset += 4\n",
+                "{t}{n} := math.Float32frombits(binary.LittleEndian.Uint32(data[offset:]))\n{t}offset += 4\n",
                 t = t,
                 n = name,
             ),
             "f64" => format!(
-                "{t}{n} := math.Float64frombits(binary.LittleEndian.Uint64(data[offset:]))\\
-                 n{t}offset += 8\n",
+                "{t}{n} := math.Float64frombits(binary.LittleEndian.Uint64(data[offset:]))\n{t}offset += 8\n",
                 t = t,
                 n = name,
             ),
@@ -543,12 +553,26 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 n = name,
             ),
         },
-        IdlType::DynString { .. } => format!(
-            "{t}{n}Len := binary.LittleEndian.Uint32(data[offset:])\n{t}offset += 4\n{t}{n} := \
-             string(data[offset:offset+int({n}Len)])\n{t}offset += int({n}Len)\n",
-            t = t,
-            n = name,
-        ),
+        IdlType::DynString { ref string } => match string.prefix_bytes {
+            1 => format!(
+                "{t}{n}Len := int(data[offset])\n{t}offset += 1\n{t}{n} := \
+                 string(data[offset:offset+{n}Len])\n{t}offset += {n}Len\n",
+                t = t,
+                n = name,
+            ),
+            2 => format!(
+                "{t}{n}Len := int(binary.LittleEndian.Uint16(data[offset:]))\n{t}offset += \
+                 2\n{t}{n} := string(data[offset:offset+{n}Len])\n{t}offset += {n}Len\n",
+                t = t,
+                n = name,
+            ),
+            _ => format!(
+                "{t}{n}Len := int(binary.LittleEndian.Uint32(data[offset:]))\n{t}offset += \
+                 4\n{t}{n} := string(data[offset:offset+{n}Len])\n{t}offset += {n}Len\n",
+                t = t,
+                n = name,
+            ),
+        },
         IdlType::Defined { defined } => {
             if let Some(td) = types.iter().find(|t| t.name == *defined) {
                 let mut result = String::new();

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -417,13 +417,15 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
                 n = name,
             ),
             2 => format!(
-                "\t{{ b := []byte(input.{n}); var buf [2]byte; binary.LittleEndian.PutUint16(buf[:], \
-                 uint16(len(b))); data = append(data, buf[:]...); data = append(data, b...) }}\n",
+                "\t{{ b := []byte(input.{n}); var buf [2]byte; \
+                 binary.LittleEndian.PutUint16(buf[:], uint16(len(b))); data = append(data, \
+                 buf[:]...); data = append(data, b...) }}\n",
                 n = name,
             ),
             _ => format!(
-                "\t{{ b := []byte(input.{n}); var buf [4]byte; binary.LittleEndian.PutUint32(buf[:], \
-                 uint32(len(b))); data = append(data, buf[:]...); data = append(data, b...) }}\n",
+                "\t{{ b := []byte(input.{n}); var buf [4]byte; \
+                 binary.LittleEndian.PutUint32(buf[:], uint32(len(b))); data = append(data, \
+                 buf[:]...); data = append(data, b...) }}\n",
                 n = name,
             ),
         },
@@ -465,6 +467,15 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
             format!("\tdata = append(data, input.{}...)\n", name,)
         }
     }
+}
+
+/// Go float decode expression. Extracted to prevent rustfmt from splitting
+/// the `\n` in the format string across a line continuation.
+fn go_float_decode(t: &str, n: &str, math_fn: &str, le_fn: &str, size: usize) -> String {
+    format!(
+        "{t}{n} := math.{math_fn}(binary.LittleEndian.{le_fn}(data[offset:]))\n{t}offset += \
+         {size}\n"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -521,16 +532,8 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 t = t,
                 n = name,
             ),
-            "f32" => format!(
-                "{t}{n} := math.Float32frombits(binary.LittleEndian.Uint32(data[offset:]))\n{t}offset += 4\n",
-                t = t,
-                n = name,
-            ),
-            "f64" => format!(
-                "{t}{n} := math.Float64frombits(binary.LittleEndian.Uint64(data[offset:]))\n{t}offset += 8\n",
-                t = t,
-                n = name,
-            ),
+            "f32" => go_float_decode(&t, name, "Float32frombits", "Uint32", 4),
+            "f64" => go_float_decode(&t, name, "Float64frombits", "Uint64", 8),
             "publicKey" => format!(
                 "{t}var {n} solana.PublicKey\n{t}copy({n}[:], data[offset:offset+32])\n{t}offset \
                  += 32\n",

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -1412,9 +1412,14 @@ fn snake_to_pascal(s: &str) -> String {
 /// Convert PascalCase to snake_case.
 fn pascal_to_snake(s: &str) -> String {
     let mut result = String::with_capacity(s.len() + 4);
-    for (i, c) in s.chars().enumerate() {
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
         if c.is_uppercase() && i > 0 {
-            result.push('_');
+            let prev_lower = chars[i - 1].is_lowercase();
+            let next_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+            if prev_lower || next_lower {
+                result.push('_');
+            }
         }
         result.push(c.to_ascii_lowercase());
     }

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -1416,7 +1416,7 @@ fn pascal_to_snake(s: &str) -> String {
     for (i, &c) in chars.iter().enumerate() {
         if c.is_uppercase() && i > 0 {
             let prev_lower = chars[i - 1].is_lowercase();
-            let next_lower = chars.get(i + 1).map_or(false, |n| n.is_lowercase());
+            let next_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
             if prev_lower || next_lower {
                 result.push('_');
             }

--- a/idl/src/parser/mod.rs
+++ b/idl/src/parser/mod.rs
@@ -112,10 +112,27 @@ pub fn parse_program(crate_root: &Path) -> ParsedProgram {
 }
 
 /// Build the final `Idl` from parsed program data.
-pub fn build_idl(parsed: ParsedProgram) -> Idl {
-    // Check for discriminator collisions across instructions, accounts, and events
-    check_discriminator_collisions(&parsed);
-    check_instruction_input_name_collision(&parsed);
+///
+/// Returns an error if discriminator collisions or input name collisions are
+/// detected.
+pub fn build_idl(parsed: ParsedProgram) -> Result<Idl, Vec<String>> {
+    let mut errors = Vec::new();
+
+    let collisions = find_discriminator_collisions(&parsed);
+    if !collisions.is_empty() {
+        errors.push("discriminator collisions detected:".to_string());
+        errors.extend(collisions);
+    }
+
+    let name_issues = find_instruction_input_name_collisions(&parsed);
+    if !name_issues.is_empty() {
+        errors.push("duplicate instruction input field names detected:".to_string());
+        errors.extend(name_issues);
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
 
     let ParsedProgram {
         program_id,
@@ -126,7 +143,7 @@ pub fn build_idl(parsed: ParsedProgram) -> Idl {
         accounts_structs,
         state_accounts,
         events: raw_events,
-        errors,
+        errors: parsed_errors,
         data_structs,
     } = parsed;
 
@@ -266,7 +283,7 @@ pub fn build_idl(parsed: ParsedProgram) -> Idl {
         }
     }
 
-    Idl {
+    Ok(Idl {
         address: program_id,
         metadata: IdlMetadata {
             name: program_name,
@@ -278,11 +295,11 @@ pub fn build_idl(parsed: ParsedProgram) -> Idl {
         accounts: account_defs,
         events: event_defs,
         types: type_defs,
-        errors,
-    }
+        errors: parsed_errors,
+    })
 }
 
-fn check_instruction_input_name_collision(parsed: &ParsedProgram) {
+fn find_instruction_input_name_collisions(parsed: &ParsedProgram) -> Vec<String> {
     let mut issues = Vec::new();
 
     for ix in &parsed.instructions {
@@ -324,13 +341,7 @@ fn check_instruction_input_name_collision(parsed: &ParsedProgram) {
         }
     }
 
-    if !issues.is_empty() {
-        eprintln!("Error: duplicate instruction input field names detected:");
-        for issue in &issues {
-            eprintln!("{}", issue);
-        }
-        std::process::exit(1);
-    }
+    issues
 }
 
 /// Check for discriminator collisions across all instruction, account, and
@@ -396,17 +407,6 @@ pub fn find_discriminator_collisions(parsed: &ParsedProgram) -> Vec<String> {
     }
 
     collisions
-}
-
-fn check_discriminator_collisions(parsed: &ParsedProgram) {
-    let collisions = find_discriminator_collisions(parsed);
-    if !collisions.is_empty() {
-        eprintln!("Error: discriminator collisions detected:");
-        for c in &collisions {
-            eprintln!("{}", c);
-        }
-        std::process::exit(1);
-    }
 }
 
 fn collect_defined_refs(ty: &IdlType, out: &mut BTreeSet<String>) {

--- a/idl/src/parser/module_resolver.rs
+++ b/idl/src/parser/module_resolver.rs
@@ -91,10 +91,15 @@ fn resolve_file(path: &Path, files: &mut Vec<ResolvedFile>) {
 fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
         if attr.path().is_ident("cfg") {
-            let tokens = attr.meta.require_list().ok().map(|l| l.tokens.to_string());
-            if let Some(t) = tokens {
-                if t.contains("test") {
-                    return true;
+            // Parse the cfg predicate properly instead of string matching.
+            // We check for exactly `cfg(test)` to avoid false positives on
+            // attributes like `cfg(feature = "testing")` or `cfg(test_utils)`.
+            if let Ok(list) = attr.meta.require_list() {
+                let inner: Result<syn::Ident, _> = syn::parse2(list.tokens.clone());
+                if let Ok(ident) = inner {
+                    if ident == "test" {
+                        return true;
+                    }
                 }
             }
         }

--- a/idl/src/parser/state.rs
+++ b/idl/src/parser/state.rs
@@ -162,7 +162,6 @@ fn type_to_string(ty: &syn::Type) -> String {
             result.push(c);
         }
     }
-    let _ = result.trim_end().to_string();
     result.trim().to_string()
 }
 

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -311,7 +311,7 @@ fn no_collision_different_kinds() {
         data_structs: vec![],
     };
     // Should not panic
-    let idl = quasar_idl::parser::build_idl(parsed);
+    let idl = quasar_idl::parser::build_idl(parsed).unwrap();
     assert_eq!(idl.instructions.len(), 1);
     assert_eq!(idl.accounts.len(), 1);
 }
@@ -371,7 +371,7 @@ fn build_idl_full_pipeline() {
         data_structs: vec![],
     };
 
-    let idl = quasar_idl::parser::build_idl(parsed);
+    let idl = quasar_idl::parser::build_idl(parsed).unwrap();
 
     // Verify structure
     assert_eq!(idl.address, "ABcDeFgH111111111111111111111111111111111111");
@@ -1537,7 +1537,7 @@ fn ts_codegen_remaining_accounts() {
         has_remaining: true,
     });
 
-    let idl = build_idl(parsed);
+    let idl = build_idl(parsed).unwrap();
     let code = generate_ts_client_kit(&idl);
 
     assert!(code.contains("remainingAccounts?"), "{code}");
@@ -1575,7 +1575,7 @@ fn ts_codegen_prefix_aware_codecs() {
     let (_, instructions) = program::extract_program_module(&file).unwrap();
     let mut parsed = test_program();
     parsed.instructions = instructions;
-    let idl = build_idl(parsed);
+    let idl = build_idl(parsed).unwrap();
     let code = generate_ts_client_kit(&idl);
 
     // String<u8, 100> → u8 prefix codec
@@ -1631,7 +1631,7 @@ fn idl_json_has_remaining() {
         has_remaining: false,
     });
 
-    let idl = build_idl(parsed);
+    let idl = build_idl(parsed).unwrap();
     let json = serde_json::to_string_pretty(&idl).unwrap();
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -1676,7 +1676,7 @@ fn idl_json_prefix_bytes_serialization() {
     let (_, instructions) = program::extract_program_module(&file).unwrap();
     let mut parsed = test_program();
     parsed.instructions = instructions;
-    let idl = build_idl(parsed);
+    let idl = build_idl(parsed).unwrap();
     let json = serde_json::to_string_pretty(&idl).unwrap();
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -40,7 +40,10 @@ pub fn resize(view: &mut AccountView, new_len: usize) -> Result<(), ProgramError
     let raw = view.account_mut_ptr();
 
     // SAFETY: `raw` is a valid `RuntimeAccount` pointer from `AccountView`.
-    let current_len = unsafe { (*raw).data_len } as i32;
+    // `data_len` is always within i32 range on Solana (max 10 MiB) — try_from
+    // is defense-in-depth against future SVM changes.
+    let current_len =
+        i32::try_from(unsafe { (*raw).data_len }).map_err(|_| ProgramError::InvalidRealloc)?;
     let new_len_i32 = i32::try_from(new_len).map_err(|_| ProgramError::InvalidRealloc)?;
 
     if new_len_i32 == current_len {

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -126,15 +126,25 @@ impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + Account
     #[inline(always)]
     pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
-        // Save slice metadata before parse consumes the &mut borrow.
-        // The declared `AccountView`s are copied by value during parsing, so the
-        // backing slice header stays valid for read-only duplicate resolution
-        // after `parse_with_instruction_data_unchecked` returns.
+        // Save raw pointer + length before parse consumes the &mut borrow.
+        // We intentionally keep these as raw pointers — reconstructing an
+        // &[AccountView] would create a shared reference that aliases the
+        // &mut AccountView references held by the parsed struct (fragile
+        // under Stacked Borrows). The RemainingIter uses only raw pointer
+        // reads for duplicate resolution, so a slice reference is unnecessary.
         let declared_ptr = ctx.accounts.as_ptr();
         let declared_len = ctx.accounts.len();
         let (accounts, bumps) = unsafe {
             T::parse_with_instruction_data_unchecked(ctx.accounts, ctx.data, program_id_addr)?
         };
+        // SAFETY: The backing memory is still valid — parse copies AccountView
+        // values out of the slice, it does not deallocate. We construct the
+        // shared slice here only for the RemainingAccounts API which uses it
+        // for read-only address comparisons via keys_eq. The parsed struct
+        // holds &mut refs into the pointed-to RuntimeAccount data (through
+        // the raw pointers inside each AccountView), not into the AccountView
+        // slice itself, so under Tree Borrows the shared slice's "Frozen"
+        // permission on the AccountView pointer fields does not conflict.
         let declared = unsafe { core::slice::from_raw_parts(declared_ptr, declared_len) };
         Ok(Self {
             accounts,

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -273,12 +273,7 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> DynCpiCall<'a, MAX_ACCTS
 mod tests {
     extern crate std;
 
-    use {
-        super::*,
-        crate::cpi::tests::AccountBuffer,
-        solana_account_view::{RuntimeAccount, MAX_PERMITTED_DATA_INCREASE, NOT_BORROWED},
-        solana_address::Address,
-    };
+    use {super::*, crate::cpi::tests::AccountBuffer, solana_address::Address};
 
     static PROGRAM_ID: Address = Address::new_from_array([0x11; 32]);
 

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -275,11 +275,10 @@ mod tests {
 
     use {
         super::*,
+        crate::cpi::tests::AccountBuffer,
         solana_account_view::{RuntimeAccount, MAX_PERMITTED_DATA_INCREASE, NOT_BORROWED},
         solana_address::Address,
     };
-
-    use crate::cpi::tests::AccountBuffer;
 
     static PROGRAM_ID: Address = Address::new_from_array([0x11; 32]);
 

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -172,36 +172,42 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> DynCpiCall<'a, MAX_ACCTS
 
     /// Invoke the CPI without any PDA signers.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_inner(&[])
     }
 
     /// Invoke the CPI with a single PDA signer (seeds for one address).
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_signed(&self, seeds: &[Seed]) -> ProgramResult {
         self.invoke_inner(&[Signer::from(seeds)])
     }
 
     /// Invoke the CPI with multiple PDA signers.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_signers(&self, signers: &[Signer]) -> ProgramResult {
         self.invoke_inner(signers)
     }
 
     /// Invoke the CPI and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_return(&self) -> Result<CpiReturn, ProgramError> {
         self.invoke_with_return_inner(&[])
     }
 
     /// Invoke the CPI with one PDA signer and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_signed_with_return(&self, seeds: &[Seed]) -> Result<CpiReturn, ProgramError> {
         self.invoke_with_return_inner(&[Signer::from(seeds)])
     }
 
     /// Invoke the CPI with multiple PDA signers and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_signers_with_return(
         &self,
         signers: &[Signer],

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -279,50 +279,7 @@ mod tests {
         solana_address::Address,
     };
 
-    struct AccountBuffer {
-        inner: std::vec::Vec<u64>,
-    }
-
-    impl AccountBuffer {
-        fn new(data_len: usize) -> Self {
-            let byte_len =
-                core::mem::size_of::<RuntimeAccount>() + data_len + MAX_PERMITTED_DATA_INCREASE;
-            Self {
-                inner: (0..byte_len.div_ceil(8)).map(|_| 0u64).collect(),
-            }
-        }
-
-        fn raw(&mut self) -> *mut RuntimeAccount {
-            self.inner.as_mut_ptr() as *mut RuntimeAccount
-        }
-
-        fn init(
-            &mut self,
-            address: [u8; 32],
-            owner: [u8; 32],
-            data_len: usize,
-            is_signer: bool,
-            is_writable: bool,
-            executable: bool,
-        ) {
-            let raw = self.raw();
-            unsafe {
-                (*raw).borrow_state = NOT_BORROWED;
-                (*raw).is_signer = is_signer as u8;
-                (*raw).is_writable = is_writable as u8;
-                (*raw).executable = executable as u8;
-                (*raw).padding = [0u8; 4];
-                (*raw).address = Address::new_from_array(address);
-                (*raw).owner = Address::new_from_array(owner);
-                (*raw).lamports = 123;
-                (*raw).data_len = data_len as u64;
-            }
-        }
-
-        unsafe fn view(&mut self) -> AccountView {
-            AccountView::new_unchecked(self.raw())
-        }
-    }
+    use crate::cpi::tests::AccountBuffer;
 
     static PROGRAM_ID: Address = Address::new_from_array([0x11; 32]);
 

--- a/lang/src/cpi/mod.rs
+++ b/lang/src/cpi/mod.rs
@@ -171,10 +171,13 @@ fn get_cpi_return() -> Result<CpiReturn, ProgramError> {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     {
         let mut program_id = MaybeUninit::<Address>::uninit();
-        let mut data = [0u8; MAX_RETURN_DATA];
+        // SAFETY: sol_get_return_data writes `min(size, MAX_RETURN_DATA)` bytes
+        // into the buffer. All consumer paths (as_slice, decode) are bounded by
+        // `data_len`, so uninitialized trailing bytes are never read.
+        let mut data = MaybeUninit::<[u8; MAX_RETURN_DATA]>::uninit();
         let size = unsafe {
             solana_define_syscall::definitions::sol_get_return_data(
-                data.as_mut_ptr(),
+                data.as_mut_ptr() as *mut u8,
                 MAX_RETURN_DATA as u64,
                 program_id.as_mut_ptr() as *mut _ as *mut u8,
             )
@@ -184,9 +187,15 @@ fn get_cpi_return() -> Result<CpiReturn, ProgramError> {
             return Err(QuasarError::MissingReturnData.into());
         }
 
+        // SAFETY: sol_get_return_data initialised `min(size, MAX_RETURN_DATA)`
+        // bytes. The remaining bytes are uninitialised but never accessed —
+        // CpiReturn::as_slice returns &data[..data_len] and decode copies
+        // exactly size_of::<T::Zc>() bytes. We assume_init the full array
+        // because the struct carries it by value; the uninitialised tail is
+        // inert (u8 has no Drop).
         return Ok(CpiReturn::new(
             unsafe { program_id.assume_init() },
-            data,
+            unsafe { data.assume_init() },
             core::cmp::min(size, MAX_RETURN_DATA),
         ));
     }
@@ -323,36 +332,42 @@ impl<'a, const ACCTS: usize, const DATA: usize> CpiCall<'a, ACCTS, DATA> {
 
     /// Invoke the CPI without any PDA signers.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_inner(&[])
     }
 
     /// Invoke the CPI with a single PDA signer (seeds for one address).
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_signed(&self, seeds: &[Seed]) -> ProgramResult {
         self.invoke_inner(&[Signer::from(seeds)])
     }
 
     /// Invoke the CPI with multiple PDA signers.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_signers(&self, signers: &[Signer]) -> ProgramResult {
         self.invoke_inner(signers)
     }
 
     /// Invoke the CPI and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_return(&self) -> Result<CpiReturn, ProgramError> {
         self.invoke_with_return_inner(&[])
     }
 
     /// Invoke the CPI with one PDA signer and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_signed_with_return(&self, seeds: &[Seed]) -> Result<CpiReturn, ProgramError> {
         self.invoke_with_return_inner(&[Signer::from(seeds)])
     }
 
     /// Invoke the CPI with multiple PDA signers and read back raw return data.
     #[inline(always)]
+    #[must_use = "CPI result must be handled with `?` or matched"]
     pub fn invoke_with_signers_with_return(
         &self,
         signers: &[Signer],

--- a/lang/src/cpi/mod.rs
+++ b/lang/src/cpi/mod.rs
@@ -433,12 +433,12 @@ mod tests {
         solana_account_view::{RuntimeAccount, MAX_PERMITTED_DATA_INCREASE, NOT_BORROWED},
     };
 
-    struct AccountBuffer {
+    pub(super) struct AccountBuffer {
         inner: std::vec::Vec<u64>,
     }
 
     impl AccountBuffer {
-        fn new(data_len: usize) -> Self {
+        pub(in crate::cpi) fn new(data_len: usize) -> Self {
             let byte_len =
                 core::mem::size_of::<RuntimeAccount>() + data_len + MAX_PERMITTED_DATA_INCREASE;
             Self {
@@ -446,11 +446,11 @@ mod tests {
             }
         }
 
-        fn raw(&mut self) -> *mut RuntimeAccount {
+        pub(in crate::cpi) fn raw(&mut self) -> *mut RuntimeAccount {
             self.inner.as_mut_ptr() as *mut RuntimeAccount
         }
 
-        fn init(
+        pub(in crate::cpi) fn init(
             &mut self,
             address: [u8; 32],
             owner: [u8; 32],
@@ -473,7 +473,7 @@ mod tests {
             }
         }
 
-        unsafe fn view(&mut self) -> AccountView {
+        pub(in crate::cpi) unsafe fn view(&mut self) -> AccountView {
             AccountView::new_unchecked(self.raw())
         }
     }

--- a/lang/src/cpi/system.rs
+++ b/lang/src/cpi/system.rs
@@ -9,6 +9,12 @@ use {
 declare_id!("11111111111111111111111111111111");
 pub use ID as SYSTEM_PROGRAM_ID;
 
+// System program instruction discriminators (u32 LE in the first 4 bytes).
+const IX_CREATE_ACCOUNT: u8 = 0;
+const IX_ASSIGN: u8 = 1;
+const IX_TRANSFER: u8 = 2;
+const IX_ALLOCATE: u8 = 8;
+
 /// Create a new account via the System program.
 ///
 /// ### Accounts:
@@ -34,10 +40,9 @@ pub fn create_account<'a>(
     let data = unsafe {
         let mut buf = core::mem::MaybeUninit::<[u8; 52]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
-        // discriminator 0 — four zero bytes
-        core::ptr::write_bytes(ptr, 0, 4);
-        core::ptr::copy_nonoverlapping(lamports.into().to_le_bytes().as_ptr(), ptr.add(4), 8);
-        core::ptr::copy_nonoverlapping(space.to_le_bytes().as_ptr(), ptr.add(12), 8);
+        (ptr as *mut u32).write_unaligned(IX_CREATE_ACCOUNT as u32);
+        (ptr.add(4) as *mut u64).write_unaligned(lamports.into());
+        (ptr.add(12) as *mut u64).write_unaligned(space);
         core::ptr::copy_nonoverlapping(owner.as_ref().as_ptr(), ptr.add(20), 32);
         buf.assume_init()
     };
@@ -74,8 +79,8 @@ pub fn transfer<'a>(
     let data = unsafe {
         let mut buf = core::mem::MaybeUninit::<[u8; 12]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
-        core::ptr::copy_nonoverlapping(2u32.to_le_bytes().as_ptr(), ptr, 4);
-        core::ptr::copy_nonoverlapping(lamports.into().to_le_bytes().as_ptr(), ptr.add(4), 8);
+        (ptr as *mut u32).write_unaligned(IX_TRANSFER as u32);
+        (ptr.add(4) as *mut u64).write_unaligned(lamports.into());
         buf.assume_init()
     };
 
@@ -106,7 +111,7 @@ pub fn assign<'a>(account: &'a AccountView, owner: &'a Address) -> CpiCall<'a, 1
     let data = unsafe {
         let mut buf = core::mem::MaybeUninit::<[u8; 36]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
-        core::ptr::copy_nonoverlapping(1u32.to_le_bytes().as_ptr(), ptr, 4);
+        (ptr as *mut u32).write_unaligned(IX_ASSIGN as u32);
         core::ptr::copy_nonoverlapping(owner.as_ref().as_ptr(), ptr.add(4), 32);
         buf.assume_init()
     };
@@ -137,8 +142,8 @@ pub fn allocate<'a>(account: &'a AccountView, space: u64) -> CpiCall<'a, 1, 12> 
     let data = unsafe {
         let mut buf = core::mem::MaybeUninit::<[u8; 12]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
-        core::ptr::copy_nonoverlapping(8u32.to_le_bytes().as_ptr(), ptr, 4);
-        core::ptr::copy_nonoverlapping(space.to_le_bytes().as_ptr(), ptr.add(4), 8);
+        (ptr as *mut u32).write_unaligned(IX_ALLOCATE as u32);
+        (ptr.add(4) as *mut u64).write_unaligned(space);
         buf.assume_init()
     };
 

--- a/lang/src/dynamic.rs
+++ b/lang/src/dynamic.rs
@@ -147,19 +147,18 @@ impl<'a> TailEncoded<'a> {
 
 /// Convert a validated UTF-8 byte slice to `&str`.
 ///
-/// Dynamic account parsing already validates UTF-8 for string fields. This
-/// helper keeps the accessor path free of UB even if invariants are violated
-/// later by unsafe mutation.
+/// Dynamic account parsing already validates UTF-8 for string fields during
+/// `AccountCheck::check` / `from_account_view`. This accessor skips
+/// re-validation to avoid burning ~1 CU per byte on every field access.
+/// A debug assertion catches mistakes in test builds.
 #[inline(always)]
 pub fn validated_utf8(bytes: &[u8]) -> &str {
-    match core::str::from_utf8(bytes) {
-        Ok(s) => s,
-        Err(_) => {
-            #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-            crate::abort_program();
-
-            #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
-            panic!("dynamic account field contains invalid UTF-8");
-        }
-    }
+    debug_assert!(
+        core::str::from_utf8(bytes).is_ok(),
+        "dynamic account field contains invalid UTF-8"
+    );
+    // SAFETY: UTF-8 was validated during account parsing. The only way to
+    // reach this with invalid bytes is via unsafe data_mut_ptr() writes,
+    // which is the caller's responsibility.
+    unsafe { core::str::from_utf8_unchecked(bytes) }
 }

--- a/lang/src/event.rs
+++ b/lang/src/event.rs
@@ -11,6 +11,43 @@ use {
     solana_program_error::ProgramError,
 };
 
+/// Validate and log an inbound event CPI.
+///
+/// Called by the generated `__handle_event` dispatch stub. Checks that the
+/// first account is a signer matching the program's event authority PDA,
+/// then logs the instruction data (minus the `0xFF` prefix).
+#[inline(always)]
+pub fn handle_event(
+    ptr: *mut u8,
+    instruction_data: &[u8],
+    event_authority: &solana_address::Address,
+) -> Result<(), ProgramError> {
+    // SAFETY: The SVM places the account count (u64) at offset 0.
+    if unsafe { *(ptr as *const u64) } == 0 {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+    // SAFETY: Pointer arithmetic follows the SVM input buffer layout.
+    unsafe {
+        let raw = ptr.add(core::mem::size_of::<u64>())
+            as *const crate::__internal::RuntimeAccount;
+
+        if (*raw).is_signer == 0 {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        if !crate::keys_eq(&(*raw).address, event_authority) {
+            return Err(ProgramError::InvalidSeeds);
+        }
+    }
+
+    if instruction_data.len() <= 1 {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    crate::log::log_data(&[&instruction_data[1..]]);
+    Ok(())
+}
+
 /// Emit an event via self-CPI to the program's own `__event_authority` PDA.
 ///
 /// The self-CPI proves the event was emitted by the program (the program ID

--- a/lang/src/event.rs
+++ b/lang/src/event.rs
@@ -16,28 +16,30 @@ use {
 /// Called by the generated `__handle_event` dispatch stub. Checks that the
 /// first account is a signer matching the program's event authority PDA,
 /// then logs the instruction data (minus the `0xFF` prefix).
+///
+/// # Safety
+///
+/// `ptr` must point to the start of a valid SVM input buffer (account count
+/// at offset 0, followed by serialized `RuntimeAccount` entries).
 #[inline(always)]
-pub fn handle_event(
+pub unsafe fn handle_event(
     ptr: *mut u8,
     instruction_data: &[u8],
     event_authority: &solana_address::Address,
 ) -> Result<(), ProgramError> {
     // SAFETY: The SVM places the account count (u64) at offset 0.
-    if unsafe { *(ptr as *const u64) } == 0 {
+    if *(ptr as *const u64) == 0 {
         return Err(ProgramError::NotEnoughAccountKeys);
     }
     // SAFETY: Pointer arithmetic follows the SVM input buffer layout.
-    unsafe {
-        let raw = ptr.add(core::mem::size_of::<u64>())
-            as *const crate::__internal::RuntimeAccount;
+    let raw = ptr.add(core::mem::size_of::<u64>()) as *const crate::__internal::RuntimeAccount;
 
-        if (*raw).is_signer == 0 {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
+    if (*raw).is_signer == 0 {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
 
-        if !crate::keys_eq(&(*raw).address, event_authority) {
-            return Err(ProgramError::InvalidSeeds);
-        }
+    if !crate::keys_eq(&(*raw).address, event_authority) {
+        return Err(ProgramError::InvalidSeeds);
     }
 
     if instruction_data.len() <= 1 {

--- a/lang/src/instruction_data.rs
+++ b/lang/src/instruction_data.rs
@@ -19,11 +19,11 @@ const _: () = assert!(cfg!(target_endian = "little"));
 /// Returns `(parsed_str, new_offset)`. The `PREFIX` const generic (1, 2, or 4)
 /// determines the byte width of the length prefix. Monomorphized per variant.
 #[inline(always)]
-pub fn read_dynamic_str<'a, const PREFIX: usize>(
-    data: &'a [u8],
+pub fn read_dynamic_str<const PREFIX: usize>(
+    data: &[u8],
     offset: usize,
     max_len: usize,
-) -> Result<(&'a str, usize), ProgramError> {
+) -> Result<(&str, usize), ProgramError> {
     if data.len() < offset + PREFIX {
         return Err(ProgramError::InvalidInstructionData);
     }
@@ -56,11 +56,11 @@ pub fn read_dynamic_str<'a, const PREFIX: usize>(
 /// compile-time assertion that MUST remain in the macro after extraction.
 /// This function does not check alignment at runtime.
 #[inline(always)]
-pub fn read_dynamic_vec<'a, T, const PREFIX: usize>(
-    data: &'a [u8],
+pub fn read_dynamic_vec<T, const PREFIX: usize>(
+    data: &[u8],
     offset: usize,
     max_count: usize,
-) -> Result<(&'a [T], usize), ProgramError> {
+) -> Result<(&[T], usize), ProgramError> {
     if data.len() < offset + PREFIX {
         return Err(ProgramError::InvalidInstructionData);
     }
@@ -117,6 +117,8 @@ fn read_prefix<const PREFIX: usize>(data: &[u8], offset: usize) -> usize {
             // SAFETY: Same as above.
             unsafe { core::ptr::read_unaligned(data.as_ptr().add(offset) as *const u32) as usize }
         }
-        _ => unreachable!(),
+        // SAFETY: PREFIX is a const generic only instantiated as 1, 2, or 4
+        // by the derive macro. This branch is dead code.
+        _ => unsafe { core::hint::unreachable_unchecked() },
     }
 }

--- a/lang/src/instruction_data.rs
+++ b/lang/src/instruction_data.rs
@@ -1,0 +1,118 @@
+//! Instruction data deserialization helpers for dynamic fields.
+//!
+//! These functions extract variable-length instruction arguments (strings,
+//! byte vectors, tail data) from raw instruction bytes. They are called by
+//! proc-macro-generated `#[instruction]` code.
+//!
+//! Each function uses const generics for the prefix byte width, enabling
+//! monomorphization per variant (no runtime dispatch).
+
+use solana_program_error::ProgramError;
+
+/// Read a length-prefixed UTF-8 string from instruction data.
+///
+/// Returns `(parsed_str, new_offset)`. The `PREFIX` const generic (1, 2, or 4)
+/// determines the byte width of the length prefix. Monomorphized per variant.
+#[inline(always)]
+pub fn read_dynamic_str<'a, const PREFIX: usize>(
+    data: &'a [u8],
+    offset: usize,
+    max_len: usize,
+) -> Result<(&'a str, usize), ProgramError> {
+    if data.len() < offset + PREFIX {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let len = read_prefix::<PREFIX>(data, offset);
+    let offset = offset + PREFIX;
+
+    if len > max_len {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    if data.len() < offset + len {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let bytes = &data[offset..offset + len];
+    let s = core::str::from_utf8(bytes).map_err(|_| ProgramError::InvalidInstructionData)?;
+
+    Ok((s, offset + len))
+}
+
+/// Read a length-prefixed typed slice from instruction data.
+///
+/// Returns `(parsed_slice, new_offset)`. The `PREFIX` const generic (1, 2, or 4)
+/// determines the byte width of the count prefix.
+///
+/// # Safety contract
+///
+/// `T` must have alignment 1. The derive macro enforces this with a
+/// compile-time assertion that MUST remain in the macro after extraction.
+/// This function does not check alignment at runtime.
+#[inline(always)]
+pub fn read_dynamic_vec<'a, T, const PREFIX: usize>(
+    data: &'a [u8],
+    offset: usize,
+    max_count: usize,
+) -> Result<(&'a [T], usize), ProgramError> {
+    if data.len() < offset + PREFIX {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let count = read_prefix::<PREFIX>(data, offset);
+    let offset = offset + PREFIX;
+
+    if count > max_count {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let byte_len = count
+        .checked_mul(core::mem::size_of::<T>())
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+    if data.len() < offset + byte_len {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    // SAFETY: Bounds checked above. The caller (derive macro) ensures T has
+    // alignment 1 via a compile-time assertion. The pointer from `data` is
+    // valid for `byte_len` bytes.
+    let slice = unsafe {
+        core::slice::from_raw_parts(data.as_ptr().add(offset) as *const T, count)
+    };
+
+    Ok((slice, offset + byte_len))
+}
+
+/// Read a tail UTF-8 string (all remaining instruction data from `offset`).
+#[inline(always)]
+pub fn read_tail_str(data: &[u8], offset: usize) -> Result<&str, ProgramError> {
+    let bytes = &data[offset..];
+    core::str::from_utf8(bytes).map_err(|_| ProgramError::InvalidInstructionData)
+}
+
+/// Read tail bytes (all remaining instruction data from `offset`).
+#[inline(always)]
+pub fn read_tail_bytes(data: &[u8], offset: usize) -> &[u8] {
+    &data[offset..]
+}
+
+/// Read a length prefix from instruction data. The `PREFIX` const generic
+/// determines the byte width (1, 2, or 4). Monomorphized per variant so the
+/// match is eliminated at compile time.
+#[inline(always)]
+fn read_prefix<const PREFIX: usize>(data: &[u8], offset: usize) -> usize {
+    match PREFIX {
+        1 => data[offset] as usize,
+        2 => {
+            // SAFETY: Bounds checked by caller. read_unaligned handles align-1 data.
+            unsafe { core::ptr::read_unaligned(data.as_ptr().add(offset) as *const u16) as usize }
+        }
+        4 => {
+            // SAFETY: Same as above.
+            unsafe { core::ptr::read_unaligned(data.as_ptr().add(offset) as *const u32) as usize }
+        }
+        _ => unreachable!(),
+    }
+}

--- a/lang/src/instruction_data.rs
+++ b/lang/src/instruction_data.rs
@@ -9,6 +9,11 @@
 
 use solana_program_error::ProgramError;
 
+// Prefix reads use native byte order via read_unaligned. Solana instruction
+// data is little-endian. This is correct on all Solana-supported targets
+// (SBF, x86-64, aarch64) but would silently produce wrong results on BE.
+const _: () = assert!(cfg!(target_endian = "little"));
+
 /// Read a length-prefixed UTF-8 string from instruction data.
 ///
 /// Returns `(parsed_str, new_offset)`. The `PREFIX` const generic (1, 2, or 4)
@@ -42,8 +47,8 @@ pub fn read_dynamic_str<'a, const PREFIX: usize>(
 
 /// Read a length-prefixed typed slice from instruction data.
 ///
-/// Returns `(parsed_slice, new_offset)`. The `PREFIX` const generic (1, 2, or 4)
-/// determines the byte width of the count prefix.
+/// Returns `(parsed_slice, new_offset)`. The `PREFIX` const generic (1, 2, or
+/// 4) determines the byte width of the count prefix.
 ///
 /// # Safety contract
 ///
@@ -78,9 +83,8 @@ pub fn read_dynamic_vec<'a, T, const PREFIX: usize>(
     // SAFETY: Bounds checked above. The caller (derive macro) ensures T has
     // alignment 1 via a compile-time assertion. The pointer from `data` is
     // valid for `byte_len` bytes.
-    let slice = unsafe {
-        core::slice::from_raw_parts(data.as_ptr().add(offset) as *const T, count)
-    };
+    let slice =
+        unsafe { core::slice::from_raw_parts(data.as_ptr().add(offset) as *const T, count) };
 
     Ok((slice, offset + byte_len))
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -104,11 +104,11 @@ pub mod entrypoint;
 pub mod error;
 /// Event emission via `sol_log_data` and self-CPI.
 pub mod event;
-/// Instruction data deserialization for dynamic fields (strings, vecs, tails).
-pub mod instruction_data;
 /// Trait for fixed-size instruction argument types with alignment-1 ZC
 /// companions.
 pub mod instruction_arg;
+/// Instruction data deserialization for dynamic fields (strings, vecs, tails).
+pub mod instruction_data;
 /// Low-level `sol_log_data` syscall wrapper.
 pub mod log;
 /// Program Derived Address creation and lookup.

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -104,6 +104,8 @@ pub mod entrypoint;
 pub mod error;
 /// Event emission via `sol_log_data` and self-CPI.
 pub mod event;
+/// Instruction data deserialization for dynamic fields (strings, vecs, tails).
+pub mod instruction_data;
 /// Trait for fixed-size instruction argument types with alignment-1 ZC
 /// companions.
 pub mod instruction_arg;
@@ -123,6 +125,8 @@ pub mod return_data;
 pub mod traits;
 /// Utility functions
 pub mod utils;
+/// Runtime validation helpers for account constraints.
+pub mod validation;
 
 /// 32-byte address comparison via four `read_unaligned` u64 words.
 ///

--- a/lang/src/pda.rs
+++ b/lang/src/pda.rs
@@ -15,6 +15,10 @@ use {solana_address::Address, solana_program_error::ProgramError};
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
+/// Maximum number of slices in a PDA hash input: up to 17 seeds + bump + program_id + PDA_MARKER.
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+const MAX_PDA_SLICES: usize = 19;
+
 /// Verify that `expected` matches `sha256(seeds || program_id ||
 /// "ProgramDerivedAddress")`.
 ///
@@ -37,7 +41,7 @@ pub fn verify_program_address(
 
         // Build the input array: [seeds..., program_id, PDA_MARKER].
         // Max 17 seeds + program_id + marker = 19 entries.
-        let mut slices = core::mem::MaybeUninit::<[&[u8]; 19]>::uninit();
+        let mut slices = core::mem::MaybeUninit::<[&[u8]; MAX_PDA_SLICES]>::uninit();
         let sptr = slices.as_mut_ptr() as *mut &[u8];
 
         let mut i = 0;
@@ -107,7 +111,7 @@ pub fn based_try_find_program_address(
 
         // Build the input array: [seeds..., bump, program_id, PDA_MARKER].
         // Max 16 seeds + bump + program_id + marker = 19 entries.
-        let mut slices = core::mem::MaybeUninit::<[&[u8]; 19]>::uninit();
+        let mut slices = core::mem::MaybeUninit::<[&[u8]; MAX_PDA_SLICES]>::uninit();
         let sptr = slices.as_mut_ptr() as *mut &[u8];
 
         let mut i = 0;

--- a/lang/src/pda.rs
+++ b/lang/src/pda.rs
@@ -185,6 +185,23 @@ pub fn based_try_find_program_address(
     }
 }
 
+/// Read the PDA bump byte from account data at the given offset.
+///
+/// Used by the BUMP_OFFSET fast path to read the bump from the account's
+/// own data instead of re-deriving it.
+#[inline(always)]
+pub fn read_bump_from_account(
+    view: &solana_account_view::AccountView,
+    offset: usize,
+) -> Result<u8, ProgramError> {
+    if crate::utils::hint::unlikely(offset >= view.data_len()) {
+        return Err(ProgramError::AccountDataTooSmall);
+    }
+    // SAFETY: Bounds checked above. `data_ptr()` returns a valid pointer
+    // to `data_len()` bytes.
+    Ok(unsafe { *view.data_ptr().add(offset) })
+}
+
 /// Compile-time PDA derivation using `const_crypto`.
 pub const fn find_program_address_const(seeds: &[&[u8]], program_id: &Address) -> (Address, u8) {
     let (bytes, bump) = const_crypto::ed25519::derive_program_address(seeds, program_id.as_array());

--- a/lang/src/pda.rs
+++ b/lang/src/pda.rs
@@ -15,7 +15,8 @@ use {solana_address::Address, solana_program_error::ProgramError};
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 
-/// Maximum number of slices in a PDA hash input: up to 17 seeds + bump + program_id + PDA_MARKER.
+/// Maximum number of slices in a PDA hash input: up to 17 seeds + bump +
+/// program_id + PDA_MARKER.
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 const MAX_PDA_SLICES: usize = 19;
 

--- a/lang/src/remaining.rs
+++ b/lang/src/remaining.rs
@@ -12,6 +12,14 @@ const _: () = assert!(
     "remaining accounts buffer navigation requires 64-bit usize"
 );
 
+// Guard against upstream ever adding Drop to AccountView. Several code
+// paths use `ptr::read` to create bitwise copies; a Drop impl would cause
+// double-free UB.
+const _: () = assert!(
+    !core::mem::needs_drop::<AccountView>(),
+    "AccountView must not implement Drop — ptr::read copies rely on this"
+);
+
 /// Size of a non-duplicate account entry in the SVM input buffer:
 /// `RuntimeAccount` header + 10 KiB realloc region + u64 padding.
 const ACCOUNT_HEADER: usize = core::mem::size_of::<RuntimeAccount>()
@@ -325,7 +333,10 @@ impl Iterator for RemainingIter<'_> {
                 self.ptr = self.boundary as *mut u8;
                 return Some(Err(QuasarError::RemainingAccountDuplicate.into()));
             }
-            self.resolve_dup(borrow as usize)?
+            match self.resolve_dup(borrow as usize) {
+                Some(v) => v,
+                None => return Some(Err(QuasarError::RemainingAccountDuplicate.into())),
+            }
         };
 
         if self.mode == RemainingMode::Strict && self.has_seen_address(view.address()) {

--- a/lang/src/remaining.rs
+++ b/lang/src/remaining.rs
@@ -178,6 +178,15 @@ impl<'a> RemainingAccounts<'a> {
     /// `MAX_REMAINING_ACCOUNTS` are accessed via the iterator.
     #[inline(always)]
     pub fn iter(&self) -> RemainingIter<'a> {
+        // Seed the bloom filter with declared account addresses for O(1)
+        // fast-reject in strict-mode duplicate detection.
+        let mut bloom = [0u64; 4];
+        if self.mode == RemainingMode::Strict {
+            for view in self.declared.iter() {
+                let (idx, bit) = bloom_hash(view.address());
+                bloom[idx] |= bit;
+            }
+        }
         RemainingIter {
             ptr: self.ptr,
             boundary: self.boundary,
@@ -185,6 +194,7 @@ impl<'a> RemainingAccounts<'a> {
             mode: self.mode,
             index: 0,
             cache: core::mem::MaybeUninit::uninit(),
+            bloom,
         }
     }
 }
@@ -255,6 +265,21 @@ pub struct RemainingIter<'a> {
     index: usize,
     /// Cache of yielded views. Elements `0..index` are initialized.
     cache: core::mem::MaybeUninit<[AccountView; MAX_REMAINING_ACCOUNTS]>,
+    /// 256-bit bloom filter for fast-reject in `has_seen_address`. Seeded
+    /// with declared account addresses at construction; updated on each yield.
+    /// False positives fall through to the exact `keys_eq` scan; false
+    /// negatives are impossible (all inserted addresses set their bit).
+    bloom: [u64; 4],
+}
+
+/// Hash an address into a (bucket, bit) pair for the 256-bit bloom filter.
+/// Uses XOR of the first two bytes for the 8-bit hash — high entropy for
+/// Solana pubkeys which are uniformly distributed.
+#[inline(always)]
+fn bloom_hash(addr: &solana_address::Address) -> (usize, u64) {
+    let b = addr.as_array();
+    let h = (b[0] as usize) ^ (b[16] as usize);
+    (h >> 6, 1u64 << (h & 63))
 }
 
 impl RemainingIter<'_> {
@@ -270,6 +295,14 @@ impl RemainingIter<'_> {
 
     #[inline(always)]
     fn has_seen_address(&self, address: &solana_address::Address) -> bool {
+        // Fast-reject via bloom filter: if the bit is not set, the address
+        // has definitely not been seen — skip the O(n) linear scan.
+        let (idx, bit) = bloom_hash(address);
+        if self.bloom[idx] & bit == 0 {
+            return false;
+        }
+
+        // Bloom hit — could be a false positive. Do the exact scan.
         if self
             .declared
             .iter()
@@ -342,6 +375,12 @@ impl Iterator for RemainingIter<'_> {
         if self.mode == RemainingMode::Strict && self.has_seen_address(view.address()) {
             self.ptr = self.boundary as *mut u8;
             return Some(Err(QuasarError::RemainingAccountDuplicate.into()));
+        }
+
+        // Update bloom filter for strict-mode duplicate detection.
+        if self.mode == RemainingMode::Strict {
+            let (bidx, bit) = bloom_hash(view.address());
+            self.bloom[bidx] |= bit;
         }
 
         // SAFETY: `self.index < MAX_REMAINING_ACCOUNTS` (checked above),

--- a/lang/src/sysvars/clock.rs
+++ b/lang/src/sysvars/clock.rs
@@ -25,8 +25,8 @@ pub struct Clock {
     pub unix_timestamp: PodI64,
 }
 
-const _ASSERT_STRUCT_LEN: () = assert!(size_of::<Clock>() == 40);
-const _ASSERT_STRUCT_ALIGN: () = assert!(align_of::<Clock>() == 1);
+const _: () = assert!(size_of::<Clock>() == 40);
+const _: () = assert!(align_of::<Clock>() == 1);
 
 impl Sysvar for Clock {
     impl_sysvar_get!(CLOCK_ID, 0);

--- a/lang/src/sysvars/rent.rs
+++ b/lang/src/sysvars/rent.rs
@@ -58,8 +58,8 @@ pub struct Rent {
     exemption_threshold: [u8; 8],
 }
 
-const _ASSERT_STRUCT_LEN: () = assert!(size_of::<Rent>() == 16);
-const _ASSERT_STRUCT_ALIGN: () = assert!(align_of::<Rent>() == 1);
+const _: () = assert!(size_of::<Rent>() == 16);
+const _: () = assert!(align_of::<Rent>() == 1);
 
 impl Rent {
     #[inline(always)]

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -312,3 +312,19 @@ pub trait Event {
     fn write_data(&self, buf: &mut [u8]);
     fn emit(&self, f: impl FnOnce(&[u8]) -> Result<(), ProgramError>) -> Result<(), ProgramError>;
 }
+
+/// Verify that the actual account count matches the expected count.
+///
+/// Used by `ParseAccounts` / `ParseAccountsUnchecked` impls to reject
+/// instruction calls with wrong account counts.
+#[inline(always)]
+pub fn check_account_count(actual: usize, expected: usize) -> Result<(), ProgramError> {
+    if crate::utils::hint::unlikely(actual != expected) {
+        return Err(if actual < expected {
+            ProgramError::NotEnoughAccountKeys
+        } else {
+            ProgramError::InvalidArgument
+        });
+    }
+    Ok(())
+}

--- a/lang/src/validation.rs
+++ b/lang/src/validation.rs
@@ -1,0 +1,40 @@
+//! Runtime validation helpers for account constraint checks.
+//!
+//! These functions are called by proc-macro-generated code to validate
+//! `has_one` and `address` constraints. Custom errors are supported via
+//! the `error` parameter — the macro resolves `@ MyError` expressions
+//! at compile time and passes them here.
+
+use {crate::utils::hint::unlikely, solana_address::Address, solana_program_error::ProgramError};
+
+/// Validate that two addresses match (used for `has_one` constraints).
+///
+/// The `error` parameter supports custom errors via
+/// `#[account(has_one = x @ MyError::Unauthorized)]`.
+#[inline(always)]
+pub fn check_has_one(
+    stored: &Address,
+    expected: &Address,
+    error: ProgramError,
+) -> Result<(), ProgramError> {
+    if unlikely(!crate::keys_eq(stored, expected)) {
+        return Err(error);
+    }
+    Ok(())
+}
+
+/// Validate that an account's address matches an expected value.
+///
+/// The `error` parameter supports custom errors via
+/// `#[account(address = expr @ MyError)]`.
+#[inline(always)]
+pub fn check_address_match(
+    actual: &Address,
+    expected: &Address,
+    error: ProgramError,
+) -> Result<(), ProgramError> {
+    if unlikely(!crate::keys_eq(actual, expected)) {
+        return Err(error);
+    }
+    Ok(())
+}

--- a/spl/src/constants.rs
+++ b/spl/src/constants.rs
@@ -2,35 +2,29 @@
 
 use solana_address::Address;
 
+/// `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`
 pub(crate) const SPL_TOKEN_BYTES: [u8; 32] = [
     6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237,
     95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
 ];
 
 /// SPL Token program address.
-#[cfg(any(target_os = "solana", target_arch = "bpf"))]
-pub static SPL_TOKEN_ID: Address = Address::new_from_array(SPL_TOKEN_BYTES);
-#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub const SPL_TOKEN_ID: Address = Address::new_from_array(SPL_TOKEN_BYTES);
 
+/// `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`
 pub(crate) const TOKEN_2022_BYTES: [u8; 32] = [
     6, 221, 246, 225, 238, 117, 143, 222, 24, 66, 93, 188, 228, 108, 205, 218, 182, 26, 252, 77,
     131, 185, 13, 39, 254, 189, 249, 40, 216, 161, 139, 252,
 ];
 
 /// Token-2022 program address.
-#[cfg(any(target_os = "solana", target_arch = "bpf"))]
-pub static TOKEN_2022_ID: Address = Address::new_from_array(TOKEN_2022_BYTES);
-#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub const TOKEN_2022_ID: Address = Address::new_from_array(TOKEN_2022_BYTES);
 
+/// `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`
 pub(crate) const ATA_PROGRAM_BYTES: [u8; 32] = [
     140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153, 218,
     255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89,
 ];
 
 /// Associated Token Account program address.
-#[cfg(any(target_os = "solana", target_arch = "bpf"))]
-pub static ATA_PROGRAM_ID: Address = Address::new_from_array(ATA_PROGRAM_BYTES);
-#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub const ATA_PROGRAM_ID: Address = Address::new_from_array(ATA_PROGRAM_BYTES);

--- a/spl/src/instructions/approve.rs
+++ b/spl/src/instructions/approve.rs
@@ -28,7 +28,7 @@ pub fn approve<'a>(
         let mut buf = core::mem::MaybeUninit::<[u8; 9]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
         core::ptr::write(ptr, 4);
-        core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(1), 8);
+        (ptr.add(1) as *mut u64).write_unaligned(amount);
         buf.assume_init()
     };
 

--- a/spl/src/instructions/burn.rs
+++ b/spl/src/instructions/burn.rs
@@ -28,7 +28,7 @@ pub fn burn<'a>(
         let mut buf = core::mem::MaybeUninit::<[u8; 9]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
         core::ptr::write(ptr, 8);
-        core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(1), 8);
+        (ptr.add(1) as *mut u64).write_unaligned(amount);
         buf.assume_init()
     };
 

--- a/spl/src/instructions/mint_to.rs
+++ b/spl/src/instructions/mint_to.rs
@@ -28,7 +28,7 @@ pub fn mint_to<'a>(
         let mut buf = core::mem::MaybeUninit::<[u8; 9]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
         core::ptr::write(ptr, 7);
-        core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(1), 8);
+        (ptr.add(1) as *mut u64).write_unaligned(amount);
         buf.assume_init()
     };
 

--- a/spl/src/instructions/transfer.rs
+++ b/spl/src/instructions/transfer.rs
@@ -28,7 +28,7 @@ pub fn transfer<'a>(
         let mut buf = core::mem::MaybeUninit::<[u8; 9]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
         core::ptr::write(ptr, 3);
-        core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(1), 8);
+        (ptr.add(1) as *mut u64).write_unaligned(amount);
         buf.assume_init()
     };
 

--- a/spl/src/instructions/transfer_checked.rs
+++ b/spl/src/instructions/transfer_checked.rs
@@ -32,7 +32,7 @@ pub fn transfer_checked<'a>(
         let mut buf = core::mem::MaybeUninit::<[u8; 10]>::uninit();
         let ptr = buf.as_mut_ptr() as *mut u8;
         core::ptr::write(ptr, 12);
-        core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(1), 8);
+        (ptr.add(1) as *mut u64).write_unaligned(amount);
         core::ptr::write(ptr.add(9), decimals);
         buf.assume_init()
     };

--- a/spl/src/state.rs
+++ b/spl/src/state.rs
@@ -206,8 +206,8 @@ impl TokenAccountState {
     }
 }
 
-const _ASSERT_TOKEN_ACCOUNT_LEN: () = assert!(TokenAccountState::LEN == 165);
-const _ASSERT_TOKEN_ACCOUNT_ALIGN: () = assert!(core::mem::align_of::<TokenAccountState>() == 1);
+const _: () = assert!(TokenAccountState::LEN == 165);
+const _: () = assert!(core::mem::align_of::<TokenAccountState>() == 1);
 
 // ---------------------------------------------------------------------------
 // MintAccountState
@@ -295,5 +295,5 @@ impl MintAccountState {
     }
 }
 
-const _ASSERT_MINT_LEN: () = assert!(MintAccountState::LEN == 82);
-const _ASSERT_MINT_ALIGN: () = assert!(core::mem::align_of::<MintAccountState>() == 1);
+const _: () = assert!(MintAccountState::LEN == 82);
+const _: () = assert!(core::mem::align_of::<MintAccountState>() == 1);

--- a/spl/src/validate.rs
+++ b/spl/src/validate.rs
@@ -180,8 +180,11 @@ pub fn validate_ata(
     mint: &Address,
     token_program: &Address,
 ) -> Result<(), ProgramError> {
-    // No allowlist check here — `validate_token_account` (called below)
-    // already verifies `token_program` is SPL Token or Token-2022.
+    // NOTE: We cannot use verify_program_address here as an optimization
+    // because it skips the Ed25519 off-curve check. An attacker could pass an
+    // account at the bump=255 address when that address is ON the curve (has
+    // a private key). The full find_program_address includes the curve check
+    // which ensures the result is a true PDA.
     let (expected, _) = crate::associated_token::get_associated_token_address_with_program(
         wallet,
         mint,


### PR DESCRIPTION
## Summary

Comprehensive audit and cleanup of the Quasar framework covering security, soundness, CU optimization, readability, and architectural improvements. **Zero CU regression** — DEPOSIT 1,577 CU, WITHDRAW 412 CU, verified at every step.

## Changes by category

### Security & Correctness
- **`__handle_event`**: replaced raw unaligned u64 dereference with `keys_eq()` — eliminates UB on non-SBF targets
- **Instruction discriminator**: reject multi-byte all-zero discriminators at compile time
- **`error_code`**: add `checked_add` overflow protection for discriminants
- **`declare_program`**: emit `compile_error!` instead of `.expect()` panics in proc-macro
- **Go client codegen**: `DynString` now respects `prefix_bytes` (was hardcoded to u32)
- **`build_idl`**: returns `Result` instead of calling `process::exit(1)`
- **`RemainingIter`**: returns `Err` on unresolvable dup instead of silent truncation
- **`classify_dynamic_string/vec`**: only match unqualified single-segment paths

### Soundness Hardening
- **`AccountView`**: compile-time `needs_drop` assertion (guards against upstream adding Drop)
- **`CtxWithRemaining`**: expanded SAFETY comment documenting Tree Borrows aliasing model
- **`resize`**: `i32::try_from(data_len)` instead of truncating `as i32` cast
- **CPI invoke methods**: `#[must_use]` on all invoke/invoke_signed/invoke_with_return
- **`has_cfg_test`**: parse `cfg()` attribute properly instead of string `.contains("test")`
- **`handle_event`**: marked `unsafe fn` (takes raw pointer)
- **`instruction_data`**: compile-time LE endianness assertion

### CU Optimizations
- **System CPI**: `write_unaligned` for disc/lamports/space (single store vs `to_le_bytes` + `copy_nonoverlapping`)
- **SPL CPI**: same `write_unaligned` for amount field in transfer, burn, mint_to, approve, transfer_checked
- **`CpiReturn`**: `MaybeUninit` instead of zero-init 1024 bytes (~128 CU/call saved)
- **`validated_utf8`**: `from_utf8_unchecked` with `debug_assert` (~32 CU/access saved)
- **SPL constants**: `static` → `const` for program IDs on BPF (enables LLVM to inline)
- **Remaining accounts**: 256-bit bloom filter for O(1) fast-reject in strict-mode dedup (~3,800 CU saved for 20+30 accounts)

### Readability
- Named constants for SVM header flag layout (`SIGNER_BIT`, `WRITABLE_MASK`, etc.)
- Named `MAX_PDA_SLICES` constant replacing magic 19
- Named system CPI discriminator constants (`IX_CREATE_ACCOUNT`, `IX_TRANSFER`, etc.)
- `pascal_to_snake` handles acronym runs correctly (`HTTPServer` → `http_server`)
- Consistent `const _:` compile-time assertions (replacing `_ASSERT_*` names)
- Base58 address doc comments on SPL constant byte arrays
- Go codegen: fix f32/f64 decode newline bug (was emitting literal `n`)
- Remove dead assignment in IDL parser state.rs

### Architecture
- Extract 9 runtime functions from proc-macro codegen into `lang/src/`:
  - `validation.rs`: `check_has_one`, `check_address_match` (with custom error support)
  - `instruction_data.rs`: `read_dynamic_str`, `read_dynamic_vec`, `read_tail_str`, `read_tail_bytes`
  - `traits.rs`: `check_account_count`
  - `pda.rs`: `read_bump_from_account`
  - `event.rs`: `handle_event`
- Deduplicate `AccountBuffer` test helper between `cpi/mod.rs` and `cpi/dyn_cpi.rs`
- `derive/src/instruction.rs` shrinks by 73 lines (-17%)

## Verification

- **CU**: DEPOSIT 1,577, WITHDRAW 412 — identical to master baseline, checked after every commit
- **SBF binary**: 7,008 bytes — identical to baseline
- **Tests**: 579+ passing, 0 failures
- **SBF build**: all 9 test programs + 3 examples build successfully
- **Clippy**: zero warnings
- **Rustfmt**: clean

## Test plan

- [x] `cargo test --workspace` (excluding pinocchio-vault/upstream-vault which need pre-built .so)
- [x] `cargo build-sbf` on vault, escrow, multisig, all 9 test programs
- [x] CU regression check via mollusk test output
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --check --all` clean