### PR TITLE
fix(derive): Handle Constant u8 Values in Typed Seed Resolution

### DIFF
--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -359,8 +359,7 @@ pub(crate) fn seed_slice_expr_for_parse(
 /// - Bare identifier matching an instruction arg -> type-appropriate conversion
 /// - Dotted field access (`config.namespace`) -> raw byte cast via
 ///   `from_raw_parts`
-/// - Anything else -> raw byte cast via `from_raw_parts` (handles constants,
-///   function calls, etc.)
+/// - Anything else -> emit as-is, let rustc decide
 pub(crate) fn typed_seed_slice_expr(
     expr: &Expr,
     field_names: &[String],
@@ -413,19 +412,8 @@ pub(crate) fn typed_seed_slice_expr(
             }}
         }
 
-        // Other expression (function call, index, etc.) — reinterpret as LE
-        // bytes. This handles constants, arithmetic, and any other expression
-        // that produces a seed-compatible value.
-        _ => quote! {{
-            const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
-            let __val = #expr;
-            unsafe {
-                core::slice::from_raw_parts(
-                    &__val as *const _ as *const u8,
-                    core::mem::size_of_val(&__val),
-                )
-            }
-        }},
+        // Byte literal or other expression — pass through and let rustc decide.
+        _ => quote! { #expr as &[u8] },
     }
 }
 
@@ -480,17 +468,8 @@ pub(crate) fn typed_seed_method_expr(
             }}
         }
 
-        // Other expression — reinterpret as LE bytes.
-        _ => quote! {{
-            const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
-            let __val = #expr;
-            unsafe {
-                core::slice::from_raw_parts(
-                    &__val as *const _ as *const u8,
-                    core::mem::size_of_val(&__val),
-                )
-            }
-        }},
+        // Other expression — pass through and let rustc decide.
+        _ => quote! { #expr as &[u8] },
     }
 }
 

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -359,7 +359,8 @@ pub(crate) fn seed_slice_expr_for_parse(
 /// - Bare identifier matching an instruction arg -> type-appropriate conversion
 /// - Dotted field access (`config.namespace`) -> raw byte cast via
 ///   `from_raw_parts`
-/// - Anything else -> emit as-is, let rustc decide
+/// - Anything else -> raw byte cast via `from_raw_parts` (handles constants,
+///   function calls, etc.)
 pub(crate) fn typed_seed_slice_expr(
     expr: &Expr,
     field_names: &[String],
@@ -383,8 +384,17 @@ pub(crate) fn typed_seed_slice_expr(
                 }
             }
 
-            // Unknown — emit as-is, rustc will error
-            quote! { &#ident as &[u8] }
+            // Unknown bare ident (e.g. a constant like SIDE_A: u8) —
+            // reinterpret as LE bytes, same as field access below.
+            quote! {{
+                const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
+                unsafe {
+                    core::slice::from_raw_parts(
+                        &#ident as *const _ as *const u8,
+                        core::mem::size_of_val(&#ident),
+                    )
+                }
+            }}
         }
 
         // Dotted field access: config.namespace
@@ -403,8 +413,19 @@ pub(crate) fn typed_seed_slice_expr(
             }}
         }
 
-        // Byte literal or other expression
-        _ => quote! { #expr as &[u8] },
+        // Other expression (function call, index, etc.) — reinterpret as LE
+        // bytes. This handles constants, arithmetic, and any other expression
+        // that produces a seed-compatible value.
+        _ => quote! {{
+            const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
+            let __val = #expr;
+            unsafe {
+                core::slice::from_raw_parts(
+                    &__val as *const _ as *const u8,
+                    core::mem::size_of_val(&__val),
+                )
+            }
+        }},
     }
 }
 
@@ -434,7 +455,16 @@ pub(crate) fn typed_seed_method_expr(
                 }
             }
 
-            quote! { &#ident as &[u8] }
+            // Unknown bare ident (e.g. a constant) — reinterpret as LE bytes.
+            quote! {{
+                const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
+                unsafe {
+                    core::slice::from_raw_parts(
+                        &#ident as *const _ as *const u8,
+                        core::mem::size_of_val(&#ident),
+                    )
+                }
+            }}
         }
 
         // Dotted field access: config.namespace -> self.config.namespace
@@ -450,7 +480,17 @@ pub(crate) fn typed_seed_method_expr(
             }}
         }
 
-        _ => quote! { #expr as &[u8] },
+        // Other expression — reinterpret as LE bytes.
+        _ => quote! {{
+            const _: () = assert!(cfg!(target_endian = "little"), "typed seeds require little-endian");
+            let __val = #expr;
+            unsafe {
+                core::slice::from_raw_parts(
+                    &__val as *const _ as *const u8,
+                    core::mem::size_of_val(&__val),
+                )
+            }
+        }},
     }
 }
 

--- a/tests/programs/test-pda/src/instructions/init_const_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_const_seed.rs
@@ -1,0 +1,26 @@
+use {
+    crate::state::{IntakeQueue, IntakeQueueInner, SIDE_A},
+    quasar_lang::prelude::*,
+};
+
+#[derive(Accounts)]
+pub struct InitConstSeed {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    #[account(mut, init, payer = payer, seeds = IntakeQueue::seeds(authority, SIDE_A), bump)]
+    pub intake: Account<IntakeQueue>,
+    pub system_program: Program<System>,
+}
+
+impl InitConstSeed {
+    #[inline(always)]
+    pub fn handler(&mut self, bumps: &InitConstSeedBumps) -> Result<(), ProgramError> {
+        self.intake.set_inner(IntakeQueueInner {
+            authority: *self.authority.address(),
+            side: SIDE_A,
+            bump: bumps.intake,
+        });
+        Ok(())
+    }
+}

--- a/tests/programs/test-pda/src/instructions/mod.rs
+++ b/tests/programs/test-pda/src/instructions/mod.rs
@@ -42,3 +42,6 @@ pub use init_scoped_item::*;
 
 pub mod verify_scoped_item;
 pub use verify_scoped_item::*;
+
+pub mod init_const_seed;
+pub use init_const_seed::*;

--- a/tests/programs/test-pda/src/lib.rs
+++ b/tests/programs/test-pda/src/lib.rs
@@ -88,4 +88,9 @@ mod quasar_test_pda {
     pub fn verify_scoped_item(ctx: Ctx<VerifyScopedItem>) -> Result<(), ProgramError> {
         ctx.accounts.handler()
     }
+
+    #[instruction(discriminator = 15)]
+    pub fn init_const_seed(ctx: Ctx<InitConstSeed>) -> Result<(), ProgramError> {
+        ctx.accounts.handler(&ctx.bumps)
+    }
 }

--- a/tests/programs/test-pda/src/state.rs
+++ b/tests/programs/test-pda/src/state.rs
@@ -1,5 +1,8 @@
 use quasar_lang::prelude::*;
 
+pub const SIDE_A: u8 = 0;
+pub const SIDE_B: u8 = 1;
+
 #[account(discriminator = 1, set_inner)]
 #[seeds(b"config")]
 pub struct ConfigAccount {
@@ -69,5 +72,13 @@ pub struct NamespaceConfig {
 pub struct ScopedItem {
     pub namespace: u32,
     pub data: u64,
+    pub bump: u8,
+}
+
+#[account(discriminator = 11, set_inner)]
+#[seeds(b"intake", authority: Address, side: u8)]
+pub struct IntakeQueue {
+    pub authority: Address,
+    pub side: u8,
     pub bump: u8,
 }


### PR DESCRIPTION
When a typed seed argument is a bare identifier that doesn't match an account field or instruction arg (e.g., a constant), the fallback code emitted `&#ident as &[u8]`. This is an invalid cast for scalar types

This PR fixes the issue outlined above (#128) by changing the fallback paths in `typed_seed_slice_expr` and `typed_seed_method_expr` to use `core::slice::from_raw_parts`, which is the same zero-cost byte reinterpretation already used for dotted field access seeds