### PR TITLE
Remove `'info` lifetime

### DIFF
--- a/derive/src/accounts/fields_process.rs
+++ b/derive/src/accounts/fields_process.rs
@@ -590,7 +590,7 @@ pub(crate) fn process_fields(
         } else {
             let base_type = strip_generics(effective_ty);
             field_constructs.push(construct(
-                quote! { unsafe { #base_type::from_account_view_unchecked(#field_name) } },
+                quote! { unsafe { core::ptr::read(#base_type::from_account_view_unchecked(#field_name)) } },
             ));
         }
 

--- a/derive/src/accounts/fields_process.rs
+++ b/derive/src/accounts/fields_process.rs
@@ -579,14 +579,12 @@ pub(crate) fn process_fields(
                 field_constructs
                     .push(quote! { #field_name: #base_type::from_account_view(#field_name)? });
             }
-        } else if let Type::Reference(type_ref) = effective_ty {
-            let base_type = strip_generics(&type_ref.elem);
-            let expr = if type_ref.mutability.is_some() {
-                quote! { unsafe { #base_type::from_account_view_unchecked_mut(#field_name) } }
-            } else {
-                quote! { unsafe { #base_type::from_account_view_unchecked(#field_name) } }
-            };
-            field_constructs.push(construct(expr));
+        } else if let Type::Reference(_) = effective_ty {
+            return Err(
+                syn::Error::new_spanned(field, "Reference types are not supported")
+                    .to_compile_error()
+                    .into(),
+            );
         } else {
             let base_type = strip_generics(effective_ty);
             field_constructs.push(construct(

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -529,7 +529,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         quote! {}
     } else {
         quote! {
-            impl<'info> #name<'info> {
+            impl #name {
                 #(#seeds_methods)*
             }
         }
@@ -634,11 +634,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
     let parse_accounts_impl = if has_instruction_args {
         quote! {
-            impl<'info> ParseAccounts<'info> for #name<'info> {
+            impl ParseAccounts for #name {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &'info mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
@@ -651,8 +651,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 fn parse_with_instruction_data(
-                    accounts: &'info mut [AccountView],
-                    __ix_data: &'info [u8],
+                    accounts: &mut [AccountView],
+                    __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
@@ -668,9 +668,9 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl<'info> quasar_lang::traits::ParseAccountsUnchecked<'info> for #name<'info> {
+            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
                 #[inline(always)]
-                unsafe fn parse_unchecked(accounts: &'info mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                unsafe fn parse_unchecked(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
                         accounts,
                         &[],
@@ -680,8 +680,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 unsafe fn parse_with_instruction_data_unchecked(
-                    accounts: &'info mut [AccountView],
-                    __ix_data: &'info [u8],
+                    accounts: &mut [AccountView],
+                    __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #ix_arg_extraction
@@ -691,11 +691,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            impl<'info> ParseAccounts<'info> for #name<'info> {
+            impl ParseAccounts for #name {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &'info mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_unchecked(
@@ -708,10 +708,10 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl<'info> quasar_lang::traits::ParseAccountsUnchecked<'info> for #name<'info> {
+            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
                 #[inline(always)]
                 unsafe fn parse_unchecked(
-                    accounts: &'info mut [AccountView],
+                    accounts: &mut [AccountView],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #parse_body
@@ -727,11 +727,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
         #seeds_impl
 
-        impl<'info> AccountCount for #name<'info> {
+        impl AccountCount for #name {
             const COUNT: usize = #count_expr;
         }
 
-        impl<'info> #name<'info> {
+        impl #name {
             #[inline(always)]
             pub unsafe fn parse_accounts(
                 mut input: *mut u8,

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -603,10 +603,10 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                         if __sweep_amount > 0 {
                             let __sweep_decimals = self.#mint.decimals();
                             self.#tp.transfer_checked(
-                                self.#field,
-                                self.#mint,
-                                self.#receiver,
-                                self.#auth,
+                                &self.#field,
+                                &self.#mint,
+                                &self.#receiver,
+                                &self.#auth,
                                 __sweep_amount,
                                 __sweep_decimals,
                             ).invoke()?;
@@ -630,7 +630,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                     quote! {
                         {
                             use quasar_spl::TokenCpi as _;
-                            self.#tp.close_account(self.#field, self.#dest, self.#auth).invoke()?;
+                            self.#tp.close_account(&self.#field, &self.#dest, &self.#auth).invoke()?;
                         }
                     }
                 } else {

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -15,13 +15,53 @@ use {
     instruction_args::{generate_instruction_arg_extraction, parse_struct_instruction_args},
     proc_macro::TokenStream,
     quote::{format_ident, quote},
-    syn::{parse_macro_input, Data, DeriveInput, Fields, Type},
+    syn::{parse_macro_input, parse_quote, Data, DeriveInput, Fields, GenericParam, Type},
 };
 
 pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let bumps_name = format_ident!("{}Bumps", name);
+
+    // Currently only custom lifetime parameters are supported, so validate that
+    // we don't have any type or const generics.
+    if let Some(param) = input
+        .generics
+        .params
+        .iter()
+        .find(|param| !matches!(param, GenericParam::Lifetime(_)))
+    {
+        let message = match param {
+            GenericParam::Type(_) => {
+                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not supported"
+            }
+            GenericParam::Const(_) => {
+                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not supported"
+            }
+            GenericParam::Lifetime(_) => unreachable!("filtered above"),
+        };
+        return syn::Error::new_spanned(param, message)
+            .to_compile_error()
+            .into();
+    }
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let mut parse_generics = input.generics.clone();
+    // 'input is the default lifetime used for account references in the generated traits, so
+    // we need to make sure that it lives longer than any user-defined lifetimes.
+    parse_generics.params.push(parse_quote!('input));
+    {
+        let parse_where = parse_generics.make_where_clause();
+        for lifetime in input.generics.lifetimes() {
+            let lifetime = &lifetime.lifetime;
+            parse_where
+                .predicates
+                .push(syn::parse_quote!('input: #lifetime));
+        }
+    }
+    // These generics are used for the ParseAccounts impl, which may have different lifetime
+    // requirements than the original struct.
+    let (parse_impl_generics, _, parse_where_clause) = parse_generics.split_for_impl();
 
     let fields = match &input.data {
         Data::Struct(data) => match &data.fields {
@@ -529,7 +569,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         quote! {}
     } else {
         quote! {
-            impl #name {
+            impl #impl_generics #name #ty_generics #where_clause {
                 #(#seeds_methods)*
             }
         }
@@ -634,11 +674,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
     let parse_accounts_impl = if has_instruction_args {
         quote! {
-            impl ParseAccounts for #name {
+            impl #parse_impl_generics ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &'input mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
@@ -651,7 +691,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 fn parse_with_instruction_data(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -668,9 +708,12 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
+            unsafe impl #parse_impl_generics quasar_lang::traits::ParseAccountsUnchecked<'input>
+                for #name #ty_generics
+                #parse_where_clause
+            {
                 #[inline(always)]
-                unsafe fn parse_unchecked(accounts: &mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                unsafe fn parse_unchecked(accounts: &'input mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
                         accounts,
                         &[],
@@ -680,7 +723,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
                 #[inline(always)]
                 unsafe fn parse_with_instruction_data_unchecked(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __ix_data: &[u8],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -691,11 +734,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            impl ParseAccounts for #name {
+            impl #parse_impl_generics ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
                 type Bumps = #bumps_name;
 
                 #[inline(always)]
-                fn parse(accounts: &mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
+                fn parse(accounts: &'input mut [AccountView], __program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {
                     #exact_len_guard
                     unsafe {
                         <Self as quasar_lang::traits::ParseAccountsUnchecked>::parse_unchecked(
@@ -708,10 +751,13 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 #epilogue_method
             }
 
-            unsafe impl quasar_lang::traits::ParseAccountsUnchecked for #name {
+            unsafe impl #parse_impl_generics quasar_lang::traits::ParseAccountsUnchecked<'input>
+                for #name #ty_generics
+                #parse_where_clause
+            {
                 #[inline(always)]
                 unsafe fn parse_unchecked(
-                    accounts: &mut [AccountView],
+                    accounts: &'input mut [AccountView],
                     __program_id: &Address,
                 ) -> Result<(Self, Self::Bumps), ProgramError> {
                     #parse_body
@@ -727,11 +773,11 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
 
         #seeds_impl
 
-        impl AccountCount for #name {
+        impl #impl_generics AccountCount for #name #ty_generics #where_clause {
             const COUNT: usize = #count_expr;
         }
 
-        impl #name {
+        impl #impl_generics #name #ty_generics #where_clause {
             #[inline(always)]
             pub unsafe fn parse_accounts(
                 mut input: *mut u8,

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -33,10 +33,12 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     {
         let message = match param {
             GenericParam::Type(_) => {
-                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not supported"
+                "#[derive(Accounts)] only supports lifetime parameters; type parameters are not \
+                 supported"
             }
             GenericParam::Const(_) => {
-                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not supported"
+                "#[derive(Accounts)] only supports lifetime parameters; const parameters are not \
+                 supported"
             }
             GenericParam::Lifetime(_) => unreachable!("filtered above"),
         };
@@ -47,8 +49,9 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let mut parse_generics = input.generics.clone();
-    // 'input is the default lifetime used for account references in the generated traits, so
-    // we need to make sure that it lives longer than any user-defined lifetimes.
+    // 'input is the default lifetime used for account references in the generated
+    // traits, so we need to make sure that it lives longer than any
+    // user-defined lifetimes.
     parse_generics.params.push(parse_quote!('input));
     {
         let parse_where = parse_generics.make_where_clause();
@@ -59,8 +62,8 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
                 .push(syn::parse_quote!('input: #lifetime));
         }
     }
-    // These generics are used for the ParseAccounts impl, which may have different lifetime
-    // requirements than the original struct.
+    // These generics are used for the ParseAccounts impl, which may have different
+    // lifetime requirements than the original struct.
     let (parse_impl_generics, _, parse_where_clause) = parse_generics.split_for_impl();
 
     let fields = match &input.data {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -176,7 +176,7 @@ pub fn error_code(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn emit_cpi(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
     quote::quote! {
-        self.program.emit_event(&#input, self.event_authority, crate::EventAuthority::BUMP)
+        self.program.emit_event(&#input, &self.event_authority, crate::EventAuthority::BUMP)
     }
     .into()
 }

--- a/examples/escrow/src/instructions/make.rs
+++ b/examples/escrow/src/instructions/make.rs
@@ -8,23 +8,25 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Make<'info> {
-    pub maker: &'info mut Signer,
-    #[account(init, payer = maker, seeds = Escrow::seeds(maker), bump)]
-    pub escrow: &'info mut Account<Escrow>,
-    pub mint_a: &'info Account<Mint>,
-    pub mint_b: &'info Account<Mint>,
-    pub maker_ta_a: &'info mut Account<Token>,
-    #[account(init_if_needed, payer = maker, token::mint = mint_b, token::authority = maker)]
-    pub maker_ta_b: &'info mut Account<Token>,
-    #[account(init_if_needed, payer = maker, token::mint = mint_a, token::authority = escrow)]
-    pub vault_ta_a: &'info mut Account<Token>,
-    pub rent: &'info Sysvar<Rent>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct Make {
+    #[account(mut)]
+    pub maker: Signer,
+    #[account(mut, init, payer = maker, seeds = Escrow::seeds(maker), bump)]
+    pub escrow: Account<Escrow>,
+    pub mint_a: Account<Mint>,
+    pub mint_b: Account<Mint>,
+    #[account(mut)]
+    pub maker_ta_a: Account<Token>,
+    #[account(mut, init_if_needed, payer = maker, token::mint = mint_b, token::authority = maker)]
+    pub maker_ta_b: Account<Token>,
+    #[account(mut, init_if_needed, payer = maker, token::mint = mint_a, token::authority = escrow)]
+    pub vault_ta_a: Account<Token>,
+    pub rent: Sysvar<Rent>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Make<'info> {
+impl Make {
     #[inline(always)]
     pub fn make_escrow(&mut self, receive: u64, bumps: &MakeBumps) -> Result<(), ProgramError> {
         self.escrow.set_inner(EscrowInner {
@@ -54,7 +56,7 @@ impl<'info> Make<'info> {
     #[inline(always)]
     pub fn deposit_tokens(&mut self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .transfer(self.maker_ta_a, self.vault_ta_a, self.maker, amount)
+            .transfer(&self.maker_ta_a, &self.vault_ta_a, &self.maker, amount)
             .invoke()
     }
 }

--- a/examples/escrow/src/instructions/refund.rs
+++ b/examples/escrow/src/instructions/refund.rs
@@ -5,40 +5,43 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Refund<'info> {
-    pub maker: &'info mut Signer,
+pub struct Refund {
+    #[account(mut)]
+    pub maker: Signer,
     #[account(
         has_one = maker,
         close = maker,
         seeds = Escrow::seeds(maker),
         bump = escrow.bump
     )]
-    pub escrow: &'info mut Account<Escrow>,
-    pub mint_a: &'info Account<Mint>,
-    #[account(init_if_needed, payer = maker, token::mint = mint_a, token::authority = maker)]
-    pub maker_ta_a: &'info mut Account<Token>,
-    pub vault_ta_a: &'info mut Account<Token>,
-    pub rent: &'info Sysvar<Rent>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+    #[account(mut)]
+    pub escrow: Account<Escrow>,
+    pub mint_a: Account<Mint>,
+    #[account(mut, init_if_needed, payer = maker, token::mint = mint_a, token::authority = maker)]
+    pub maker_ta_a: Account<Token>,
+    #[account(mut)]
+    pub vault_ta_a: Account<Token>,
+    pub rent: Sysvar<Rent>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Refund<'info> {
+impl Refund {
     #[inline(always)]
     pub fn withdraw_tokens_and_close(&mut self, bumps: &RefundBumps) -> Result<(), ProgramError> {
         let seeds = self.escrow_seeds(bumps);
 
         self.token_program
             .transfer(
-                self.vault_ta_a,
-                self.maker_ta_a,
-                self.escrow,
+                &self.vault_ta_a,
+                &self.maker_ta_a,
+                &self.escrow,
                 self.vault_ta_a.amount(),
             )
             .invoke_signed(&seeds)?;
 
         self.token_program
-            .close_account(self.vault_ta_a, self.maker, self.escrow)
+            .close_account(&self.vault_ta_a, &self.maker, &self.escrow)
             .invoke_signed(&seeds)?;
         Ok(())
     }

--- a/examples/escrow/src/instructions/take.rs
+++ b/examples/escrow/src/instructions/take.rs
@@ -5,9 +5,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Take<'info> {
-    pub taker: &'info mut Signer,
+pub struct Take {
+    #[account(mut)]
+    pub taker: Signer,
     #[account(
+        mut,
         has_one = maker,
         has_one = maker_ta_b,
         constraint = escrow.receive > 0,
@@ -15,29 +17,32 @@ pub struct Take<'info> {
         seeds = Escrow::seeds(maker),
         bump = escrow.bump
     )]
-    pub escrow: &'info mut Account<Escrow>,
-    pub maker: &'info mut UncheckedAccount,
-    pub mint_a: &'info Account<Mint>,
-    pub mint_b: &'info Account<Mint>,
-    #[account(init_if_needed, payer = taker, token::mint = mint_a, token::authority = taker)]
-    pub taker_ta_a: &'info mut Account<Token>,
-    pub taker_ta_b: &'info mut Account<Token>,
-    #[account(init_if_needed, payer = taker, token::mint = mint_b, token::authority = maker)]
-    pub maker_ta_b: &'info mut Account<Token>,
-    pub vault_ta_a: &'info mut Account<Token>,
-    pub rent: &'info Sysvar<Rent>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+    pub escrow: Account<Escrow>,
+    #[account(mut)]
+    pub maker: UncheckedAccount,
+    pub mint_a: Account<Mint>,
+    pub mint_b: Account<Mint>,
+    #[account(mut, init_if_needed, payer = taker, token::mint = mint_a, token::authority = taker)]
+    pub taker_ta_a: Account<Token>,
+    #[account(mut)]
+    pub taker_ta_b: Account<Token>,
+    #[account(mut, init_if_needed, payer = taker, token::mint = mint_b, token::authority = maker)]
+    pub maker_ta_b: Account<Token>,
+    #[account(mut)]
+    pub vault_ta_a: Account<Token>,
+    pub rent: Sysvar<Rent>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Take<'info> {
+impl Take {
     #[inline(always)]
     pub fn transfer_tokens(&mut self) -> Result<(), ProgramError> {
         self.token_program
             .transfer(
-                self.taker_ta_b,
-                self.maker_ta_b,
-                self.taker,
+                &self.taker_ta_b,
+                &self.maker_ta_b,
+                &self.taker,
                 self.escrow.receive,
             )
             .invoke()
@@ -49,15 +54,15 @@ impl<'info> Take<'info> {
 
         self.token_program
             .transfer(
-                self.vault_ta_a,
-                self.taker_ta_a,
-                self.escrow,
+                &self.vault_ta_a,
+                &self.taker_ta_a,
+                &self.escrow,
                 self.vault_ta_a.amount(),
             )
             .invoke_signed(&seeds)?;
 
         self.token_program
-            .close_account(self.vault_ta_a, self.taker, self.escrow)
+            .close_account(&self.vault_ta_a, &self.taker, &self.escrow)
             .invoke_signed(&seeds)?;
         Ok(())
     }

--- a/examples/multisig/src/instructions/create.rs
+++ b/examples/multisig/src/instructions/create.rs
@@ -4,15 +4,16 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Create<'info> {
-    pub creator: &'info mut Signer,
+pub struct Create<'config> {
+    #[account(mut)]
+    pub creator: Signer,
     #[account(init, payer = creator, seeds = MultisigConfig::seeds(creator), bump)]
-    pub config: Account<MultisigConfig<'info>>,
-    pub rent: &'info Sysvar<Rent>,
-    pub system_program: &'info Program<System>,
+    pub config: Account<MultisigConfig<'config>>,
+    pub rent: Sysvar<Rent>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Create<'info> {
+impl Create<'_> {
     #[inline(always)]
     pub fn create_multisig(
         &mut self,
@@ -53,7 +54,7 @@ impl<'info> Create<'info> {
                 signers,
             },
             self.creator.to_account_view(),
-            Some(&**self.rent),
+            Some(&self.rent),
         )
     }
 }

--- a/examples/multisig/src/instructions/deposit.rs
+++ b/examples/multisig/src/instructions/deposit.rs
@@ -1,19 +1,20 @@
 use {crate::state::MultisigConfig, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct Deposit<'info> {
-    pub depositor: &'info mut Signer,
-    pub config: Account<MultisigConfig<'info>>,
+pub struct Deposit<'config> {
+    #[account(mut)]
+    pub depositor: Signer,
+    pub config: Account<MultisigConfig<'config>>,
     #[account(mut, seeds = [b"vault", config], bump)]
-    pub vault: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub vault: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Deposit<'info> {
+impl Deposit<'_> {
     #[inline(always)]
     pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
         self.system_program
-            .transfer(self.depositor, self.vault, amount)
+            .transfer(&self.depositor, &self.vault, amount)
             .invoke()
     }
 }

--- a/examples/multisig/src/instructions/execute_transfer.rs
+++ b/examples/multisig/src/instructions/execute_transfer.rs
@@ -4,21 +4,22 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ExecuteTransfer<'info> {
+pub struct ExecuteTransfer<'config> {
     #[account(
         has_one = creator,
         seeds = MultisigConfig::seeds(creator),
         bump = config.bump
     )]
-    pub config: Account<MultisigConfig<'info>>,
-    pub creator: &'info UncheckedAccount,
+    pub config: Account<MultisigConfig<'config>>,
+    pub creator: UncheckedAccount,
     #[account(mut, seeds = [b"vault", config], bump)]
-    pub vault: &'info mut UncheckedAccount,
-    pub recipient: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub vault: UncheckedAccount,
+    #[account(mut)]
+    pub recipient: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ExecuteTransfer<'info> {
+impl ExecuteTransfer<'_> {
     #[inline(always)]
     pub fn verify_and_transfer(
         &self,
@@ -50,7 +51,7 @@ impl<'info> ExecuteTransfer<'info> {
 
         let seeds = self.vault_seeds(bumps);
         self.system_program
-            .transfer(self.vault, self.recipient, amount)
+            .transfer(&self.vault, &self.recipient, amount)
             .invoke_signed(&seeds)?;
         Ok(())
     }

--- a/examples/multisig/src/instructions/set_label.rs
+++ b/examples/multisig/src/instructions/set_label.rs
@@ -1,21 +1,22 @@
 use {crate::state::MultisigConfig, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct SetLabel<'info> {
-    pub creator: &'info mut Signer,
+pub struct SetLabel<'config> {
+    #[account(mut)]
+    pub creator: Signer,
     #[account(
         mut,
         has_one = creator,
         seeds = MultisigConfig::seeds(creator),
         bump = config.bump
     )]
-    pub config: Account<MultisigConfig<'info>>,
-    pub system_program: &'info Program<System>,
+    pub config: Account<MultisigConfig<'config>>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> SetLabel<'info> {
+impl SetLabel<'_> {
     #[inline(always)]
     pub fn update_label(&mut self, label: &str) -> Result<(), ProgramError> {
-        self.config.set_label(self.creator, label)
+        self.config.set_label(&self.creator, label)
     }
 }

--- a/examples/upstream-vault/src/instructions/deposit.rs
+++ b/examples/upstream-vault/src/instructions/deposit.rs
@@ -1,18 +1,19 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Deposit<'info> {
-    pub user: &'info mut Signer,
+pub struct Deposit {
+    #[account(mut)]
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub vault: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Deposit<'info> {
+impl Deposit {
     #[inline(always)]
     pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
         self.system_program
-            .transfer(self.user, self.vault, amount)
+            .transfer(&self.user, &self.vault, amount)
             .invoke()
     }
 }

--- a/examples/upstream-vault/src/instructions/withdraw.rs
+++ b/examples/upstream-vault/src/instructions/withdraw.rs
@@ -1,13 +1,14 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Withdraw<'info> {
-    pub user: &'info mut Signer,
+pub struct Withdraw {
+    #[account(mut)]
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
+    pub vault: UncheckedAccount,
 }
 
-impl<'info> Withdraw<'info> {
+impl Withdraw {
     #[inline(always)]
     pub fn withdraw(&self, amount: u64) -> Result<(), ProgramError> {
         let vault = self.vault.to_account_view();

--- a/examples/vault/src/instructions/deposit.rs
+++ b/examples/vault/src/instructions/deposit.rs
@@ -1,18 +1,18 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Deposit<'info> {
-    pub user: &'info mut Signer,
+pub struct Deposit {
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub vault: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Deposit<'info> {
+impl Deposit {
     #[inline(always)]
     pub fn deposit(&self, amount: u64) -> Result<(), ProgramError> {
         self.system_program
-            .transfer(self.user, self.vault, amount)
+            .transfer(&self.user, &self.vault, amount)
             .invoke()
     }
 }

--- a/examples/vault/src/instructions/deposit.rs
+++ b/examples/vault/src/instructions/deposit.rs
@@ -2,6 +2,7 @@ use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct Deposit {
+    #[account(mut)]
     pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
     pub vault: UncheckedAccount,

--- a/examples/vault/src/instructions/withdraw.rs
+++ b/examples/vault/src/instructions/withdraw.rs
@@ -2,6 +2,7 @@ use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct Withdraw {
+    #[account(mut)]
     pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
     pub vault: UncheckedAccount,

--- a/examples/vault/src/instructions/withdraw.rs
+++ b/examples/vault/src/instructions/withdraw.rs
@@ -1,13 +1,13 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Withdraw<'info> {
-    pub user: &'info mut Signer,
+pub struct Withdraw {
+    pub user: Signer,
     #[account(mut, seeds = [b"vault", user], bump)]
-    pub vault: &'info mut UncheckedAccount,
+    pub vault: UncheckedAccount,
 }
 
-impl<'info> Withdraw<'info> {
+impl Withdraw {
     #[inline(always)]
     pub fn withdraw(&self, amount: u64) -> Result<(), ProgramError> {
         let vault = self.vault.to_account_view();

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -17,7 +17,7 @@ use crate::{prelude::*, remaining::RemainingAccounts, traits::ParseAccountsUnche
 /// Cast `&[u8; 32]` to `&Address`.
 ///
 /// The entrypoint owns the original 32-byte program-id storage for the entire
-/// instruction, so the returned reference is valid for `'info`. This avoids
+/// instruction, so the returned reference is valid for `'input`. This avoids
 /// copying the program ID into a stack-local `Address` on every dispatch path.
 #[inline(always)]
 unsafe fn as_address(bytes: &[u8; 32]) -> &Address {
@@ -29,18 +29,18 @@ unsafe fn as_address(bytes: &[u8; 32]) -> &Address {
 /// Produced by the `dispatch!` macro from the entrypoint's raw pointers.
 /// Consumed by [`Ctx::new()`] or [`CtxWithRemaining::new()`] which parse
 /// and validate the accounts.
-pub struct Context<'info> {
+pub struct Context<'input> {
     /// 32-byte program ID passed by the runtime.
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Declared accounts (first `N` accounts deserialized from the input).
-    pub accounts: &'info mut [AccountView],
+    pub accounts: &'input mut [AccountView],
 
     /// Pointer to the first remaining account (past the declared accounts).
     pub remaining_ptr: *mut u8,
 
     /// Raw instruction data (discriminator already consumed by `dispatch!`).
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 
     /// End of accounts region: `ix_data_ptr - sizeof(u64)`.
     pub accounts_boundary: *const u8,
@@ -50,7 +50,7 @@ pub struct Context<'info> {
 ///
 /// Use [`CtxWithRemaining`] for instructions that need
 /// `remaining_accounts()`.
-pub struct Ctx<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount> {
+pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -58,15 +58,15 @@ pub struct Ctx<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + 
     pub bumps: T::Bumps,
 
     /// 32-byte program ID (raw bytes, not [`Address`]).
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Instruction data with discriminator already consumed.
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 }
 
-impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount> Ctx<'info, T> {
+impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'input, T> {
     #[inline(always)]
-    pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
+    pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
         let (accounts, bumps) = unsafe {
             T::parse_with_instruction_data_unchecked(ctx.accounts, ctx.data, program_id_addr)?
@@ -92,10 +92,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
 /// when inspecting trailing accounts in local logic, or
 /// `remaining_accounts_passthrough()` when forwarding a variable number of
 /// accounts to a downstream CPI.
-pub struct CtxWithRemaining<
-    'info,
-    T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount,
-> {
+pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -103,26 +100,24 @@ pub struct CtxWithRemaining<
     pub bumps: T::Bumps,
 
     /// 32-byte program ID (raw bytes).
-    pub program_id: &'info [u8; 32],
+    pub program_id: &'input [u8; 32],
 
     /// Instruction data with discriminator already consumed.
-    pub data: &'info [u8],
+    pub data: &'input [u8],
 
     /// Pointer to the first remaining account in the input buffer.
     remaining_ptr: *mut u8,
 
     /// Declared accounts slice (for duplicate resolution in remaining).
-    declared: &'info [AccountView],
+    declared: &'input [AccountView],
 
     /// End-of-accounts boundary pointer.
     accounts_boundary: *const u8,
 }
 
-impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCount>
-    CtxWithRemaining<'info, T>
-{
+impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> CtxWithRemaining<'input, T> {
     #[inline(always)]
-    pub fn new(ctx: Context<'info>) -> Result<Self, ProgramError> {
+    pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
         // Save slice metadata before parse consumes the &mut borrow.
         // The declared `AccountView`s are copied by value during parsing, so the
@@ -157,7 +152,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
     /// this for local program logic so each trailing account has a unique
     /// identity within the instruction context.
     #[inline(always)]
-    pub fn remaining_accounts(&self) -> RemainingAccounts<'info> {
+    pub fn remaining_accounts(&self) -> RemainingAccounts<'input> {
         RemainingAccounts::new(self.remaining_ptr, self.accounts_boundary, self.declared)
     }
 
@@ -167,7 +162,7 @@ impl<'info, T: ParseAccounts<'info> + ParseAccountsUnchecked<'info> + AccountCou
     /// for CPI forwarding scenarios. Prefer `remaining_accounts()` unless you
     /// explicitly need Solana's raw duplicate-meta behavior.
     #[inline(always)]
-    pub fn remaining_accounts_passthrough(&self) -> RemainingAccounts<'info> {
+    pub fn remaining_accounts_passthrough(&self) -> RemainingAccounts<'input> {
         RemainingAccounts::new_passthrough(
             self.remaining_ptr,
             self.accounts_boundary,

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -50,7 +50,7 @@ pub struct Context<'input> {
 ///
 /// Use [`CtxWithRemaining`] for instructions that need
 /// `remaining_accounts()`.
-pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
+pub struct Ctx<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -64,7 +64,9 @@ pub struct Ctx<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount>
     pub data: &'input [u8],
 }
 
-impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'input, T> {
+impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount>
+    Ctx<'input, T>
+{
     #[inline(always)]
     pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };
@@ -92,7 +94,10 @@ impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> Ctx<'inpu
 /// when inspecting trailing accounts in local logic, or
 /// `remaining_accounts_passthrough()` when forwarding a variable number of
 /// accounts to a downstream CPI.
-pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> {
+pub struct CtxWithRemaining<
+    'input,
+    T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount,
+> {
     /// Validated and typed account struct.
     pub accounts: T,
 
@@ -115,7 +120,9 @@ pub struct CtxWithRemaining<'input, T: ParseAccounts + ParseAccountsUnchecked + 
     accounts_boundary: *const u8,
 }
 
-impl<'input, T: ParseAccounts + ParseAccountsUnchecked + AccountCount> CtxWithRemaining<'input, T> {
+impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + AccountCount>
+    CtxWithRemaining<'input, T>
+{
     #[inline(always)]
     pub fn new(ctx: Context<'input>) -> Result<Self, ProgramError> {
         let program_id_addr = unsafe { as_address(ctx.program_id) };

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -121,10 +121,10 @@ pub trait AccountCount {
 ///
 /// Returns the parsed struct and a `Bumps` companion containing any PDA bump
 /// seeds discovered during validation.
-pub trait ParseAccounts<'info>: Sized {
+pub trait ParseAccounts: Sized {
     type Bumps: Copy;
     fn parse(
-        accounts: &'info mut [AccountView],
+        accounts: &mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -137,8 +137,8 @@ pub trait ParseAccounts<'info>: Sized {
     /// The default implementation ignores `data` and delegates to `parse`.
     #[inline(always)]
     fn parse_with_instruction_data(
-        accounts: &'info mut [AccountView],
-        _data: &'info [u8],
+        accounts: &mut [AccountView],
+        _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
         Self::parse(accounts, program_id)
@@ -178,12 +178,12 @@ pub trait ParseAccounts<'info>: Sized {
 ///
 /// The caller must ensure `accounts.len() == Self::COUNT`.
 #[doc(hidden)]
-pub unsafe trait ParseAccountsUnchecked<'info>: ParseAccounts<'info> {
+pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
     /// # Safety
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
     unsafe fn parse_unchecked(
-        accounts: &'info mut [AccountView],
+        accounts: &mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -192,8 +192,8 @@ pub unsafe trait ParseAccountsUnchecked<'info>: ParseAccounts<'info> {
     /// `accounts.len()` must exactly match `Self::COUNT`.
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
-        accounts: &'info mut [AccountView],
-        _data: &'info [u8],
+        accounts: &mut [AccountView],
+        _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
         Self::parse_unchecked(accounts, program_id)

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -121,10 +121,10 @@ pub trait AccountCount {
 ///
 /// Returns the parsed struct and a `Bumps` companion containing any PDA bump
 /// seeds discovered during validation.
-pub trait ParseAccounts: Sized {
+pub trait ParseAccounts<'input>: Sized {
     type Bumps: Copy;
     fn parse(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -137,7 +137,7 @@ pub trait ParseAccounts: Sized {
     /// The default implementation ignores `data` and delegates to `parse`.
     #[inline(always)]
     fn parse_with_instruction_data(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
@@ -178,12 +178,12 @@ pub trait ParseAccounts: Sized {
 ///
 /// The caller must ensure `accounts.len() == Self::COUNT`.
 #[doc(hidden)]
-pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
+pub unsafe trait ParseAccountsUnchecked<'input>: ParseAccounts<'input> {
     /// # Safety
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
     unsafe fn parse_unchecked(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -192,7 +192,7 @@ pub unsafe trait ParseAccountsUnchecked: ParseAccounts {
     /// `accounts.len()` must exactly match `Self::COUNT`.
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
-        accounts: &mut [AccountView],
+        accounts: &'input mut [AccountView],
         _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {

--- a/lang/tests/compile_fail/account_reference_field.rs
+++ b/lang/tests/compile_fail/account_reference_field.rs
@@ -1,0 +1,10 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct BadAccountField<'account> {
+    #[account(mut)]
+    pub signer: &'account mut Signer,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/account_reference_field.stderr
+++ b/lang/tests/compile_fail/account_reference_field.stderr
@@ -1,0 +1,6 @@
+error: Reference types are not supported
+ --> tests/compile_fail/account_reference_field.rs:6:5
+  |
+6 | /     #[account(mut)]
+7 | |     pub signer: &'account mut Signer,
+  | |____________________________________^

--- a/lang/tests/compile_fail/accounts_type_generic.rs
+++ b/lang/tests/compile_fail/accounts_type_generic.rs
@@ -1,0 +1,10 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct BadGenericAccount<'info, T> {
+    pub signer: &'info Signer,
+    pub _marker: core::marker::PhantomData<T>,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/accounts_type_generic.rs
+++ b/lang/tests/compile_fail/accounts_type_generic.rs
@@ -2,8 +2,8 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct BadGenericAccount<'info, T> {
-    pub signer: &'info Signer,
+pub struct BadGenericAccount<T> {
+    pub signer: Signer,
     pub _marker: core::marker::PhantomData<T>,
 }
 

--- a/lang/tests/compile_fail/accounts_type_generic.stderr
+++ b/lang/tests/compile_fail/accounts_type_generic.stderr
@@ -1,0 +1,5 @@
+error: #[derive(Accounts)] only supports lifetime parameters; type parameters are not supported
+ --> tests/compile_fail/accounts_type_generic.rs:5:37
+  |
+5 | pub struct BadGenericAccount<'info, T> {
+  |                                     ^

--- a/lang/tests/compile_fail/accounts_type_generic.stderr
+++ b/lang/tests/compile_fail/accounts_type_generic.stderr
@@ -1,5 +1,5 @@
 error: #[derive(Accounts)] only supports lifetime parameters; type parameters are not supported
- --> tests/compile_fail/accounts_type_generic.rs:5:37
+ --> tests/compile_fail/accounts_type_generic.rs:5:30
   |
-5 | pub struct BadGenericAccount<'info, T> {
-  |                                     ^
+5 | pub struct BadGenericAccount<T> {
+  |                              ^

--- a/lang/tests/compile_fail/close_mint.rs
+++ b/lang/tests/compile_fail/close_mint.rs
@@ -5,10 +5,11 @@ use quasar_spl::Mint;
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadCloseMint<'info> {
-    pub destination: &'info mut UncheckedAccount,
-    #[account(close = destination)]
-    pub mint: &'info mut Account<Mint>,
+pub struct BadCloseMint {
+    #[account(mut)]
+    pub destination: UncheckedAccount,
+    #[account(mut, close = destination)]
+    pub mint: Account<Mint>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/close_mint.stderr
+++ b/lang/tests/compile_fail/close_mint.stderr
@@ -1,5 +1,5 @@
 error: #[account(close)] cannot be used on mint accounts. Mint closing is not supported through the token-account close path.
-  --> tests/compile_fail/close_mint.rs:11:9
+  --> tests/compile_fail/close_mint.rs:12:9
    |
-11 |     pub mint: &'info mut Account<Mint>,
+12 |     pub mint: Account<Mint>,
    |         ^^^^

--- a/lang/tests/compile_fail/instruction_vec_alignment.rs
+++ b/lang/tests/compile_fail/instruction_vec_alignment.rs
@@ -6,8 +6,8 @@ solana_address::declare_id!("11111111111111111111111111111112");
 type Vec<T, const N: usize> = quasar_lang::dynamic::Vec<T, u32, N>;
 
 #[derive(Accounts)]
-pub struct Test<'info> {
-    pub signer: &'info Signer,
+pub struct Test {
+    pub signer: Signer,
 }
 
 #[instruction(discriminator = 0)]

--- a/lang/tests/compile_fail/metadata_bad_rent.rs
+++ b/lang/tests/compile_fail/metadata_bad_rent.rs
@@ -5,10 +5,12 @@ use quasar_spl::{metadata::MetadataProgram, Mint, Token};
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadMetadataRent<'info> {
-    pub payer: &'info mut Signer,
-    pub mint_authority: &'info Signer,
+pub struct BadMetadataRent {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint_authority: Signer,
     #[account(
+        mut,
         init,
         payer = payer,
         mint::decimals = 0,
@@ -17,12 +19,13 @@ pub struct BadMetadataRent<'info> {
         metadata::symbol = b"TNFT",
         metadata::uri = b"https://example.com/nft.json",
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub metadata: &'info mut UncheckedAccount,
-    pub metadata_program: &'info Program<MetadataProgram>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub rent: &'info UncheckedAccount,
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub metadata: UncheckedAccount,
+    pub metadata_program: Program<MetadataProgram>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub rent: UncheckedAccount,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/multi_token_program_missing_mint_selector.rs
+++ b/lang/tests/compile_fail/multi_token_program_missing_mint_selector.rs
@@ -5,19 +5,21 @@ use quasar_spl::{Mint, Token, Token2022};
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadMintProgramSelector<'info> {
-    pub payer: &'info mut Signer,
-    pub mint_authority: &'info Signer,
+pub struct BadMintProgramSelector {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint_authority: Signer,
     #[account(
+        mut,
         init,
         payer = payer,
         mint::decimals = 6,
         mint::authority = mint_authority,
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub token_program_2022: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub token_program_2022: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/multi_token_program_missing_mint_selector.stderr
+++ b/lang/tests/compile_fail/multi_token_program_missing_mint_selector.stderr
@@ -1,5 +1,5 @@
 error: Multiple token program fields detected. `mint::token_program = <field>` is required for `mint::*` / `master_edition::*` on this field when more than one token program field is present.
-  --> tests/compile_fail/multi_token_program_missing_mint_selector.rs:17:9
+  --> tests/compile_fail/multi_token_program_missing_mint_selector.rs:19:9
    |
-17 |     pub mint: &'info mut Account<Mint>,
+19 |     pub mint: Account<Mint>,
    |         ^^^^

--- a/lang/tests/compile_fail/multi_token_program_missing_token_selector.rs
+++ b/lang/tests/compile_fail/multi_token_program_missing_token_selector.rs
@@ -5,20 +5,22 @@ use quasar_spl::{Mint, Token, Token2022};
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadTokenProgramSelector<'info> {
-    pub payer: &'info mut Signer,
-    pub authority: &'info Signer,
-    pub mint: &'info Account<Mint>,
+pub struct BadTokenProgramSelector {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    pub mint: Account<Mint>,
     #[account(
+        mut,
         init,
         payer = payer,
         token::mint = mint,
         token::authority = authority,
     )]
-    pub token: &'info mut Account<Token>,
-    pub token_program: &'info Program<Token>,
-    pub token_program_2022: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+    pub token: Account<Token>,
+    pub token_program: Program<Token>,
+    pub token_program_2022: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/multi_token_program_missing_token_selector.stderr
+++ b/lang/tests/compile_fail/multi_token_program_missing_token_selector.stderr
@@ -1,5 +1,5 @@
 error: Multiple token program fields detected. `token::token_program = <field>` is required for `token::*` on this field when more than one token program field is present.
-  --> tests/compile_fail/multi_token_program_missing_token_selector.rs:18:9
+  --> tests/compile_fail/multi_token_program_missing_token_selector.rs:20:9
    |
-18 |     pub token: &'info mut Account<Token>,
+20 |     pub token: Account<Token>,
    |         ^^^^^

--- a/lang/tests/compile_fail/realloc_bad_optional.rs
+++ b/lang/tests/compile_fail/realloc_bad_optional.rs
@@ -9,11 +9,12 @@ pub struct DemoAccount {
 }
 
 #[derive(Accounts)]
-pub struct BadReallocOptional<'info> {
-    #[account(realloc = 64)]
-    pub account: Option<&'info mut Account<DemoAccount>>,
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct BadReallocOptional {
+    #[account(mut, realloc = 64)]
+    pub account: Option<Account<DemoAccount>>,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/realloc_bad_optional.stderr
+++ b/lang/tests/compile_fail/realloc_bad_optional.stderr
@@ -1,5 +1,5 @@
 error: #[account(realloc)] cannot be used on Option<Account<T>> fields
   --> tests/compile_fail/realloc_bad_optional.rs:14:9
    |
-14 |     pub account: Option<&'info mut Account<DemoAccount>>,
+14 |     pub account: Option<Account<DemoAccount>>,
    |         ^^^^^^^

--- a/lang/tests/compile_fail/realloc_bad_signer.rs
+++ b/lang/tests/compile_fail/realloc_bad_signer.rs
@@ -4,11 +4,12 @@ use quasar_lang::prelude::*;
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadReallocSigner<'info> {
-    #[account(realloc = 64)]
-    pub account: &'info mut Signer,
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct BadReallocSigner {
+    #[account(mut, realloc = 64)]
+    pub account: Signer,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/realloc_bad_signer.stderr
+++ b/lang/tests/compile_fail/realloc_bad_signer.stderr
@@ -1,5 +1,5 @@
 error: #[account(realloc)] is only valid on Account<T> fields
  --> tests/compile_fail/realloc_bad_signer.rs:9:9
   |
-9 |     pub account: &'info mut Signer,
+9 |     pub account: Signer,
   |         ^^^^^^^

--- a/lang/tests/compile_fail/realloc_bad_unchecked.rs
+++ b/lang/tests/compile_fail/realloc_bad_unchecked.rs
@@ -4,11 +4,12 @@ use quasar_lang::prelude::*;
 solana_address::declare_id!("11111111111111111111111111111112");
 
 #[derive(Accounts)]
-pub struct BadReallocUnchecked<'info> {
-    #[account(realloc = 64)]
-    pub account: &'info mut UncheckedAccount,
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct BadReallocUnchecked {
+    #[account(mut, realloc = 64)]
+    pub account: UncheckedAccount,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/realloc_bad_unchecked.stderr
+++ b/lang/tests/compile_fail/realloc_bad_unchecked.stderr
@@ -1,5 +1,5 @@
 error: #[account(realloc)] is only valid on Account<T> fields
  --> tests/compile_fail/realloc_bad_unchecked.rs:9:9
   |
-9 |     pub account: &'info mut UncheckedAccount,
+9 |     pub account: UncheckedAccount,
   |         ^^^^^^^

--- a/lang/tests/compile_fail/seeds_raw_on_account.rs
+++ b/lang/tests/compile_fail/seeds_raw_on_account.rs
@@ -9,9 +9,9 @@ pub struct Config {
 }
 
 #[derive(Accounts)]
-pub struct Bad<'info> {
+pub struct Bad {
     #[account(seeds = [b"config"], bump = config.bump)]
-    pub config: &'info Account<Config>,
+    pub config: Account<Config>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/seeds_raw_on_account.stderr
+++ b/lang/tests/compile_fail/seeds_raw_on_account.stderr
@@ -1,5 +1,5 @@
 error: raw `seeds = [...]` is not allowed on program accounts. Add `#[seeds(...)]` to `Config` and use `Config::seeds(...)` instead.
   --> tests/compile_fail/seeds_raw_on_account.rs:14:9
    |
-14 |     pub config: &'info Account<Config>,
+14 |     pub config: Account<Config>,
    |         ^^^^^^

--- a/lang/tests/compile_fail/seeds_wrong_arity.rs
+++ b/lang/tests/compile_fail/seeds_wrong_arity.rs
@@ -12,10 +12,10 @@ pub struct Vault {
 }
 
 #[derive(Accounts)]
-pub struct Bad<'info> {
-    pub authority: &'info Signer,
+pub struct Bad {
+    pub authority: Signer,
     #[account(seeds = Vault::seeds(), bump = vault.bump)]
-    pub vault: &'info Account<Vault>,
+    pub vault: Account<Vault>,
 }
 
 fn main() {}

--- a/lang/tests/compile_fail/seeds_wrong_arity.stderr
+++ b/lang/tests/compile_fail/seeds_wrong_arity.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation panicked: Vault::seeds() argument count mismatch (check
   --> tests/compile_fail/seeds_wrong_arity.rs:14:10
    |
 14 | #[derive(Accounts)]
-   |          ^^^^^^^^ evaluation of `<Bad<'info> as quasar_lang::traits::ParseAccountsUnchecked<'info>>::parse_unchecked::_` failed here
+   |          ^^^^^^^^ evaluation of `<Bad<'info> as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_unchecked::_` failed here

--- a/lang/tests/compile_fail/seeds_wrong_arity.stderr
+++ b/lang/tests/compile_fail/seeds_wrong_arity.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation panicked: Vault::seeds() argument count mismatch (check
   --> tests/compile_fail/seeds_wrong_arity.rs:14:10
    |
 14 | #[derive(Accounts)]
-   |          ^^^^^^^^ evaluation of `<Bad<'info> as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_unchecked::_` failed here
+   |          ^^^^^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_unchecked::_` failed here

--- a/lang/tests/parse_accounts.rs
+++ b/lang/tests/parse_accounts.rs
@@ -49,6 +49,12 @@ struct OnlySigner<'info> {
     signer: &'info mut Signer,
 }
 
+#[derive(Accounts)]
+struct MixedLifetimes<'signer, 'readonly> {
+    signer: &'signer mut Signer,
+    readonly_signer: &'readonly Signer,
+}
+
 #[test]
 fn parse_accounts_rejects_too_few_non_composite_accounts() {
     let mut accounts: [AccountView; 0] = [];
@@ -72,4 +78,25 @@ fn parse_accounts_rejects_extra_non_composite_accounts() {
         Err(err) => err,
     };
     assert_eq!(err, ProgramError::InvalidArgument);
+}
+
+#[test]
+fn parse_accounts_accepts_fields_with_different_lifetimes() {
+    let mut first = AccountBuffer::new();
+    first.init_signer(1);
+    let mut second = AccountBuffer::new();
+    second.init_signer(2);
+    let mut accounts = unsafe { [first.view(), second.view()] };
+
+    let (parsed, _) = MixedLifetimes::parse(&mut accounts, &Address::default())
+        .expect("parse should accept distinct field lifetimes");
+
+    assert_eq!(
+        parsed.signer.to_account_view().address(),
+        &Address::from([1; 32])
+    );
+    assert_eq!(
+        parsed.readonly_signer.to_account_view().address(),
+        &Address::from([2; 32])
+    );
 }

--- a/lang/tests/parse_accounts.rs
+++ b/lang/tests/parse_accounts.rs
@@ -45,14 +45,9 @@ impl AccountBuffer {
 }
 
 #[derive(Accounts)]
-struct OnlySigner<'info> {
-    signer: &'info mut Signer,
-}
-
-#[derive(Accounts)]
-struct MixedLifetimes<'signer, 'readonly> {
-    signer: &'signer mut Signer,
-    readonly_signer: &'readonly Signer,
+struct OnlySigner {
+    #[account(mut)]
+    signer: Signer,
 }
 
 #[test]
@@ -78,25 +73,4 @@ fn parse_accounts_rejects_extra_non_composite_accounts() {
         Err(err) => err,
     };
     assert_eq!(err, ProgramError::InvalidArgument);
-}
-
-#[test]
-fn parse_accounts_accepts_fields_with_different_lifetimes() {
-    let mut first = AccountBuffer::new();
-    first.init_signer(1);
-    let mut second = AccountBuffer::new();
-    second.init_signer(2);
-    let mut accounts = unsafe { [first.view(), second.view()] };
-
-    let (parsed, _) = MixedLifetimes::parse(&mut accounts, &Address::default())
-        .expect("parse should accept distinct field lifetimes");
-
-    assert_eq!(
-        parsed.signer.to_account_view().address(),
-        &Address::from([1; 32])
-    );
-    assert_eq!(
-        parsed.readonly_signer.to_account_view().address(),
-        &Address::from([2; 32])
-    );
 }

--- a/tests/programs/test-errors/src/instructions/account_check.rs
+++ b/tests/programs/test-errors/src/instructions/account_check.rs
@@ -1,11 +1,11 @@
 use {crate::state::ErrorTestAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct AccountCheckIx<'info> {
-    pub account: &'info Account<ErrorTestAccount>,
+pub struct AccountCheckIx {
+    pub account: Account<ErrorTestAccount>,
 }
 
-impl<'info> AccountCheckIx<'info> {
+impl AccountCheckIx {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/address_custom_error.rs
+++ b/tests/programs/test-errors/src/instructions/address_custom_error.rs
@@ -6,12 +6,12 @@ use {
 pub const EXPECTED_ADDR: Address = Address::new_from_array([99u8; 32]);
 
 #[derive(Accounts)]
-pub struct AddressCustomError<'info> {
+pub struct AddressCustomError {
     #[account(address = EXPECTED_ADDR @ TestError::AddressCustom)]
-    pub target: &'info Account<ErrorTestAccount>,
+    pub target: Account<ErrorTestAccount>,
 }
 
-impl<'info> AddressCustomError<'info> {
+impl AddressCustomError {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/address_default.rs
+++ b/tests/programs/test-errors/src/instructions/address_default.rs
@@ -3,12 +3,12 @@ use {crate::state::ErrorTestAccount, quasar_lang::prelude::*};
 pub const EXPECTED_ADDR_DEFAULT: Address = Address::new_from_array([88u8; 32]);
 
 #[derive(Accounts)]
-pub struct AddressDefault<'info> {
+pub struct AddressDefault {
     #[account(address = EXPECTED_ADDR_DEFAULT)]
-    pub target: &'info Account<ErrorTestAccount>,
+    pub target: Account<ErrorTestAccount>,
 }
 
-impl<'info> AddressDefault<'info> {
+impl AddressDefault {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/constraint_default.rs
+++ b/tests/programs/test-errors/src/instructions/constraint_default.rs
@@ -1,12 +1,12 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct ConstraintDefault<'info> {
+pub struct ConstraintDefault {
     #[account(constraint = false)]
-    pub target: &'info SystemAccount,
+    pub target: SystemAccount,
 }
 
-impl<'info> ConstraintDefault<'info> {
+impl ConstraintDefault {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/constraint_fail.rs
+++ b/tests/programs/test-errors/src/instructions/constraint_fail.rs
@@ -1,12 +1,12 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct ConstraintFail<'info> {
+pub struct ConstraintFail {
     #[account(constraint = false @ TestError::ConstraintCustom)]
-    pub target: &'info SystemAccount,
+    pub target: SystemAccount,
 }
 
-impl<'info> ConstraintFail<'info> {
+impl ConstraintFail {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/custom_error.rs
+++ b/tests/programs/test-errors/src/instructions/custom_error.rs
@@ -1,11 +1,11 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct CustomError<'info> {
-    pub signer: &'info Signer,
+pub struct CustomError {
+    pub signer: Signer,
 }
 
-impl<'info> CustomError<'info> {
+impl CustomError {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Err(TestError::Hello.into())

--- a/tests/programs/test-errors/src/instructions/explicit_error.rs
+++ b/tests/programs/test-errors/src/instructions/explicit_error.rs
@@ -1,11 +1,11 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct ExplicitError<'info> {
-    pub signer: &'info Signer,
+pub struct ExplicitError {
+    pub signer: Signer,
 }
 
-impl<'info> ExplicitError<'info> {
+impl ExplicitError {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Err(TestError::ExplicitNum.into())

--- a/tests/programs/test-errors/src/instructions/has_one_custom.rs
+++ b/tests/programs/test-errors/src/instructions/has_one_custom.rs
@@ -4,13 +4,13 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct HasOneCustom<'info> {
-    pub authority: &'info Signer,
+pub struct HasOneCustom {
+    pub authority: Signer,
     #[account(has_one = authority @ TestError::Hello)]
-    pub account: &'info Account<ErrorTestAccount>,
+    pub account: Account<ErrorTestAccount>,
 }
 
-impl<'info> HasOneCustom<'info> {
+impl HasOneCustom {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/has_one_default.rs
+++ b/tests/programs/test-errors/src/instructions/has_one_default.rs
@@ -1,13 +1,13 @@
 use {crate::state::ErrorTestAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct HasOneDefault<'info> {
-    pub authority: &'info Signer,
+pub struct HasOneDefault {
+    pub authority: Signer,
     #[account(has_one = authority)]
-    pub account: &'info Account<ErrorTestAccount>,
+    pub account: Account<ErrorTestAccount>,
 }
 
-impl<'info> HasOneDefault<'info> {
+impl HasOneDefault {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_dup_readonly.rs
+++ b/tests/programs/test-errors/src/instructions/header_dup_readonly.rs
@@ -2,15 +2,15 @@ use quasar_lang::prelude::*;
 
 /// Tests: duplicate readonly aliases are accepted when explicitly annotated.
 #[derive(Accounts)]
-pub struct HeaderDupReadonly<'info> {
-    pub source: &'info Signer,
+pub struct HeaderDupReadonly {
+    pub source: Signer,
     /// CHECK: test-only — validates that duplicate readonly aliases are parsed
     /// correctly.
     #[account(dup)]
-    pub destination: &'info UncheckedAccount,
+    pub destination: UncheckedAccount,
 }
 
-impl<'info> HeaderDupReadonly<'info> {
+impl HeaderDupReadonly {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_dup_signer.rs
+++ b/tests/programs/test-errors/src/instructions/header_dup_signer.rs
@@ -2,15 +2,16 @@ use quasar_lang::prelude::*;
 
 /// Tests: "Account 'authority' (index 1): must be signer"
 #[derive(Accounts)]
-pub struct HeaderDupSigner<'info> {
-    pub payer: &'info mut Signer,
+pub struct HeaderDupSigner {
+    #[account(mut)]
+    pub payer: Signer,
     /// CHECK: test-only — validates that dup signer accounts are parsed
     /// correctly.
     #[account(dup)]
-    pub authority: &'info Signer,
+    pub authority: Signer,
 }
 
-impl<'info> HeaderDupSigner<'info> {
+impl HeaderDupSigner {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_executable.rs
+++ b/tests/programs/test-errors/src/instructions/header_executable.rs
@@ -3,11 +3,11 @@ use quasar_lang::prelude::*;
 /// Tests: "Account 'program' (index 0): must be executable program with no
 /// duplicates"
 #[derive(Accounts)]
-pub struct HeaderExecutable<'info> {
-    pub program: &'info Program<System>,
+pub struct HeaderExecutable {
+    pub program: Program<System>,
 }
 
-impl<'info> HeaderExecutable<'info> {
+impl HeaderExecutable {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_nodup_mut.rs
+++ b/tests/programs/test-errors/src/instructions/header_nodup_mut.rs
@@ -2,11 +2,12 @@ use quasar_lang::prelude::*;
 
 /// Tests: "Account 'account' (index 0): must be writable with no duplicates"
 #[derive(Accounts)]
-pub struct HeaderNoDupMut<'info> {
-    pub account: &'info mut UncheckedAccount,
+pub struct HeaderNoDupMut {
+    #[account(mut)]
+    pub account: UncheckedAccount,
 }
 
-impl<'info> HeaderNoDupMut<'info> {
+impl HeaderNoDupMut {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_nodup_mut_signer.rs
+++ b/tests/programs/test-errors/src/instructions/header_nodup_mut_signer.rs
@@ -3,11 +3,12 @@ use quasar_lang::prelude::*;
 /// Tests: "Account 'account' (index 0): must be writable signer with no
 /// duplicates"
 #[derive(Accounts)]
-pub struct HeaderNoDupMutSigner<'info> {
-    pub account: &'info mut Signer,
+pub struct HeaderNoDupMutSigner {
+    #[account(mut)]
+    pub account: Signer,
 }
 
-impl<'info> HeaderNoDupMutSigner<'info> {
+impl HeaderNoDupMutSigner {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/header_nodup_signer.rs
+++ b/tests/programs/test-errors/src/instructions/header_nodup_signer.rs
@@ -2,11 +2,11 @@ use quasar_lang::prelude::*;
 
 /// Tests: "Account 'account' (index 0): must be signer with no duplicates"
 #[derive(Accounts)]
-pub struct HeaderNoDupSigner<'info> {
-    pub account: &'info Signer,
+pub struct HeaderNoDupSigner {
+    pub account: Signer,
 }
 
-impl<'info> HeaderNoDupSigner<'info> {
+impl HeaderNoDupSigner {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/mut_account_check.rs
+++ b/tests/programs/test-errors/src/instructions/mut_account_check.rs
@@ -1,12 +1,12 @@
 use {crate::state::ErrorTestAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct MutAccountCheck<'info> {
+pub struct MutAccountCheck {
     #[account(mut)]
-    pub account: &'info Account<ErrorTestAccount>,
+    pub account: Account<ErrorTestAccount>,
 }
 
-impl<'info> MutAccountCheck<'info> {
+impl MutAccountCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/program_check.rs
+++ b/tests/programs/test-errors/src/instructions/program_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct ProgramCheck<'info> {
-    pub program: &'info Program<System>,
+pub struct ProgramCheck {
+    pub program: Program<System>,
 }
 
-impl<'info> ProgramCheck<'info> {
+impl ProgramCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/program_error.rs
+++ b/tests/programs/test-errors/src/instructions/program_error.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct ProgramErrorIx<'info> {
-    pub signer: &'info Signer,
+pub struct ProgramErrorIx {
+    pub signer: Signer,
 }
 
-impl<'info> ProgramErrorIx<'info> {
+impl ProgramErrorIx {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Err(ProgramError::InvalidAccountData)

--- a/tests/programs/test-errors/src/instructions/require_eq_check.rs
+++ b/tests/programs/test-errors/src/instructions/require_eq_check.rs
@@ -1,11 +1,11 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct RequireEqCheck<'info> {
-    pub signer: &'info Signer,
+pub struct RequireEqCheck {
+    pub signer: Signer,
 }
 
-impl<'info> RequireEqCheck<'info> {
+impl RequireEqCheck {
     #[inline(always)]
     pub fn handler(&self, a: u64, b: u64) -> Result<(), ProgramError> {
         require_eq!(a, b, TestError::RequireEqFailed);

--- a/tests/programs/test-errors/src/instructions/require_false.rs
+++ b/tests/programs/test-errors/src/instructions/require_false.rs
@@ -1,11 +1,11 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct RequireFalse<'info> {
-    pub signer: &'info Signer,
+pub struct RequireFalse {
+    pub signer: Signer,
 }
 
-impl<'info> RequireFalse<'info> {
+impl RequireFalse {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         require!(false, TestError::RequireFailed);

--- a/tests/programs/test-errors/src/instructions/require_neq_check.rs
+++ b/tests/programs/test-errors/src/instructions/require_neq_check.rs
@@ -1,11 +1,11 @@
 use {crate::errors::TestError, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct RequireNeqCheck<'info> {
-    pub signer: &'info Signer,
+pub struct RequireNeqCheck {
+    pub signer: Signer,
 }
 
-impl<'info> RequireNeqCheck<'info> {
+impl RequireNeqCheck {
     #[inline(always)]
     pub fn handler(&self, a: u64, b: u64) -> Result<(), ProgramError> {
         require!(a != b, TestError::RequireEqFailed);

--- a/tests/programs/test-errors/src/instructions/signer_mut_check.rs
+++ b/tests/programs/test-errors/src/instructions/signer_mut_check.rs
@@ -1,11 +1,12 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SignerMutCheck<'info> {
-    pub signer: &'info mut Signer,
+pub struct SignerMutCheck {
+    #[account(mut)]
+    pub signer: Signer,
 }
 
-impl<'info> SignerMutCheck<'info> {
+impl SignerMutCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/signer_needed.rs
+++ b/tests/programs/test-errors/src/instructions/signer_needed.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SignerNeeded<'info> {
-    pub signer: &'info Signer,
+pub struct SignerNeeded {
+    pub signer: Signer,
 }
 
-impl<'info> SignerNeeded<'info> {
+impl SignerNeeded {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/signer_readonly_check.rs
+++ b/tests/programs/test-errors/src/instructions/signer_readonly_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SignerReadonlyCheck<'info> {
-    pub signer: &'info Signer,
+pub struct SignerReadonlyCheck {
+    pub signer: Signer,
 }
 
-impl<'info> SignerReadonlyCheck<'info> {
+impl SignerReadonlyCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/system_account_check.rs
+++ b/tests/programs/test-errors/src/instructions/system_account_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SystemAccountCheck<'info> {
-    pub account: &'info SystemAccount,
+pub struct SystemAccountCheck {
+    pub account: SystemAccount,
 }
 
-impl<'info> SystemAccountCheck<'info> {
+impl SystemAccountCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/three_accounts_dup.rs
+++ b/tests/programs/test-errors/src/instructions/three_accounts_dup.rs
@@ -1,13 +1,14 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct ThreeAccountsDup<'info> {
-    pub first: &'info Signer,
-    pub second: &'info mut UncheckedAccount,
-    pub third: &'info UncheckedAccount,
+pub struct ThreeAccountsDup {
+    pub first: Signer,
+    #[account(mut)]
+    pub second: UncheckedAccount,
+    pub third: UncheckedAccount,
 }
 
-impl<'info> ThreeAccountsDup<'info> {
+impl ThreeAccountsDup {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/two_accounts_check.rs
+++ b/tests/programs/test-errors/src/instructions/two_accounts_check.rs
@@ -1,12 +1,12 @@
 use {crate::state::ErrorTestAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct TwoAccountsCheck<'info> {
-    pub first: &'info Account<ErrorTestAccount>,
-    pub second: &'info Account<ErrorTestAccount>,
+pub struct TwoAccountsCheck {
+    pub first: Account<ErrorTestAccount>,
+    pub second: Account<ErrorTestAccount>,
 }
 
-impl<'info> TwoAccountsCheck<'info> {
+impl TwoAccountsCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-errors/src/instructions/unchecked_account_check.rs
+++ b/tests/programs/test-errors/src/instructions/unchecked_account_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct UncheckedAccountCheck<'info> {
-    pub account: &'info UncheckedAccount,
+pub struct UncheckedAccountCheck {
+    pub account: UncheckedAccount,
 }
 
-impl<'info> UncheckedAccountCheck<'info> {
+impl UncheckedAccountCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-events/src/instructions/emit_address_event.rs
+++ b/tests/programs/test-events/src/instructions/emit_address_event.rs
@@ -1,11 +1,11 @@
 use {crate::events::AddressEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitAddressEvent<'info> {
-    pub signer: &'info Signer,
+pub struct EmitAddressEvent {
+    pub signer: Signer,
 }
 
-impl<'info> EmitAddressEvent<'info> {
+impl EmitAddressEvent {
     #[inline(always)]
     pub fn handler(&self, addr: Address, value: u64) -> Result<(), ProgramError> {
         emit!(AddressEvent { addr, value });

--- a/tests/programs/test-events/src/instructions/emit_bool_event.rs
+++ b/tests/programs/test-events/src/instructions/emit_bool_event.rs
@@ -1,11 +1,11 @@
 use {crate::events::BoolEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitBoolEvent<'info> {
-    pub signer: &'info Signer,
+pub struct EmitBoolEvent {
+    pub signer: Signer,
 }
 
-impl<'info> EmitBoolEvent<'info> {
+impl EmitBoolEvent {
     #[inline(always)]
     pub fn handler(&self, flag: bool) -> Result<(), ProgramError> {
         emit!(BoolEvent { flag });

--- a/tests/programs/test-events/src/instructions/emit_empty_event.rs
+++ b/tests/programs/test-events/src/instructions/emit_empty_event.rs
@@ -1,11 +1,11 @@
 use {crate::events::EmptyEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitEmptyEvent<'info> {
-    pub signer: &'info Signer,
+pub struct EmitEmptyEvent {
+    pub signer: Signer,
 }
 
-impl<'info> EmitEmptyEvent<'info> {
+impl EmitEmptyEvent {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         emit!(EmptyEvent {});

--- a/tests/programs/test-events/src/instructions/emit_large_event.rs
+++ b/tests/programs/test-events/src/instructions/emit_large_event.rs
@@ -1,11 +1,11 @@
 use {crate::events::LargeEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitLargeEvent<'info> {
-    pub signer: &'info Signer,
+pub struct EmitLargeEvent {
+    pub signer: Signer,
 }
 
-impl<'info> EmitLargeEvent<'info> {
+impl EmitLargeEvent {
     #[inline(always)]
     #[allow(clippy::too_many_arguments)]
     pub fn handler(

--- a/tests/programs/test-events/src/instructions/emit_multi_field.rs
+++ b/tests/programs/test-events/src/instructions/emit_multi_field.rs
@@ -1,11 +1,11 @@
 use {crate::events::MultiEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitMultiField<'info> {
-    pub signer: &'info Signer,
+pub struct EmitMultiField {
+    pub signer: Signer,
 }
 
-impl<'info> EmitMultiField<'info> {
+impl EmitMultiField {
     #[inline(always)]
     pub fn handler(&self, a: u64, b: u64, c: Address) -> Result<(), ProgramError> {
         emit!(MultiEvent { a, b, c });

--- a/tests/programs/test-events/src/instructions/emit_two_events.rs
+++ b/tests/programs/test-events/src/instructions/emit_two_events.rs
@@ -4,11 +4,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct EmitTwoEvents<'info> {
-    pub signer: &'info Signer,
+pub struct EmitTwoEvents {
+    pub signer: Signer,
 }
 
-impl<'info> EmitTwoEvents<'info> {
+impl EmitTwoEvents {
     #[inline(always)]
     pub fn handler(&self, first: u64, second: u64) -> Result<(), ProgramError> {
         emit!(SimpleEvent { value: first });

--- a/tests/programs/test-events/src/instructions/emit_u64_event.rs
+++ b/tests/programs/test-events/src/instructions/emit_u64_event.rs
@@ -1,11 +1,11 @@
 use {crate::events::SimpleEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitU64Event<'info> {
-    pub signer: &'info Signer,
+pub struct EmitU64Event {
+    pub signer: Signer,
 }
 
-impl<'info> EmitU64Event<'info> {
+impl EmitU64Event {
     #[inline(always)]
     pub fn handler(&self, value: u64) -> Result<(), ProgramError> {
         emit!(SimpleEvent { value });

--- a/tests/programs/test-events/src/instructions/emit_via_cpi.rs
+++ b/tests/programs/test-events/src/instructions/emit_via_cpi.rs
@@ -4,13 +4,13 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct EmitViaCpi<'info> {
-    pub signer: &'info Signer,
-    pub event_authority: &'info EventAuthority,
-    pub program: &'info Program<QuasarTestEvents>,
+pub struct EmitViaCpi {
+    pub signer: Signer,
+    pub event_authority: EventAuthority,
+    pub program: Program<QuasarTestEvents>,
 }
 
-impl<'info> EmitViaCpi<'info> {
+impl EmitViaCpi {
     #[inline(always)]
     pub fn handler(&self, value: u64) -> Result<(), ProgramError> {
         emit_cpi!(SimpleEvent { value })?;

--- a/tests/programs/test-heap/src/instructions/emit_event_ok.rs
+++ b/tests/programs/test-heap/src/instructions/emit_event_ok.rs
@@ -1,11 +1,11 @@
 use {crate::events::HeapTestEvent, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct EmitEventOk<'info> {
-    pub signer: &'info Signer,
+pub struct EmitEventOk {
+    pub signer: Signer,
 }
 
-impl<'info> EmitEventOk<'info> {
+impl EmitEventOk {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         emit!(HeapTestEvent { value: 42 });

--- a/tests/programs/test-heap/src/instructions/heap_vec_ok.rs
+++ b/tests/programs/test-heap/src/instructions/heap_vec_ok.rs
@@ -5,11 +5,11 @@ extern crate alloc;
 use {alloc::vec, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct HeapVecOk<'info> {
-    pub signer: &'info Signer,
+pub struct HeapVecOk {
+    pub signer: Signer,
 }
 
-impl<'info> HeapVecOk<'info> {
+impl HeapVecOk {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         #[allow(clippy::useless_vec)]

--- a/tests/programs/test-heap/src/instructions/no_heap_alloc_attempt.rs
+++ b/tests/programs/test-heap/src/instructions/no_heap_alloc_attempt.rs
@@ -6,11 +6,11 @@ extern crate alloc;
 use {alloc::vec, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct NoHeapAllocAttempt<'info> {
-    pub signer: &'info Signer,
+pub struct NoHeapAllocAttempt {
+    pub signer: Signer,
 }
 
-impl<'info> NoHeapAllocAttempt<'info> {
+impl NoHeapAllocAttempt {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         #[allow(clippy::useless_vec)]

--- a/tests/programs/test-heap/src/instructions/no_heap_ok.rs
+++ b/tests/programs/test-heap/src/instructions/no_heap_ok.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct NoHeapOk<'info> {
-    pub signer: &'info Signer,
+pub struct NoHeapOk {
+    pub signer: Signer,
 }
 
-impl<'info> NoHeapOk<'info> {
+impl NoHeapOk {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/assign_test.rs
+++ b/tests/programs/test-misc/src/instructions/assign_test.rs
@@ -1,14 +1,15 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct AssignTest<'info> {
-    pub account: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct AssignTest {
+    #[account(mut)]
+    pub account: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> AssignTest<'info> {
+impl AssignTest {
     #[inline(always)]
     pub fn handler(&self, owner: Address) -> Result<(), ProgramError> {
-        self.system_program.assign(self.account, &owner).invoke()
+        self.system_program.assign(&self.account, &owner).invoke()
     }
 }

--- a/tests/programs/test-misc/src/instructions/check_multi_disc.rs
+++ b/tests/programs/test-misc/src/instructions/check_multi_disc.rs
@@ -1,11 +1,11 @@
 use {crate::state::MultiDiscAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct CheckMultiDisc<'info> {
-    pub account: &'info Account<MultiDiscAccount>,
+pub struct CheckMultiDisc {
+    pub account: Account<MultiDiscAccount>,
 }
 
-impl<'info> CheckMultiDisc<'info> {
+impl CheckMultiDisc {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/close_account.rs
+++ b/tests/programs/test-misc/src/instructions/close_account.rs
@@ -1,18 +1,20 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct CloseAccount<'info> {
-    pub authority: &'info mut Signer,
+pub struct CloseAccount {
+    #[account(mut)]
+    pub authority: Signer,
     #[account(
         has_one = authority,
         close = authority,
         seeds = SimpleAccount::seeds(authority),
         bump = account.bump
     )]
-    pub account: &'info mut Account<SimpleAccount>,
+    #[account(mut)]
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> CloseAccount<'info> {
+impl CloseAccount {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/constraint_check.rs
+++ b/tests/programs/test-misc/src/instructions/constraint_check.rs
@@ -1,12 +1,12 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct ConstraintCheck<'info> {
+pub struct ConstraintCheck {
     #[account(constraint = account.value > 0)]
-    pub account: &'info Account<SimpleAccount>,
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> ConstraintCheck<'info> {
+impl ConstraintCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/constraint_custom_error.rs
+++ b/tests/programs/test-misc/src/instructions/constraint_custom_error.rs
@@ -4,12 +4,12 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ConstraintCustomError<'info> {
+pub struct ConstraintCustomError {
     #[account(constraint = account.value > 0 @ TestError::CustomConstraint)]
-    pub account: &'info Account<SimpleAccount>,
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> ConstraintCustomError<'info> {
+impl ConstraintCustomError {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/cpi_invoke_ignore_return.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_invoke_ignore_return.rs
@@ -1,11 +1,11 @@
 use {crate::state::TestMiscProgram, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct CpiInvokeIgnoreReturn<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct CpiInvokeIgnoreReturn {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> CpiInvokeIgnoreReturn<'info> {
+impl CpiInvokeIgnoreReturn {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         quasar_lang::cpi::CpiCall::<1, 1>::new(

--- a/tests/programs/test-misc/src/instructions/cpi_invoke_missing_return.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_invoke_missing_return.rs
@@ -1,11 +1,11 @@
 use {crate::state::TestMiscProgram, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct CpiInvokeMissingReturn<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct CpiInvokeMissingReturn {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> CpiInvokeMissingReturn<'info> {
+impl CpiInvokeMissingReturn {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         quasar_lang::cpi::CpiCall::<1, 1>::new(

--- a/tests/programs/test-misc/src/instructions/cpi_invoke_struct_return.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_invoke_struct_return.rs
@@ -4,11 +4,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CpiInvokeStructReturn<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct CpiInvokeStructReturn {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> CpiInvokeStructReturn<'info> {
+impl CpiInvokeStructReturn {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         let ret = quasar_lang::cpi::CpiCall::<1, 1>::new(

--- a/tests/programs/test-misc/src/instructions/cpi_invoke_with_return.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_invoke_with_return.rs
@@ -4,11 +4,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CpiInvokeWithReturn<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct CpiInvokeWithReturn {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> CpiInvokeWithReturn<'info> {
+impl CpiInvokeWithReturn {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         let ret = quasar_lang::cpi::CpiCall::<1, 1>::new(

--- a/tests/programs/test-misc/src/instructions/create_account_test.rs
+++ b/tests/programs/test-misc/src/instructions/create_account_test.rs
@@ -1,17 +1,19 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct CreateAccountTest<'info> {
-    pub payer: &'info mut Signer,
-    pub new_account: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct CreateAccountTest {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut)]
+    pub new_account: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> CreateAccountTest<'info> {
+impl CreateAccountTest {
     #[inline(always)]
     pub fn handler(&self, lamports: u64, space: u64, owner: Address) -> Result<(), ProgramError> {
         self.system_program
-            .create_account(self.payer, self.new_account, lamports, space, &owner)
+            .create_account(&self.payer, &self.new_account, lamports, space, &owner)
             .invoke()
     }
 }

--- a/tests/programs/test-misc/src/instructions/double_mut_check.rs
+++ b/tests/programs/test-misc/src/instructions/double_mut_check.rs
@@ -1,15 +1,15 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct DoubleMutCheck<'info> {
-    pub signer: &'info Signer,
+pub struct DoubleMutCheck {
+    pub signer: Signer,
     #[account(mut)]
-    pub account_a: &'info mut Account<SimpleAccount>,
+    pub account_a: Account<SimpleAccount>,
     #[account(mut)]
-    pub account_b: &'info mut Account<SimpleAccount>,
+    pub account_b: Account<SimpleAccount>,
 }
 
-impl<'info> DoubleMutCheck<'info> {
+impl DoubleMutCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/dynamic_account_check.rs
+++ b/tests/programs/test-misc/src/instructions/dynamic_account_check.rs
@@ -1,11 +1,11 @@
 use {crate::state::DynamicAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct DynamicAccountCheck<'info> {
-    pub account: Account<DynamicAccount<'info>>,
+pub struct DynamicAccountCheck<'account> {
+    pub account: Account<DynamicAccount<'account>>,
 }
 
-impl<'info> DynamicAccountCheck<'info> {
+impl DynamicAccountCheck<'_> {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/dynamic_instruction_check.rs
+++ b/tests/programs/test-misc/src/instructions/dynamic_instruction_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct DynamicInstructionCheck<'info> {
-    pub authority: &'info Signer,
+pub struct DynamicInstructionCheck {
+    pub authority: Signer,
 }
 
-impl<'info> DynamicInstructionCheck<'info> {
+impl DynamicInstructionCheck {
     #[inline(always)]
     pub fn handler(&self, _name: &str) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/dynamic_mutate.rs
+++ b/tests/programs/test-misc/src/instructions/dynamic_mutate.rs
@@ -1,18 +1,18 @@
 use {crate::state::DynamicAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct DynamicMutate<'info> {
+pub struct DynamicMutate<'account> {
     #[account(mut)]
-    pub account: Account<DynamicAccount<'info>>,
+    pub account: Account<DynamicAccount<'account>>,
     #[account(mut)]
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> DynamicMutate<'info> {
+impl DynamicMutate<'_> {
     #[inline(always)]
     pub fn handler(&mut self, new_name: &str) -> Result<(), ProgramError> {
-        self.account.set_name(self.payer, new_name)?;
+        self.account.set_name(&self.payer, new_name)?;
         Ok(())
     }
 }

--- a/tests/programs/test-misc/src/instructions/explicit_payer.rs
+++ b/tests/programs/test-misc/src/instructions/explicit_payer.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ExplicitPayer<'info> {
-    pub funder: &'info mut Signer,
-    #[account(init, payer = funder, seeds = ExplicitPayerAccount::seeds(funder), bump)]
-    pub account: &'info mut Account<ExplicitPayerAccount>,
-    pub system_program: &'info Program<System>,
+pub struct ExplicitPayer {
+    #[account(mut)]
+    pub funder: Signer,
+    #[account(mut, init, payer = funder, seeds = ExplicitPayerAccount::seeds(funder), bump)]
+    pub account: Account<ExplicitPayerAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ExplicitPayer<'info> {
+impl ExplicitPayer {
     #[inline(always)]
     pub fn handler(&mut self, value: u64, bumps: &ExplicitPayerBumps) -> Result<(), ProgramError> {
         self.account.set_inner(ExplicitPayerAccountInner {

--- a/tests/programs/test-misc/src/instructions/has_one_and_owner_check.rs
+++ b/tests/programs/test-misc/src/instructions/has_one_and_owner_check.rs
@@ -1,13 +1,13 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct HasOneAndOwnerCheck<'info> {
-    pub authority: &'info Signer,
+pub struct HasOneAndOwnerCheck {
+    pub authority: Signer,
     #[account(has_one = authority)]
-    pub account: &'info Account<SimpleAccount>,
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> HasOneAndOwnerCheck<'info> {
+impl HasOneAndOwnerCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/init_if_needed.rs
+++ b/tests/programs/test-misc/src/instructions/init_if_needed.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeeded<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, payer = payer, seeds = SimpleAccount::seeds(payer), bump)]
-    pub account: &'info mut Account<SimpleAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeeded {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, payer = payer, seeds = SimpleAccount::seeds(payer), bump)]
+    pub account: Account<SimpleAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeeded<'info> {
+impl InitIfNeeded {
     #[inline(always)]
     pub fn handler(&mut self, value: u64, bumps: &InitIfNeededBumps) -> Result<(), ProgramError> {
         self.account.set_inner(SimpleAccountInner {

--- a/tests/programs/test-misc/src/instructions/initialize.rs
+++ b/tests/programs/test-misc/src/instructions/initialize.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitializeSimple<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = SimpleAccount::seeds(payer), bump)]
-    pub account: &'info mut Account<SimpleAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitializeSimple {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = SimpleAccount::seeds(payer), bump)]
+    pub account: Account<SimpleAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitializeSimple<'info> {
+impl InitializeSimple {
     #[inline(always)]
     pub fn handler(
         &mut self,

--- a/tests/programs/test-misc/src/instructions/interface_migration_check.rs
+++ b/tests/programs/test-misc/src/instructions/interface_migration_check.rs
@@ -2,11 +2,11 @@ use {crate::state::VaultInterface, quasar_lang::prelude::*};
 
 /// Accepts either VaultV1 or VaultV2 through a single InterfaceAccount field.
 #[derive(Accounts)]
-pub struct InterfaceMigrationCheck<'info> {
-    pub vault: &'info InterfaceAccount<VaultInterface>,
+pub struct InterfaceMigrationCheck {
+    pub vault: InterfaceAccount<VaultInterface>,
 }
 
-impl<'info> InterfaceMigrationCheck<'info> {
+impl InterfaceMigrationCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/mut_check.rs
+++ b/tests/programs/test-misc/src/instructions/mut_check.rs
@@ -4,12 +4,12 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct MutCheck<'info> {
+pub struct MutCheck {
     #[account(mut)]
-    pub account: &'info mut Account<SimpleAccount>,
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> MutCheck<'info> {
+impl MutCheck {
     #[inline(always)]
     pub fn handler(&mut self, new_value: u64) -> Result<(), ProgramError> {
         let authority = self.account.authority;

--- a/tests/programs/test-misc/src/instructions/mutate_then_readback.rs
+++ b/tests/programs/test-misc/src/instructions/mutate_then_readback.rs
@@ -1,18 +1,18 @@
 use {crate::state::DynamicAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct MutateThenReadback<'info> {
+pub struct MutateThenReadback<'account> {
     #[account(mut)]
-    pub account: Account<DynamicAccount<'info>>,
+    pub account: Account<DynamicAccount<'account>>,
     #[account(mut)]
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> MutateThenReadback<'info> {
+impl MutateThenReadback<'_> {
     #[inline(always)]
     pub fn handler(&mut self, new_name: &str, expected_tags_count: u8) -> Result<(), ProgramError> {
-        self.account.set_name(self.payer, new_name)?;
+        self.account.set_name(&self.payer, new_name)?;
 
         let name = self.account.name();
         if name.len() != new_name.len() {

--- a/tests/programs/test-misc/src/instructions/no_disc_check.rs
+++ b/tests/programs/test-misc/src/instructions/no_disc_check.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitNoDisc<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = NoDiscAccount::seeds(payer), bump)]
-    pub account: &'info mut Account<NoDiscAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitNoDisc {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = NoDiscAccount::seeds(payer), bump)]
+    pub account: Account<NoDiscAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitNoDisc<'info> {
+impl InitNoDisc {
     #[inline(always)]
     pub fn handler(&mut self, value: u64, _bumps: &InitNoDiscBumps) -> Result<(), ProgramError> {
         self.account.set_inner(NoDiscAccountInner {
@@ -23,12 +24,12 @@ impl<'info> InitNoDisc<'info> {
 }
 
 #[derive(Accounts)]
-pub struct ReadNoDisc<'info> {
+pub struct ReadNoDisc {
     #[account(mut)]
-    pub account: &'info Account<NoDiscAccount>,
+    pub account: Account<NoDiscAccount>,
 }
 
-impl<'info> ReadNoDisc<'info> {
+impl ReadNoDisc {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         // Just access the fields to verify Deref works.

--- a/tests/programs/test-misc/src/instructions/option_address_none.rs
+++ b/tests/programs/test-misc/src/instructions/option_address_none.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct OptionAddressNone<'info> {
-    pub signer: &'info Signer,
+pub struct OptionAddressNone {
+    pub signer: Signer,
 }
 
-impl<'info> OptionAddressNone<'info> {
+impl OptionAddressNone {
     #[inline(always)]
     pub fn handler(&self, addr: Option<Address>) -> Result<(), ProgramError> {
         require!(addr.is_none(), ProgramError::InvalidInstructionData);

--- a/tests/programs/test-misc/src/instructions/option_address_some.rs
+++ b/tests/programs/test-misc/src/instructions/option_address_some.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct OptionAddressSome<'info> {
-    pub signer: &'info Signer,
+pub struct OptionAddressSome {
+    pub signer: Signer,
 }
 
-impl<'info> OptionAddressSome<'info> {
+impl OptionAddressSome {
     #[inline(always)]
     pub fn handler(&self, addr: Option<Address>) -> Result<(), ProgramError> {
         require!(addr.is_some(), ProgramError::InvalidInstructionData);

--- a/tests/programs/test-misc/src/instructions/option_u64_none.rs
+++ b/tests/programs/test-misc/src/instructions/option_u64_none.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct OptionU64None<'info> {
-    pub signer: &'info Signer,
+pub struct OptionU64None {
+    pub signer: Signer,
 }
 
-impl<'info> OptionU64None<'info> {
+impl OptionU64None {
     #[inline(always)]
     pub fn handler(&self, value: Option<u64>) -> Result<(), ProgramError> {
         require!(value.is_none(), ProgramError::InvalidInstructionData);

--- a/tests/programs/test-misc/src/instructions/option_u64_some.rs
+++ b/tests/programs/test-misc/src/instructions/option_u64_some.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct OptionU64Some<'info> {
-    pub signer: &'info Signer,
+pub struct OptionU64Some {
+    pub signer: Signer,
 }
 
-impl<'info> OptionU64Some<'info> {
+impl OptionU64Some {
     #[inline(always)]
     pub fn handler(&self, value: Option<u64>) -> Result<(), ProgramError> {
         require!(value == Some(42), ProgramError::InvalidInstructionData);

--- a/tests/programs/test-misc/src/instructions/optional_account.rs
+++ b/tests/programs/test-misc/src/instructions/optional_account.rs
@@ -1,12 +1,12 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct OptionalAccount<'info> {
-    pub required: &'info Account<SimpleAccount>,
-    pub optional: Option<&'info Account<SimpleAccount>>,
+pub struct OptionalAccount {
+    pub required: Account<SimpleAccount>,
+    pub optional: Option<Account<SimpleAccount>>,
 }
 
-impl<'info> OptionalAccount<'info> {
+impl OptionalAccount {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/optional_has_one.rs
+++ b/tests/programs/test-misc/src/instructions/optional_has_one.rs
@@ -1,13 +1,13 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct OptionalHasOne<'info> {
-    pub authority: &'info Signer,
+pub struct OptionalHasOne {
+    pub authority: Signer,
     #[account(has_one = authority)]
-    pub account: Option<&'info Account<SimpleAccount>>,
+    pub account: Option<Account<SimpleAccount>>,
 }
 
-impl<'info> OptionalHasOne<'info> {
+impl OptionalHasOne {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/owner_check.rs
+++ b/tests/programs/test-misc/src/instructions/owner_check.rs
@@ -1,11 +1,11 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct OwnerCheck<'info> {
-    pub account: &'info Account<SimpleAccount>,
+pub struct OwnerCheck {
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> OwnerCheck<'info> {
+impl OwnerCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/plain_ok.rs
+++ b/tests/programs/test-misc/src/instructions/plain_ok.rs
@@ -1,11 +1,11 @@
 use {crate::state::TestMiscProgram, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct PlainOk<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct PlainOk {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> PlainOk<'info> {
+impl PlainOk {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/realloc_check.rs
+++ b/tests/programs/test-misc/src/instructions/realloc_check.rs
@@ -2,15 +2,15 @@ use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
 #[instruction(new_space: u64)]
-pub struct ReallocCheck<'info> {
-    #[account(realloc = new_space as usize)]
-    pub account: &'info mut Account<SimpleAccount>,
+pub struct ReallocCheck {
+    #[account(mut, realloc = new_space as usize)]
+    pub account: Account<SimpleAccount>,
     #[account(mut)]
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ReallocCheck<'info> {
+impl ReallocCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/remaining_accounts_check.rs
+++ b/tests/programs/test-misc/src/instructions/remaining_accounts_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::{prelude::*, remaining::RemainingAccounts};
 
 #[derive(Accounts)]
-pub struct RemainingAccountsCheck<'info> {
-    pub authority: &'info Signer,
+pub struct RemainingAccountsCheck {
+    pub authority: Signer,
 }
 
-impl<'info> RemainingAccountsCheck<'info> {
+impl RemainingAccountsCheck {
     #[inline(always)]
     pub fn handler(&self, remaining: RemainingAccounts) -> Result<(), ProgramError> {
         for account in remaining.iter() {

--- a/tests/programs/test-misc/src/instructions/return_payload.rs
+++ b/tests/programs/test-misc/src/instructions/return_payload.rs
@@ -4,11 +4,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReturnPayloadInstruction<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct ReturnPayloadInstruction {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> ReturnPayloadInstruction<'info> {
+impl ReturnPayloadInstruction {
     #[inline(always)]
     pub fn handler(&self) -> Result<ReturnPayload, ProgramError> {
         Ok(RETURN_PAYLOAD_VALUE)

--- a/tests/programs/test-misc/src/instructions/return_u64.rs
+++ b/tests/programs/test-misc/src/instructions/return_u64.rs
@@ -4,11 +4,11 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReturnU64<'info> {
-    pub program: &'info Program<TestMiscProgram>,
+pub struct ReturnU64 {
+    pub program: Program<TestMiscProgram>,
 }
 
-impl<'info> ReturnU64<'info> {
+impl ReturnU64 {
     #[inline(always)]
     pub fn handler(&self) -> Result<u64, ProgramError> {
         Ok(RETURN_U64_VALUE)

--- a/tests/programs/test-misc/src/instructions/signer_and_mut_check.rs
+++ b/tests/programs/test-misc/src/instructions/signer_and_mut_check.rs
@@ -4,13 +4,13 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SignerAndMutCheck<'info> {
+pub struct SignerAndMutCheck {
     #[account(mut)]
-    pub account: &'info mut Account<SimpleAccount>,
-    pub signer: &'info Signer,
+    pub account: Account<SimpleAccount>,
+    pub signer: Signer,
 }
 
-impl<'info> SignerAndMutCheck<'info> {
+impl SignerAndMutCheck {
     #[inline(always)]
     pub fn handler(&mut self, new_value: u64) -> Result<(), ProgramError> {
         let authority = self.account.authority;

--- a/tests/programs/test-misc/src/instructions/signer_check.rs
+++ b/tests/programs/test-misc/src/instructions/signer_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SignerCheck<'info> {
-    pub signer: &'info Signer,
+pub struct SignerCheck {
+    pub signer: Signer,
 }
 
-impl<'info> SignerCheck<'info> {
+impl SignerCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/space_override.rs
+++ b/tests/programs/test-misc/src/instructions/space_override.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SpaceOverride<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, space = 100, seeds = SpaceTestAccount::seeds(payer), bump)]
-    pub account: &'info mut Account<SpaceTestAccount>,
-    pub system_program: &'info Program<System>,
+pub struct SpaceOverride {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, space = 100, seeds = SpaceTestAccount::seeds(payer), bump)]
+    pub account: Account<SpaceTestAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> SpaceOverride<'info> {
+impl SpaceOverride {
     #[inline(always)]
     pub fn handler(&mut self, value: u64, bumps: &SpaceOverrideBumps) -> Result<(), ProgramError> {
         self.account.set_inner(SpaceTestAccountInner {

--- a/tests/programs/test-misc/src/instructions/system_account_check.rs
+++ b/tests/programs/test-misc/src/instructions/system_account_check.rs
@@ -1,11 +1,11 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct SystemAccountCheck<'info> {
-    pub target: &'info SystemAccount,
+pub struct SystemAccountCheck {
+    pub target: SystemAccount,
 }
 
-impl<'info> SystemAccountCheck<'info> {
+impl SystemAccountCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/transfer_test.rs
+++ b/tests/programs/test-misc/src/instructions/transfer_test.rs
@@ -1,18 +1,19 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct TransferTest<'info> {
-    pub from: &'info mut Signer,
+pub struct TransferTest {
     #[account(mut)]
-    pub to: &'info mut UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub from: Signer,
+    #[account(mut)]
+    pub to: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> TransferTest<'info> {
+impl TransferTest {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.system_program
-            .transfer(self.from, self.to, amount)
+            .transfer(&self.from, &self.to, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-misc/src/instructions/update_address.rs
+++ b/tests/programs/test-misc/src/instructions/update_address.rs
@@ -1,12 +1,12 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct UpdateAddress<'info> {
+pub struct UpdateAddress {
     #[account(address = crate::EXPECTED_ADDRESS)]
-    pub target: &'info Account<SimpleAccount>,
+    pub target: Account<SimpleAccount>,
 }
 
-impl<'info> UpdateAddress<'info> {
+impl UpdateAddress {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-misc/src/instructions/update_has_one.rs
+++ b/tests/programs/test-misc/src/instructions/update_has_one.rs
@@ -1,13 +1,13 @@
 use {crate::state::SimpleAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct UpdateHasOne<'info> {
-    pub authority: &'info Signer,
+pub struct UpdateHasOne {
+    pub authority: Signer,
     #[account(has_one = authority, seeds = SimpleAccount::seeds(authority), bump = account.bump)]
-    pub account: &'info Account<SimpleAccount>,
+    pub account: Account<SimpleAccount>,
 }
 
-impl<'info> UpdateHasOne<'info> {
+impl UpdateHasOne {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-pda/src/instructions/close_pda.rs
+++ b/tests/programs/test-pda/src/instructions/close_pda.rs
@@ -1,18 +1,20 @@
 use {crate::state::UserAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct ClosePda<'info> {
-    pub authority: &'info mut Signer,
+pub struct ClosePda {
+    #[account(mut)]
+    pub authority: Signer,
     #[account(
+        mut,
         has_one = authority,
         close = authority,
         seeds = UserAccount::seeds(authority),
         bump = user.bump
     )]
-    pub user: &'info mut Account<UserAccount>,
+    pub user: Account<UserAccount>,
 }
 
-impl<'info> ClosePda<'info> {
+impl ClosePda {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-pda/src/instructions/init_empty_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_empty_seed.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitEmptySeed<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = EmptySeedAccount::seeds(), bump)]
-    pub empty: &'info mut Account<EmptySeedAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitEmptySeed {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = EmptySeedAccount::seeds(), bump)]
+    pub empty: Account<EmptySeedAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitEmptySeed<'info> {
+impl InitEmptySeed {
     #[inline(always)]
     pub fn handler(&mut self, bumps: &InitEmptySeedBumps) -> Result<(), ProgramError> {
         self.empty

--- a/tests/programs/test-pda/src/instructions/init_instruction_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_instruction_seed.rs
@@ -4,15 +4,16 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitInstructionSeed<'info> {
-    pub payer: &'info mut Signer,
-    pub authority: &'info Signer,
-    #[account(init, payer = payer, seeds = ItemAccount::seeds(authority), bump)]
-    pub item: &'info mut Account<ItemAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitInstructionSeed {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    #[account(mut, init, payer = payer, seeds = ItemAccount::seeds(authority), bump)]
+    pub item: Account<ItemAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitInstructionSeed<'info> {
+impl InitInstructionSeed {
     #[inline(always)]
     pub fn handler(
         &mut self,

--- a/tests/programs/test-pda/src/instructions/init_ix_data_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_ix_data_seed.rs
@@ -5,15 +5,16 @@ use {
 
 #[derive(Accounts)]
 #[instruction(index: u64)]
-pub struct InitIxDataSeed<'info> {
-    pub payer: &'info mut Signer,
-    pub authority: &'info Signer,
-    #[account(init, payer = payer, seeds = IndexedAccount::seeds(authority, index), bump)]
-    pub item: &'info mut Account<IndexedAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitIxDataSeed {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    #[account(mut, init, payer = payer, seeds = IndexedAccount::seeds(authority, index), bump)]
+    pub item: Account<IndexedAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIxDataSeed<'info> {
+impl InitIxDataSeed {
     #[inline(always)]
     pub fn handler(&mut self, index: u64, bumps: &InitIxDataSeedBumps) -> Result<(), ProgramError> {
         self.item.set_inner(IndexedAccountInner {

--- a/tests/programs/test-pda/src/instructions/init_literal_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_literal_seed.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitLiteralSeed<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = ConfigAccount::seeds(), bump)]
-    pub config: &'info mut Account<ConfigAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitLiteralSeed {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = ConfigAccount::seeds(), bump)]
+    pub config: Account<ConfigAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitLiteralSeed<'info> {
+impl InitLiteralSeed {
     #[inline(always)]
     pub fn handler(&mut self, bumps: &InitLiteralSeedBumps) -> Result<(), ProgramError> {
         self.config

--- a/tests/programs/test-pda/src/instructions/init_max_multi_seeds.rs
+++ b/tests/programs/test-pda/src/instructions/init_max_multi_seeds.rs
@@ -1,9 +1,10 @@
 use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct InitMaxMultiSeeds<'info> {
-    pub payer: &'info mut Signer,
-    pub authority: &'info Signer,
+pub struct InitMaxMultiSeeds {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
     #[account(
         seeds = [
             b"max", b"max", b"max", b"max", b"max",
@@ -12,11 +13,11 @@ pub struct InitMaxMultiSeeds<'info> {
         ],
         bump
     )]
-    pub complex: &'info UncheckedAccount,
-    pub system_program: &'info Program<System>,
+    pub complex: UncheckedAccount,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMaxMultiSeeds<'info> {
+impl InitMaxMultiSeeds {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-pda/src/instructions/init_max_seed_length.rs
+++ b/tests/programs/test-pda/src/instructions/init_max_seed_length.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMaxSeedLength<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = MaxSeedAccount::seeds(), bump)]
-    pub max_seed: &'info mut Account<MaxSeedAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitMaxSeedLength {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = MaxSeedAccount::seeds(), bump)]
+    pub max_seed: Account<MaxSeedAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMaxSeedLength<'info> {
+impl InitMaxSeedLength {
     #[inline(always)]
     pub fn handler(&mut self, bumps: &InitMaxSeedLengthBumps) -> Result<(), ProgramError> {
         self.max_seed.set_inner(MaxSeedAccountInner {

--- a/tests/programs/test-pda/src/instructions/init_multi_seeds.rs
+++ b/tests/programs/test-pda/src/instructions/init_multi_seeds.rs
@@ -4,15 +4,16 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMultiSeeds<'info> {
-    pub payer: &'info mut Signer,
-    pub authority: &'info Signer,
-    #[account(init, payer = payer, seeds = ComplexAccount::seeds(payer, authority), bump)]
-    pub complex: &'info mut Account<ComplexAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitMultiSeeds {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    #[account(mut, init, payer = payer, seeds = ComplexAccount::seeds(payer, authority), bump)]
+    pub complex: Account<ComplexAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMultiSeeds<'info> {
+impl InitMultiSeeds {
     #[inline(always)]
     pub fn handler(
         &mut self,

--- a/tests/programs/test-pda/src/instructions/init_ns_config.rs
+++ b/tests/programs/test-pda/src/instructions/init_ns_config.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitNsConfig<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = NamespaceConfig::seeds(), bump)]
-    pub config: &'info mut Account<NamespaceConfig>,
-    pub system_program: &'info Program<System>,
+pub struct InitNsConfig {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = NamespaceConfig::seeds(), bump)]
+    pub config: Account<NamespaceConfig>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitNsConfig<'info> {
+impl InitNsConfig {
     pub fn handler(
         &mut self,
         namespace: u32,

--- a/tests/programs/test-pda/src/instructions/init_pubkey_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_pubkey_seed.rs
@@ -4,14 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitPubkeySeed<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = UserAccount::seeds(payer), bump)]
-    pub user: &'info mut Account<UserAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitPubkeySeed {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = UserAccount::seeds(payer), bump)]
+    pub user: Account<UserAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitPubkeySeed<'info> {
+impl InitPubkeySeed {
     #[inline(always)]
     pub fn handler(&mut self, value: u64, bumps: &InitPubkeySeedBumps) -> Result<(), ProgramError> {
         self.user.set_inner(UserAccountInner {

--- a/tests/programs/test-pda/src/instructions/init_scoped_item.rs
+++ b/tests/programs/test-pda/src/instructions/init_scoped_item.rs
@@ -5,14 +5,15 @@ use {
 
 #[derive(Accounts)]
 #[instruction(namespace: u32)]
-pub struct InitScopedItem<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = ScopedItem::seeds(namespace), bump)]
-    pub item: &'info mut Account<ScopedItem>,
-    pub system_program: &'info Program<System>,
+pub struct InitScopedItem {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = ScopedItem::seeds(namespace), bump)]
+    pub item: Account<ScopedItem>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitScopedItem<'info> {
+impl InitScopedItem {
     pub fn handler(
         &mut self,
         namespace: u32,

--- a/tests/programs/test-pda/src/instructions/init_three_seeds.rs
+++ b/tests/programs/test-pda/src/instructions/init_three_seeds.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitThreeSeeds<'info> {
-    pub payer: &'info mut Signer,
-    pub first: &'info Signer,
-    pub second: &'info Signer,
-    #[account(init, payer = payer, seeds = ThreeSeedAccount::seeds(first, second), bump)]
-    pub triple: &'info mut Account<ThreeSeedAccount>,
-    pub system_program: &'info Program<System>,
+pub struct InitThreeSeeds {
+    #[account(mut)]
+    pub payer: Signer,
+    pub first: Signer,
+    pub second: Signer,
+    #[account(mut, init, payer = payer, seeds = ThreeSeedAccount::seeds(first, second), bump)]
+    pub triple: Account<ThreeSeedAccount>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitThreeSeeds<'info> {
+impl InitThreeSeeds {
     #[inline(always)]
     pub fn handler(&mut self, bumps: &InitThreeSeedsBumps) -> Result<(), ProgramError> {
         self.triple.set_inner(ThreeSeedAccountInner {

--- a/tests/programs/test-pda/src/instructions/pda_transfer.rs
+++ b/tests/programs/test-pda/src/instructions/pda_transfer.rs
@@ -1,14 +1,15 @@
 use {crate::state::UserAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct PdaTransfer<'info> {
-    pub authority: &'info Signer,
+pub struct PdaTransfer {
+    pub authority: Signer,
     #[account(mut, has_one = authority, seeds = UserAccount::seeds(authority), bump = pda.bump)]
-    pub pda: &'info mut Account<UserAccount>,
-    pub recipient: &'info mut SystemAccount,
+    pub pda: Account<UserAccount>,
+    #[account(mut)]
+    pub recipient: SystemAccount,
 }
 
-impl<'info> PdaTransfer<'info> {
+impl PdaTransfer {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         let pda_view = self.pda.to_account_view();

--- a/tests/programs/test-pda/src/instructions/update_pda.rs
+++ b/tests/programs/test-pda/src/instructions/update_pda.rs
@@ -1,13 +1,13 @@
 use {crate::state::UserAccount, quasar_lang::prelude::*};
 
 #[derive(Accounts)]
-pub struct UpdatePda<'info> {
-    pub authority: &'info Signer,
+pub struct UpdatePda {
+    pub authority: Signer,
     #[account(mut, has_one = authority, seeds = UserAccount::seeds(authority), bump = user.bump)]
-    pub user: &'info mut Account<UserAccount>,
+    pub user: Account<UserAccount>,
 }
 
-impl<'info> UpdatePda<'info> {
+impl UpdatePda {
     #[inline(always)]
     pub fn handler(&mut self, new_value: u64) -> Result<(), ProgramError> {
         self.user.value = new_value.into();

--- a/tests/programs/test-pda/src/instructions/verify_scoped_item.rs
+++ b/tests/programs/test-pda/src/instructions/verify_scoped_item.rs
@@ -4,13 +4,13 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct VerifyScopedItem<'info> {
-    pub config: &'info Account<NamespaceConfig>,
+pub struct VerifyScopedItem {
+    pub config: Account<NamespaceConfig>,
     #[account(seeds = ScopedItem::seeds(config.namespace), bump = item.bump)]
-    pub item: &'info Account<ScopedItem>,
+    pub item: Account<ScopedItem>,
 }
 
-impl<'info> VerifyScopedItem<'info> {
+impl VerifyScopedItem {
     pub fn handler(&mut self) -> Result<(), ProgramError> {
         Ok(())
     }

--- a/tests/programs/test-sysvar/src/instructions/read_clock.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_clock.rs
@@ -7,14 +7,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadClock<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = ClockSnapshot::seeds(), bump)]
-    pub snapshot: &'info mut Account<ClockSnapshot>,
-    pub system_program: &'info Program<System>,
+pub struct ReadClock {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = ClockSnapshot::seeds(), bump)]
+    pub snapshot: Account<ClockSnapshot>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ReadClock<'info> {
+impl ReadClock {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
         let clock = Clock::get()?;

--- a/tests/programs/test-sysvar/src/instructions/read_clock_from_account.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_clock_from_account.rs
@@ -4,17 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadClockFromAccount<'info> {
-    pub _payer: &'info Signer,
+pub struct ReadClockFromAccount {
+    pub _payer: Signer,
     #[account(mut)]
-    pub snapshot: &'info mut Account<ClockSnapshot>,
-    pub clock: &'info Sysvar<Clock>,
+    pub snapshot: Account<ClockSnapshot>,
+    pub clock: Sysvar<Clock>,
 }
 
-impl<'info> ReadClockFromAccount<'info> {
+impl ReadClockFromAccount {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
-        let clock = self.clock;
+        let clock = &self.clock;
         self.snapshot.set_inner(ClockSnapshotInner {
             slot: clock.slot.get(),
             unix_timestamp: clock.unix_timestamp.get(),

--- a/tests/programs/test-sysvar/src/instructions/read_clock_full.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_clock_full.rs
@@ -7,14 +7,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadClockFull<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = ClockFullSnapshot::seeds(), bump)]
-    pub snapshot: &'info mut Account<ClockFullSnapshot>,
-    pub system_program: &'info Program<System>,
+pub struct ReadClockFull {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = ClockFullSnapshot::seeds(), bump)]
+    pub snapshot: Account<ClockFullSnapshot>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ReadClockFull<'info> {
+impl ReadClockFull {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
         let clock = Clock::get()?;

--- a/tests/programs/test-sysvar/src/instructions/read_clock_full_from_account.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_clock_full_from_account.rs
@@ -4,17 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadClockFullFromAccount<'info> {
-    pub _payer: &'info Signer,
+pub struct ReadClockFullFromAccount {
+    pub _payer: Signer,
     #[account(mut)]
-    pub snapshot: &'info mut Account<ClockFullSnapshot>,
-    pub clock: &'info Sysvar<Clock>,
+    pub snapshot: Account<ClockFullSnapshot>,
+    pub clock: Sysvar<Clock>,
 }
 
-impl<'info> ReadClockFullFromAccount<'info> {
+impl ReadClockFullFromAccount {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
-        let clock = self.clock;
+        let clock = &self.clock;
         self.snapshot.set_inner(ClockFullSnapshotInner {
             slot: clock.slot.get(),
             epoch_start_timestamp: clock.epoch_start_timestamp.get(),

--- a/tests/programs/test-sysvar/src/instructions/read_rent.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_rent.rs
@@ -7,14 +7,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadRent<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = RentSnapshot::seeds(), bump)]
-    pub snapshot: &'info mut Account<RentSnapshot>,
-    pub system_program: &'info Program<System>,
+pub struct ReadRent {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = RentSnapshot::seeds(), bump)]
+    pub snapshot: Account<RentSnapshot>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ReadRent<'info> {
+impl ReadRent {
     #[inline(always)]
     pub fn handler(&mut self) -> Result<(), ProgramError> {
         let rent = Rent::get()?;

--- a/tests/programs/test-sysvar/src/instructions/read_rent_calc.rs
+++ b/tests/programs/test-sysvar/src/instructions/read_rent_calc.rs
@@ -7,14 +7,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ReadRentCalc<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, payer = payer, seeds = RentCalcSnapshot::seeds(), bump)]
-    pub snapshot: &'info mut Account<RentCalcSnapshot>,
-    pub system_program: &'info Program<System>,
+pub struct ReadRentCalc {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, payer = payer, seeds = RentCalcSnapshot::seeds(), bump)]
+    pub snapshot: Account<RentCalcSnapshot>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> ReadRentCalc<'info> {
+impl ReadRentCalc {
     #[inline(always)]
     pub fn handler(&mut self, data_len: u64) -> Result<(), ProgramError> {
         let rent = Rent::get()?;

--- a/tests/programs/test-token-cpi/src/instructions/approve.rs
+++ b/tests/programs/test-token-cpi/src/instructions/approve.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Approve<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut Account<Token>,
-    pub delegate: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token>,
+pub struct Approve {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: Account<Token>,
+    pub delegate: UncheckedAccount,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> Approve<'info> {
+impl Approve {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .approve(self.source, self.delegate, self.authority, amount)
+            .approve(&self.source, &self.delegate, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/approve_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/approve_interface.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ApproveInterface<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut InterfaceAccount<Token>,
-    pub delegate: &'info UncheckedAccount,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct ApproveInterface {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: InterfaceAccount<Token>,
+    pub delegate: UncheckedAccount,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ApproveInterface<'info> {
+impl ApproveInterface {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .approve(self.source, self.delegate, self.authority, amount)
+            .approve(&self.source, &self.delegate, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/approve_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/approve_t22.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ApproveT22<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut Account<Token2022>,
-    pub delegate: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token2022>,
+pub struct ApproveT22 {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: Account<Token2022>,
+    pub delegate: UncheckedAccount,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> ApproveT22<'info> {
+impl ApproveT22 {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .approve(self.source, self.delegate, self.authority, amount)
+            .approve(&self.source, &self.delegate, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/burn.rs
+++ b/tests/programs/test-token-cpi/src/instructions/burn.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Burn<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut Account<Token>,
-    pub mint: &'info mut Account<Mint>,
-    pub token_program: &'info Program<Token>,
+pub struct Burn {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: Account<Token>,
+    #[account(mut)]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> Burn<'info> {
+impl Burn {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .burn(self.from, self.mint, self.authority, amount)
+            .burn(&self.from, &self.mint, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/burn_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/burn_interface.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct BurnInterface<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info mut InterfaceAccount<Mint>,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct BurnInterface {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: InterfaceAccount<Token>,
+    #[account(mut)]
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> BurnInterface<'info> {
+impl BurnInterface {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .burn(self.from, self.mint, self.authority, amount)
+            .burn(&self.from, &self.mint, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/burn_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/burn_t22.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct BurnT22<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut Account<Token2022>,
-    pub mint: &'info mut Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
+pub struct BurnT22 {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: Account<Token2022>,
+    #[account(mut)]
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> BurnT22<'info> {
+impl BurnT22 {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .burn(self.from, self.mint, self.authority, amount)
+            .burn(&self.from, &self.mint, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/close_token.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token.rs
@@ -7,18 +7,18 @@ use {
 /// The macro's epilogue calls `Account::close(dest)` which zeros the account,
 /// transfers lamports, and reassigns to the system program.
 #[derive(Accounts)]
-pub struct CloseToken<'info> {
-    pub authority: &'info Signer,
-    #[account(close = destination, token::mint = mint, token::authority = authority)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
+pub struct CloseToken {
+    pub authority: Signer,
+    #[account(mut, close = destination, token::mint = mint, token::authority = authority)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
     /// CHECK: destination may alias authority (close sends lamports to it).
     #[account(mut, dup)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Program<Token>,
+    pub destination: UncheckedAccount,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> CloseToken<'info> {
+impl CloseToken {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/close_token_account.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token_account.rs
@@ -4,21 +4,23 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CloseTokenAccount<'info> {
-    pub account: &'info mut Account<Token>,
-    pub destination: &'info mut Signer,
+pub struct CloseTokenAccount {
+    #[account(mut)]
+    pub account: Account<Token>,
+    #[account(mut)]
+    pub destination: Signer,
     /// CHECK: authority may equal destination when the signer is closing to
     /// themselves.
     #[account(dup)]
-    pub authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub authority: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> CloseTokenAccount<'info> {
+impl CloseTokenAccount {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .close_account(self.account, self.destination, self.authority)
+            .close_account(&self.account, &self.destination, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/close_token_account_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token_account_interface.rs
@@ -4,21 +4,23 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CloseTokenAccountInterface<'info> {
-    pub account: &'info mut InterfaceAccount<Token>,
-    pub destination: &'info mut Signer,
+pub struct CloseTokenAccountInterface {
+    #[account(mut)]
+    pub account: InterfaceAccount<Token>,
+    #[account(mut)]
+    pub destination: Signer,
     /// CHECK: authority may equal destination when the signer is closing to
     /// themselves.
     #[account(dup)]
-    pub authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub authority: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> CloseTokenAccountInterface<'info> {
+impl CloseTokenAccountInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .close_account(self.account, self.destination, self.authority)
+            .close_account(&self.account, &self.destination, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/close_token_account_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token_account_t22.rs
@@ -4,21 +4,23 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CloseTokenAccountT22<'info> {
-    pub account: &'info mut Account<Token2022>,
-    pub destination: &'info mut Signer,
+pub struct CloseTokenAccountT22 {
+    #[account(mut)]
+    pub account: Account<Token2022>,
+    #[account(mut)]
+    pub destination: Signer,
     /// CHECK: authority may equal destination when the signer is closing to
     /// themselves.
     #[account(dup)]
-    pub authority: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
+    pub authority: Signer,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> CloseTokenAccountT22<'info> {
+impl CloseTokenAccountT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .close_account(self.account, self.destination, self.authority)
+            .close_account(&self.account, &self.destination, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/close_token_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token_interface.rs
@@ -4,18 +4,18 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CloseTokenInterface<'info> {
-    pub authority: &'info Signer,
-    #[account(close = destination, token::mint = mint, token::authority = authority)]
-    pub token_account: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
+pub struct CloseTokenInterface {
+    pub authority: Signer,
+    #[account(mut, close = destination, token::mint = mint, token::authority = authority)]
+    pub token_account: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
     /// CHECK: destination may alias authority (close sends lamports to it).
     #[account(mut, dup)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub destination: UncheckedAccount,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> CloseTokenInterface<'info> {
+impl CloseTokenInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/close_token_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token_t22.rs
@@ -4,18 +4,18 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct CloseTokenT22<'info> {
-    pub authority: &'info Signer,
-    #[account(close = destination, token::mint = mint, token::authority = authority)]
-    pub token_account: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
+pub struct CloseTokenT22 {
+    pub authority: Signer,
+    #[account(mut, close = destination, token::mint = mint, token::authority = authority)]
+    pub token_account: Account<Token2022>,
+    pub mint: Account<Mint2022>,
     /// CHECK: destination may alias authority (close sends lamports to it).
     #[account(mut, dup)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Program<Token2022>,
+    pub destination: UncheckedAccount,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> CloseTokenT22<'info> {
+impl CloseTokenT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_ata.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_ata.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitAta<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitAta {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token>,
+    pub wallet: Signer,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitAta<'info> {
+impl InitAta {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_ata.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_ata.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededAta<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitIfNeededAta {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token>,
+    pub wallet: Signer,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitIfNeededAta<'info> {
+impl InitIfNeededAta {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMint<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededMint {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMint<'info> {
+impl InitIfNeededMint {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint_with_freeze.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_mint_with_freeze.rs
@@ -4,22 +4,24 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMintWithFreeze<'info> {
-    pub payer: &'info mut Signer,
+pub struct InitIfNeededMintWithFreeze {
+    #[account(mut)]
+    pub payer: Signer,
     #[account(
+        mut,
         init_if_needed,
         mint::decimals = 6,
         mint::authority = mint_authority,
         mint::freeze_authority = freeze_authority
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMintWithFreeze<'info> {
+impl InitIfNeededMintWithFreeze {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_if_needed_token.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_if_needed_token.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededToken<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededToken {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededToken<'info> {
+impl InitIfNeededToken {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_mint.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_mint.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintAccount<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitMintAccount {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMintAccount<'info> {
+impl InitMintAccount {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_mint_with_metadata.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_mint_with_metadata.rs
@@ -4,10 +4,12 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintWithMetadata<'info> {
-    pub payer: &'info mut Signer,
-    pub mint_authority: &'info Signer,
+pub struct InitMintWithMetadata {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint_authority: Signer,
     #[account(
+        mut,
         init,
         mint::decimals = 0,
         mint::authority = mint_authority,
@@ -17,15 +19,16 @@ pub struct InitMintWithMetadata<'info> {
         metadata::seller_fee_basis_points = 500,
         metadata::is_mutable = true,
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub metadata: &'info mut UncheckedAccount,
-    pub metadata_program: &'info Program<MetadataProgram>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub rent: &'info Sysvar<Rent>,
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub metadata: UncheckedAccount,
+    pub metadata_program: Program<MetadataProgram>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub rent: Sysvar<Rent>,
 }
 
-impl<'info> InitMintWithMetadata<'info> {
+impl InitMintWithMetadata {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/init_token_account.rs
+++ b/tests/programs/test-token-cpi/src/instructions/init_token_account.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitTokenAccount<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitTokenAccount {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitTokenAccount<'info> {
+impl InitTokenAccount {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/interface_transfer.rs
+++ b/tests/programs/test-token-cpi/src/instructions/interface_transfer.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InterfaceTransfer<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut InterfaceAccount<Token>,
-    pub to: &'info mut InterfaceAccount<Token>,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct InterfaceTransfer {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: InterfaceAccount<Token>,
+    #[account(mut)]
+    pub to: InterfaceAccount<Token>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> InterfaceTransfer<'info> {
+impl InterfaceTransfer {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .transfer(self.from, self.to, self.authority, amount)
+            .transfer(&self.from, &self.to, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/mint_to.rs
+++ b/tests/programs/test-token-cpi/src/instructions/mint_to.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct MintTo<'info> {
-    pub authority: &'info Signer,
-    pub mint: &'info mut Account<Mint>,
-    pub to: &'info mut Account<Token>,
-    pub token_program: &'info Program<Token>,
+pub struct MintTo {
+    pub authority: Signer,
+    #[account(mut)]
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub to: Account<Token>,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> MintTo<'info> {
+impl MintTo {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .mint_to(self.mint, self.to, self.authority, amount)
+            .mint_to(&self.mint, &self.to, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/mint_to_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/mint_to_interface.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct MintToInterface<'info> {
-    pub authority: &'info Signer,
-    pub mint: &'info mut InterfaceAccount<Mint>,
-    pub to: &'info mut InterfaceAccount<Token>,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct MintToInterface {
+    pub authority: Signer,
+    #[account(mut)]
+    pub mint: InterfaceAccount<Mint>,
+    #[account(mut)]
+    pub to: InterfaceAccount<Token>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> MintToInterface<'info> {
+impl MintToInterface {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .mint_to(self.mint, self.to, self.authority, amount)
+            .mint_to(&self.mint, &self.to, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/mint_to_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/mint_to_t22.rs
@@ -4,18 +4,20 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct MintToT22<'info> {
-    pub authority: &'info Signer,
-    pub mint: &'info mut Account<Mint2022>,
-    pub to: &'info mut Account<Token2022>,
-    pub token_program: &'info Program<Token2022>,
+pub struct MintToT22 {
+    pub authority: Signer,
+    #[account(mut)]
+    pub mint: Account<Mint2022>,
+    #[account(mut)]
+    pub to: Account<Token2022>,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> MintToT22<'info> {
+impl MintToT22 {
     #[inline(always)]
     pub fn handler(&self, amount: u64) -> Result<(), ProgramError> {
         self.token_program
-            .mint_to(self.mint, self.to, self.authority, amount)
+            .mint_to(&self.mint, &self.to, &self.authority, amount)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/revoke.rs
+++ b/tests/programs/test-token-cpi/src/instructions/revoke.rs
@@ -4,17 +4,18 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct Revoke<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut Account<Token>,
-    pub token_program: &'info Program<Token>,
+pub struct Revoke {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: Account<Token>,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> Revoke<'info> {
+impl Revoke {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .revoke(self.source, self.authority)
+            .revoke(&self.source, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/revoke_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/revoke_interface.rs
@@ -4,17 +4,18 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct RevokeInterface<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut InterfaceAccount<Token>,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct RevokeInterface {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: InterfaceAccount<Token>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> RevokeInterface<'info> {
+impl RevokeInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .revoke(self.source, self.authority)
+            .revoke(&self.source, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/revoke_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/revoke_t22.rs
@@ -4,17 +4,18 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct RevokeT22<'info> {
-    pub authority: &'info Signer,
-    pub source: &'info mut Account<Token2022>,
-    pub token_program: &'info Program<Token2022>,
+pub struct RevokeT22 {
+    pub authority: Signer,
+    #[account(mut)]
+    pub source: Account<Token2022>,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> RevokeT22<'info> {
+impl RevokeT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         self.token_program
-            .revoke(self.source, self.authority)
+            .revoke(&self.source, &self.authority)
             .invoke()
     }
 }

--- a/tests/programs/test-token-cpi/src/instructions/sweep_and_close.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_and_close.rs
@@ -5,19 +5,19 @@ use {
 
 /// Tests sweep + close — transfers all tokens, then closes the account.
 #[derive(Accounts)]
-pub struct SweepAndClose<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut Account<Token>,
+pub struct SweepAndClose {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
+    pub source: Account<Token>,
     #[account(mut)]
-    pub receiver: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
+    pub receiver: Account<Token>,
+    pub mint: Account<Mint>,
     #[account(mut)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Program<Token>,
+    pub destination: UncheckedAccount,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> SweepAndClose<'info> {
+impl SweepAndClose {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/sweep_and_close_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_and_close_interface.rs
@@ -4,19 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SweepAndCloseInterface<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut InterfaceAccount<Token>,
+pub struct SweepAndCloseInterface {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
+    pub source: InterfaceAccount<Token>,
     #[account(mut)]
-    pub receiver: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
+    pub receiver: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
     #[account(mut)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub destination: UncheckedAccount,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> SweepAndCloseInterface<'info> {
+impl SweepAndCloseInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/sweep_and_close_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_and_close_t22.rs
@@ -4,19 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SweepAndCloseT22<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut Account<Token2022>,
+pub struct SweepAndCloseT22 {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, close = destination, token::mint = mint, token::authority = authority)]
+    pub source: Account<Token2022>,
     #[account(mut)]
-    pub receiver: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
+    pub receiver: Account<Token2022>,
+    pub mint: Account<Mint2022>,
     #[account(mut)]
-    pub destination: &'info mut UncheckedAccount,
-    pub token_program: &'info Program<Token2022>,
+    pub destination: UncheckedAccount,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> SweepAndCloseT22<'info> {
+impl SweepAndCloseT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/sweep_token.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_token.rs
@@ -6,17 +6,17 @@ use {
 /// Tests sweep without close — transfers all remaining tokens at end of
 /// instruction.
 #[derive(Accounts)]
-pub struct SweepToken<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut Account<Token>,
+pub struct SweepToken {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, token::mint = mint, token::authority = authority)]
+    pub source: Account<Token>,
     #[account(mut)]
-    pub receiver: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
+    pub receiver: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> SweepToken<'info> {
+impl SweepToken {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/sweep_token_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_token_interface.rs
@@ -4,17 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SweepTokenInterface<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut InterfaceAccount<Token>,
+pub struct SweepTokenInterface {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, token::mint = mint, token::authority = authority)]
+    pub source: InterfaceAccount<Token>,
     #[account(mut)]
-    pub receiver: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub receiver: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> SweepTokenInterface<'info> {
+impl SweepTokenInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/sweep_token_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/sweep_token_t22.rs
@@ -4,17 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct SweepTokenT22<'info> {
-    pub authority: &'info Signer,
-    #[account(sweep = receiver, token::mint = mint, token::authority = authority)]
-    pub source: &'info mut Account<Token2022>,
+pub struct SweepTokenT22 {
+    pub authority: Signer,
+    #[account(mut, sweep = receiver, token::mint = mint, token::authority = authority)]
+    pub source: Account<Token2022>,
     #[account(mut)]
-    pub receiver: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
+    pub receiver: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> SweepTokenT22<'info> {
+impl SweepTokenT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/transfer_checked.rs
+++ b/tests/programs/test-token-cpi/src/instructions/transfer_checked.rs
@@ -4,23 +4,25 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct TransferChecked<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub to: &'info mut Account<Token>,
-    pub token_program: &'info Program<Token>,
+pub struct TransferChecked {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: Account<Token>,
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub to: Account<Token>,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> TransferChecked<'info> {
+impl TransferChecked {
     #[inline(always)]
     pub fn handler(&self, amount: u64, decimals: u8) -> Result<(), ProgramError> {
         self.token_program
             .transfer_checked(
-                self.from,
-                self.mint,
-                self.to,
-                self.authority,
+                &self.from,
+                &self.mint,
+                &self.to,
+                &self.authority,
                 amount,
                 decimals,
             )

--- a/tests/programs/test-token-cpi/src/instructions/transfer_checked_interface.rs
+++ b/tests/programs/test-token-cpi/src/instructions/transfer_checked_interface.rs
@@ -4,23 +4,25 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct TransferCheckedInterface<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub to: &'info mut InterfaceAccount<Token>,
-    pub token_program: &'info Interface<TokenInterface>,
+pub struct TransferCheckedInterface {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    #[account(mut)]
+    pub to: InterfaceAccount<Token>,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> TransferCheckedInterface<'info> {
+impl TransferCheckedInterface {
     #[inline(always)]
     pub fn handler(&self, amount: u64, decimals: u8) -> Result<(), ProgramError> {
         self.token_program
             .transfer_checked(
-                self.from,
-                self.mint,
-                self.to,
-                self.authority,
+                &self.from,
+                &self.mint,
+                &self.to,
+                &self.authority,
                 amount,
                 decimals,
             )

--- a/tests/programs/test-token-cpi/src/instructions/transfer_checked_t22.rs
+++ b/tests/programs/test-token-cpi/src/instructions/transfer_checked_t22.rs
@@ -4,23 +4,25 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct TransferCheckedT22<'info> {
-    pub authority: &'info Signer,
-    pub from: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub to: &'info mut Account<Token2022>,
-    pub token_program: &'info Program<Token2022>,
+pub struct TransferCheckedT22 {
+    pub authority: Signer,
+    #[account(mut)]
+    pub from: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    #[account(mut)]
+    pub to: Account<Token2022>,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> TransferCheckedT22<'info> {
+impl TransferCheckedT22 {
     #[inline(always)]
     pub fn handler(&self, amount: u64, decimals: u8) -> Result<(), ProgramError> {
         self.token_program
             .transfer_checked(
-                self.from,
-                self.mint,
-                self.to,
-                self.authority,
+                &self.from,
+                &self.mint,
+                &self.to,
+                &self.authority,
                 amount,
                 decimals,
             )

--- a/tests/programs/test-token-cpi/src/instructions/validate_ata_check.rs
+++ b/tests/programs/test-token-cpi/src/instructions/validate_ata_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateAtaCheck<'info> {
+pub struct ValidateAtaCheck {
     #[account(associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub wallet: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub ata: Account<Token>,
+    pub mint: Account<Mint>,
+    pub wallet: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateAtaCheck<'info> {
+impl ValidateAtaCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/validate_ata_interface_check.rs
+++ b/tests/programs/test-token-cpi/src/instructions/validate_ata_interface_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateAtaInterfaceCheck<'info> {
+pub struct ValidateAtaInterfaceCheck {
     #[account(associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub wallet: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub ata: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub wallet: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateAtaInterfaceCheck<'info> {
+impl ValidateAtaInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/validate_token_check.rs
+++ b/tests/programs/test-token-cpi/src/instructions/validate_token_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateTokenCheck<'info> {
+pub struct ValidateTokenCheck {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub authority: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateTokenCheck<'info> {
+impl ValidateTokenCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/validate_token_interface_check.rs
+++ b/tests/programs/test-token-cpi/src/instructions/validate_token_interface_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateTokenInterfaceCheck<'info> {
+pub struct ValidateTokenInterfaceCheck {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub token_account: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateTokenInterfaceCheck<'info> {
+impl ValidateTokenInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-cpi/src/instructions/validate_token_no_program.rs
+++ b/tests/programs/test-token-cpi/src/instructions/validate_token_no_program.rs
@@ -7,14 +7,14 @@ use {
 /// No `token_program` field needed — the program is known at compile time
 /// from the `Account<Token>` type (SPL Token only).
 #[derive(Accounts)]
-pub struct ValidateTokenNoProgram<'info> {
+pub struct ValidateTokenNoProgram {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub authority: &'info Signer,
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub authority: Signer,
 }
 
-impl<'info> ValidateTokenNoProgram<'info> {
+impl ValidateTokenNoProgram {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_ata.rs
+++ b/tests/programs/test-token-init/src/instructions/init_ata.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitAta<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitAta {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token>,
+    pub wallet: Signer,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitAta<'info> {
+impl InitAta {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_ata_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_ata_t22.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitAtaT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token2022>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitAtaT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token2022>,
+    pub wallet: Signer,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitAtaT22<'info> {
+impl InitAtaT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_ata.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_ata.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededAta<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitIfNeededAta {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token>,
+    pub wallet: Signer,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitIfNeededAta<'info> {
+impl InitIfNeededAta {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_ata_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_ata_t22.rs
@@ -4,18 +4,19 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededAtaT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info mut Account<Token2022>,
-    pub wallet: &'info Signer,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
-    pub ata_program: &'info Program<AssociatedTokenProgram>,
+pub struct InitIfNeededAtaT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, associated_token::mint = mint, associated_token::authority = wallet)]
+    pub ata: Account<Token2022>,
+    pub wallet: Signer,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
+    pub ata_program: Program<AssociatedTokenProgram>,
 }
 
-impl<'info> InitIfNeededAtaT22<'info> {
+impl InitIfNeededAtaT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_mint.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_mint.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMint<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededMint {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMint<'info> {
+impl InitIfNeededMint {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_mint_interface.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_mint_interface.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMintInterface<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut InterfaceAccount<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededMintInterface {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: InterfaceAccount<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Interface<TokenInterface>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMintInterface<'info> {
+impl InitIfNeededMintInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_mint_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_mint_t22.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMintT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint2022>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededMintT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint2022>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMintT22<'info> {
+impl InitIfNeededMintT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_mint_with_freeze.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_mint_with_freeze.rs
@@ -4,22 +4,24 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMintWithFreeze<'info> {
-    pub payer: &'info mut Signer,
+pub struct InitIfNeededMintWithFreeze {
+    #[account(mut)]
+    pub payer: Signer,
     #[account(
+        mut,
         init_if_needed,
         mint::decimals = 6,
         mint::authority = mint_authority,
         mint::freeze_authority = freeze_authority
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMintWithFreeze<'info> {
+impl InitIfNeededMintWithFreeze {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_mint_with_freeze_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_mint_with_freeze_t22.rs
@@ -4,22 +4,24 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededMintWithFreezeT22<'info> {
-    pub payer: &'info mut Signer,
+pub struct InitIfNeededMintWithFreezeT22 {
+    #[account(mut)]
+    pub payer: Signer,
     #[account(
+        mut,
         init_if_needed,
         mint::decimals = 6,
         mint::authority = mint_authority,
         mint::freeze_authority = freeze_authority
     )]
-    pub mint: &'info mut Account<Mint2022>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+    pub mint: Account<Mint2022>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededMintWithFreezeT22<'info> {
+impl InitIfNeededMintWithFreezeT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_token.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_token.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededToken<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededToken {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededToken<'info> {
+impl InitIfNeededToken {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_token_interface.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_token_interface.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededTokenInterface<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub token_program: &'info Interface<TokenInterface>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededTokenInterface {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, token::mint = mint, token::authority = payer)]
+    pub token_account: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<TokenInterface>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededTokenInterface<'info> {
+impl InitIfNeededTokenInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_if_needed_token_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_if_needed_token_t22.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitIfNeededTokenT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init_if_needed, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitIfNeededTokenT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init_if_needed, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitIfNeededTokenT22<'info> {
+impl InitIfNeededTokenT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMint<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitMint {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMint<'info> {
+impl InitMint {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint_interface.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint_interface.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintInterface<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut InterfaceAccount<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
-    pub system_program: &'info Program<System>,
+pub struct InitMintInterface {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: InterfaceAccount<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Interface<TokenInterface>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMintInterface<'info> {
+impl InitMintInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint_pda.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint_pda.rs
@@ -4,15 +4,16 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintPda<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, seeds = [b"mint", payer], bump, mint::decimals = 6, mint::authority = payer)]
-    pub mint: &'info mut Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitMintPda {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, seeds = [b"mint", payer], bump, mint::decimals = 6, mint::authority = payer)]
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMintPda<'info> {
+impl InitMintPda {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint_pda_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint_pda_t22.rs
@@ -4,15 +4,16 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintPdaT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, seeds = [b"mint", payer], bump, mint::decimals = 6, mint::authority = payer)]
-    pub mint: &'info mut Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitMintPdaT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, seeds = [b"mint", payer], bump, mint::decimals = 6, mint::authority = payer)]
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMintPdaT22<'info> {
+impl InitMintPdaT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint_t22.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, mint::decimals = 6, mint::authority = mint_authority)]
-    pub mint: &'info mut Account<Mint2022>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitMintT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, mint::decimals = 6, mint::authority = mint_authority)]
+    pub mint: Account<Mint2022>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitMintT22<'info> {
+impl InitMintT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_mint_with_metadata.rs
+++ b/tests/programs/test-token-init/src/instructions/init_mint_with_metadata.rs
@@ -4,10 +4,12 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitMintWithMetadata<'info> {
-    pub payer: &'info mut Signer,
-    pub mint_authority: &'info Signer,
+pub struct InitMintWithMetadata {
+    #[account(mut)]
+    pub payer: Signer,
+    pub mint_authority: Signer,
     #[account(
+        mut,
         init,
         mint::decimals = 0,
         mint::authority = mint_authority,
@@ -17,15 +19,16 @@ pub struct InitMintWithMetadata<'info> {
         metadata::seller_fee_basis_points = 500,
         metadata::is_mutable = true,
     )]
-    pub mint: &'info mut Account<Mint>,
-    pub metadata: &'info mut UncheckedAccount,
-    pub metadata_program: &'info Program<MetadataProgram>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
-    pub rent: &'info Sysvar<Rent>,
+    pub mint: Account<Mint>,
+    #[account(mut)]
+    pub metadata: UncheckedAccount,
+    pub metadata_program: Program<MetadataProgram>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
+    pub rent: Sysvar<Rent>,
 }
 
-impl<'info> InitMintWithMetadata<'info> {
+impl InitMintWithMetadata {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_token.rs
+++ b/tests/programs/test-token-init/src/instructions/init_token.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitToken<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitToken {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitToken<'info> {
+impl InitToken {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_token_interface.rs
+++ b/tests/programs/test-token-init/src/instructions/init_token_interface.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitTokenInterface<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub token_program: &'info Interface<TokenInterface>,
-    pub system_program: &'info Program<System>,
+pub struct InitTokenInterface {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, token::mint = mint, token::authority = payer)]
+    pub token_account: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub token_program: Interface<TokenInterface>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitTokenInterface<'info> {
+impl InitTokenInterface {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_token_pda.rs
+++ b/tests/programs/test-token-init/src/instructions/init_token_pda.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitTokenPda<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, seeds = [b"token", payer], bump, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub token_program: &'info Program<Token>,
-    pub system_program: &'info Program<System>,
+pub struct InitTokenPda {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, seeds = [b"token", payer], bump, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub token_program: Program<Token>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitTokenPda<'info> {
+impl InitTokenPda {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_token_pda_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_token_pda_t22.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitTokenPdaT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, seeds = [b"token", payer], bump, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitTokenPdaT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, seeds = [b"token", payer], bump, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitTokenPdaT22<'info> {
+impl InitTokenPdaT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-init/src/instructions/init_token_t22.rs
+++ b/tests/programs/test-token-init/src/instructions/init_token_t22.rs
@@ -4,16 +4,17 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct InitTokenT22<'info> {
-    pub payer: &'info mut Signer,
-    #[account(init, token::mint = mint, token::authority = payer)]
-    pub token_account: &'info mut Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub token_program: &'info Program<Token2022>,
-    pub system_program: &'info Program<System>,
+pub struct InitTokenT22 {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(mut, init, token::mint = mint, token::authority = payer)]
+    pub token_account: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub token_program: Program<Token2022>,
+    pub system_program: Program<System>,
 }
 
-impl<'info> InitTokenT22<'info> {
+impl InitTokenT22 {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_ata_2022_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_ata_2022_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateAta2022Check<'info> {
+pub struct ValidateAta2022Check {
     #[account(associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub wallet: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
+    pub ata: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub wallet: Signer,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> ValidateAta2022Check<'info> {
+impl ValidateAta2022Check {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_ata_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_ata_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateAtaCheck<'info> {
+pub struct ValidateAtaCheck {
     #[account(associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub wallet: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub ata: Account<Token>,
+    pub mint: Account<Mint>,
+    pub wallet: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateAtaCheck<'info> {
+impl ValidateAtaCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_ata_interface_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_ata_interface_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateAtaInterfaceCheck<'info> {
+pub struct ValidateAtaInterfaceCheck {
     #[account(associated_token::mint = mint, associated_token::authority = wallet)]
-    pub ata: &'info InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub wallet: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub ata: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub wallet: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateAtaInterfaceCheck<'info> {
+impl ValidateAtaInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_2022_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_2022_check.rs
@@ -4,14 +4,14 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMint2022Check<'info> {
+pub struct ValidateMint2022Check {
     #[account(mint::authority = mint_authority, mint::decimals = 6)]
-    pub mint: &'info Account<Mint2022>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> ValidateMint2022Check<'info> {
+impl ValidateMint2022Check {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_check.rs
@@ -4,14 +4,14 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMintCheck<'info> {
+pub struct ValidateMintCheck {
     #[account(mint::authority = mint_authority, mint::decimals = 6)]
-    pub mint: &'info Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateMintCheck<'info> {
+impl ValidateMintCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_interface_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_interface_check.rs
@@ -4,14 +4,14 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMintInterfaceCheck<'info> {
+pub struct ValidateMintInterfaceCheck {
     #[account(mint::authority = mint_authority, mint::decimals = 6)]
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub mint_authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub mint: InterfaceAccount<Mint>,
+    pub mint_authority: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateMintInterfaceCheck<'info> {
+impl ValidateMintInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_no_program.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_no_program.rs
@@ -3,13 +3,13 @@ use {quasar_lang::prelude::*, quasar_spl::Mint};
 /// No `token_program` field — program is known at compile time from
 /// Account<Mint>.
 #[derive(Accounts)]
-pub struct ValidateMintNoProgram<'info> {
+pub struct ValidateMintNoProgram {
     #[account(mint::authority = mint_authority, mint::decimals = 6)]
-    pub mint: &'info Account<Mint>,
-    pub mint_authority: &'info Signer,
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
 }
 
-impl<'info> ValidateMintNoProgram<'info> {
+impl ValidateMintNoProgram {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_2022_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_2022_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMintWithFreeze2022Check<'info> {
+pub struct ValidateMintWithFreeze2022Check {
     #[account(mint::authority = mint_authority, mint::decimals = 6, mint::freeze_authority = freeze_authority)]
-    pub mint: &'info Account<Mint2022>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> ValidateMintWithFreeze2022Check<'info> {
+impl ValidateMintWithFreeze2022Check {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMintWithFreezeCheck<'info> {
+pub struct ValidateMintWithFreezeCheck {
     #[account(mint::authority = mint_authority, mint::decimals = 6, mint::freeze_authority = freeze_authority)]
-    pub mint: &'info Account<Mint>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Program<Token>,
+    pub mint: Account<Mint>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateMintWithFreezeCheck<'info> {
+impl ValidateMintWithFreezeCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_interface_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_mint_with_freeze_interface_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateMintWithFreezeInterfaceCheck<'info> {
+pub struct ValidateMintWithFreezeInterfaceCheck {
     #[account(mint::authority = mint_authority, mint::decimals = 6, mint::freeze_authority = freeze_authority)]
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub mint_authority: &'info Signer,
-    pub freeze_authority: &'info UncheckedAccount,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub mint: InterfaceAccount<Mint>,
+    pub mint_authority: Signer,
+    pub freeze_authority: UncheckedAccount,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateMintWithFreezeInterfaceCheck<'info> {
+impl ValidateMintWithFreezeInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_token_2022_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_token_2022_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateToken2022Check<'info> {
+pub struct ValidateToken2022Check {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info Account<Token2022>,
-    pub mint: &'info Account<Mint2022>,
-    pub authority: &'info Signer,
-    pub token_program: &'info Program<Token2022>,
+    pub token_account: Account<Token2022>,
+    pub mint: Account<Mint2022>,
+    pub authority: Signer,
+    pub token_program: Program<Token2022>,
 }
 
-impl<'info> ValidateToken2022Check<'info> {
+impl ValidateToken2022Check {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_token_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_token_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateTokenCheck<'info> {
+pub struct ValidateTokenCheck {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub authority: &'info Signer,
-    pub token_program: &'info Program<Token>,
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub authority: Signer,
+    pub token_program: Program<Token>,
 }
 
-impl<'info> ValidateTokenCheck<'info> {
+impl ValidateTokenCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_token_interface_check.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_token_interface_check.rs
@@ -4,15 +4,15 @@ use {
 };
 
 #[derive(Accounts)]
-pub struct ValidateTokenInterfaceCheck<'info> {
+pub struct ValidateTokenInterfaceCheck {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info InterfaceAccount<Token>,
-    pub mint: &'info InterfaceAccount<Mint>,
-    pub authority: &'info Signer,
-    pub token_program: &'info Interface<TokenInterface>,
+    pub token_account: InterfaceAccount<Token>,
+    pub mint: InterfaceAccount<Mint>,
+    pub authority: Signer,
+    pub token_program: Interface<TokenInterface>,
 }
 
-impl<'info> ValidateTokenInterfaceCheck<'info> {
+impl ValidateTokenInterfaceCheck {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/tests/programs/test-token-validate/src/instructions/validate_token_no_program.rs
+++ b/tests/programs/test-token-validate/src/instructions/validate_token_no_program.rs
@@ -6,14 +6,14 @@ use {
 /// No `token_program` field — program is known at compile time from
 /// Account<Token>.
 #[derive(Accounts)]
-pub struct ValidateTokenNoProgram<'info> {
+pub struct ValidateTokenNoProgram {
     #[account(token::mint = mint, token::authority = authority)]
-    pub token_account: &'info Account<Token>,
-    pub mint: &'info Account<Mint>,
-    pub authority: &'info Signer,
+    pub token_account: Account<Token>,
+    pub mint: Account<Mint>,
+    pub authority: Signer,
 }
 
-impl<'info> ValidateTokenNoProgram<'info> {
+impl ValidateTokenNoProgram {
     #[inline(always)]
     pub fn handler(&self) -> Result<(), ProgramError> {
         Ok(())


### PR DESCRIPTION
### Problem

Currently, the `Accounts` derive uses an `'info` lifetime and expects accounts to be specified as references. This is not strictly necessary and the syntax can be simplified.

Current use of `#[derive(Accounts)]` with `'info` lifetime:
```rust
#[derive(Accounts)]
pub struct Deposit<'info> {
    pub user: &'info mut Signer,
    #[account(mut, seeds = [b"vault", user], bump)]
    pub vault: &'info mut UncheckedAccount,
    pub system_program: &'info Program<System>,
}
```

### Solution

Allow account fields to be defined as owned types, which removes the need to use a lifetime. Since an `AccountView` holds a raw pointer, passing a reference or its value should be equivalent.

The `#[derive(Accounts)]` after the changes in this PR:
```rust
#[derive(Accounts)]
pub struct Deposit {
    #[account(mut)]
    pub user: Signer,
    #[account(mut, seeds = [b"vault", user], bump)]
    pub vault: UncheckedAccount,
    pub system_program: Program<System>,
}
```