### PR TITLE
feat(examples): add anchor-v2 vault benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "3"
 members = ["lang", "derive", "pod", "spl", "idl", "profile", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli"]
-exclude = ["examples/anchor-vault"]
+exclude = ["examples/anchor-vault", "examples/anchor-v2-vault"]
 
 [workspace.package]
 version = "0.0.0"

--- a/examples/anchor-v2-vault/Cargo.toml
+++ b/examples/anchor-v2-vault/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "anchor-v2-vault"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint", "dep:borsh"]
+default = ["no-log-ix-name"]
+idl-build = ["anchor-lang-v2/idl-build"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+] }
+
+[dependencies]
+anchor-lang-v2 = { git = "https://github.com/solana-foundation/anchor.git", rev = "01126a79", default-features = false, features = ["alloc"] }
+borsh = { version = "1", optional = true }
+bytemuck = { version = "1", features = ["derive"] }
+pinocchio = { version = "0.11", default-features = false, features = ["copy"] }
+pinocchio-system = "0.6"
+wincode = { version = "0.4", features = ["derive"] }
+
+[dev-dependencies]
+mollusk-svm = "0.10.3"
+solana-account = { version = "3.4.0" }
+solana-address = { version = "2.2.0", features = ["decode"] }
+solana-instruction = { version = "3.2.0", features = ["bincode"] }
+
+# Matches upstream anchor bench/Cargo.toml so CU numbers are directly
+# comparable with solana-foundation/anchor's own v2 bench.
+[profile.release]
+overflow-checks = false
+lto = "fat"
+codegen-units = 1
+opt-level = 3

--- a/examples/anchor-v2-vault/src/lib.rs
+++ b/examples/anchor-v2-vault/src/lib.rs
@@ -1,0 +1,56 @@
+use anchor_lang_v2::prelude::*;
+
+#[cfg(test)]
+mod tests;
+
+declare_id!("33333333333333333333333333333333333333333333");
+
+#[program]
+pub mod anchor_v2_vault {
+    use super::*;
+
+    #[discrim = 0]
+    pub fn deposit(ctx: &mut Context<'_, Deposit>, amount: u64) -> Result<()> {
+        pinocchio_system::instructions::Transfer {
+            from: ctx.accounts.user.account(),
+            to: ctx.accounts.vault.account(),
+            lamports: amount,
+        }
+        .invoke()?;
+        Ok(())
+    }
+
+    #[discrim = 1]
+    pub fn withdraw(ctx: &mut Context<'_, Withdraw>, amount: u64) -> Result<()> {
+        let mut vault = *ctx.accounts.vault.account();
+        let mut user = *ctx.accounts.user.account();
+        vault.set_lamports(vault.lamports() - amount);
+        user.set_lamports(user.lamports() + amount);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Deposit {
+    #[account(mut)]
+    pub user: Signer,
+    #[account(
+        mut,
+        seeds = [b"vault", user.account().address().as_ref()],
+        bump,
+    )]
+    pub vault: UncheckedAccount,
+    pub system_program: Program<System>,
+}
+
+#[derive(Accounts)]
+pub struct Withdraw {
+    #[account(mut)]
+    pub user: Signer,
+    #[account(
+        mut,
+        seeds = [b"vault", user.account().address().as_ref()],
+        bump,
+    )]
+    pub vault: UncheckedAccount,
+}

--- a/examples/anchor-v2-vault/src/tests.rs
+++ b/examples/anchor-v2-vault/src/tests.rs
@@ -1,0 +1,168 @@
+use mollusk_svm::{program::keyed_account_for_system_program, Mollusk};
+
+use solana_account::Account;
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+fn setup() -> Mollusk {
+    let id_bytes: [u8; 32] = crate::ID.to_bytes();
+    let program_id = Address::new_from_array(id_bytes);
+    Mollusk::new(&program_id, "../../target/deploy/anchor_v2_vault")
+}
+
+fn program_id() -> Address {
+    Address::new_from_array(crate::ID.to_bytes())
+}
+
+/// Anchor v2 `#[discrim = N]` — single-byte discriminator, not sha256.
+fn deposit_ix_data(amount: u64) -> Vec<u8> {
+    let mut data = vec![0u8];
+    data.extend_from_slice(&amount.to_le_bytes());
+    data
+}
+
+fn withdraw_ix_data(amount: u64) -> Vec<u8> {
+    let mut data = vec![1u8];
+    data.extend_from_slice(&amount.to_le_bytes());
+    data
+}
+
+#[test]
+fn test_deposit() {
+    let mollusk = setup();
+    let pid = program_id();
+
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let user = Address::new_unique();
+    let user_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let (vault, _vault_bump) = Address::find_program_address(&[b"vault", user.as_ref()], &pid);
+    let vault_account = Account::new(0, 0, &system_program);
+
+    let deposit_amount: u64 = 1_000_000_000;
+
+    let instruction = Instruction {
+        program_id: pid,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+        data: deposit_ix_data(deposit_amount),
+    };
+
+    let result = mollusk.process_instruction(
+        &instruction,
+        &[
+            (user, user_account.clone()),
+            (vault, vault_account.clone()),
+            (system_program, system_program_account.clone()),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "deposit failed: {:?}",
+        result.program_result
+    );
+
+    let user_after = result.resulting_accounts[0].1.lamports;
+    let vault_after = result.resulting_accounts[1].1.lamports;
+
+    assert_eq!(
+        user_after,
+        10_000_000_000 - deposit_amount,
+        "user lamports after deposit"
+    );
+    assert_eq!(vault_after, deposit_amount, "vault lamports after deposit");
+
+    println!("\n========================================");
+    println!("  ANCHOR V2 DEPOSIT CU: {}", result.compute_units_consumed);
+    println!("========================================\n");
+}
+
+#[test]
+fn test_withdraw() {
+    let mollusk = setup();
+    let pid = program_id();
+
+    let (system_program, system_program_account) = keyed_account_for_system_program();
+
+    let user = Address::new_unique();
+    let user_account = Account::new(10_000_000_000, 0, &system_program);
+
+    let (vault, _vault_bump) = Address::find_program_address(&[b"vault", user.as_ref()], &pid);
+    let vault_account = Account::new(0, 0, &pid);
+
+    let deposit_amount: u64 = 1_000_000_000;
+
+    // First deposit
+    let deposit_ix = Instruction {
+        program_id: pid,
+        accounts: vec![
+            AccountMeta::new(user, true),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+        data: deposit_ix_data(deposit_amount),
+    };
+
+    let result = mollusk.process_instruction(
+        &deposit_ix,
+        &[
+            (user, user_account),
+            (vault, vault_account),
+            (system_program, system_program_account),
+        ],
+    );
+    assert!(
+        result.program_result.is_ok(),
+        "deposit failed: {:?}",
+        result.program_result
+    );
+
+    let user_after_deposit = result.resulting_accounts[0].1.clone();
+    let vault_after_deposit = result.resulting_accounts[1].1.clone();
+
+    // Now withdraw
+    let withdraw_amount: u64 = 500_000_000;
+
+    let withdraw_ix = Instruction {
+        program_id: pid,
+        accounts: vec![AccountMeta::new(user, true), AccountMeta::new(vault, false)],
+        data: withdraw_ix_data(withdraw_amount),
+    };
+
+    let result = mollusk.process_instruction(
+        &withdraw_ix,
+        &[
+            (user, user_after_deposit.clone()),
+            (vault, vault_after_deposit),
+        ],
+    );
+
+    assert!(
+        result.program_result.is_ok(),
+        "withdraw failed: {:?}",
+        result.program_result
+    );
+
+    let user_final = result.resulting_accounts[0].1.lamports;
+    let vault_final = result.resulting_accounts[1].1.lamports;
+
+    assert_eq!(
+        user_final,
+        user_after_deposit.lamports + withdraw_amount,
+        "user lamports after withdraw"
+    );
+    assert_eq!(
+        vault_final,
+        deposit_amount - withdraw_amount,
+        "vault lamports after withdraw"
+    );
+
+    println!("\n========================================");
+    println!("  ANCHOR V2 WITHDRAW CU: {}", result.compute_units_consumed);
+    println!("========================================\n");
+}


### PR DESCRIPTION
## Summary

Adds an \`anchor-v2-vault\` example benchmarking the upcoming [anchor-lang-v2](https://github.com/solana-foundation/anchor/pull/4393) (pinocchio-backed, trait-based account system) against the existing \`quasar-vault\`. Shape-matches \`examples/vault\` so the comparison is apples-to-apples.

- Pinned to \`solana-foundation/anchor\` \`rev = 01126a79\` on the \`notdeghost/anchor-v2-prototype\` branch.
- Drops the \`guardrails\` feature to match upstream's "production" v2 profile.
- Uses the same \`[profile.release]\` (\`overflow-checks=false\`, \`lto=fat\`, \`codegen-units=1\`) as \`solana-foundation/anchor/bench/Cargo.toml\`.
- Same mollusk harness and \`declare_id\` (\`33..33\`) as \`quasar-vault\` so PDA derivation cost is identical between the two.

## Results

Measured on mollusk-svm 0.10.3, solana tools v1.52:

| Instruction | \`quasar-vault\` | \`anchor-v2-vault\` | delta |
|-------------|---------------:|------------------:|------:|
| deposit     |          1,568 |             1,561 |    -7 |
| withdraw    |            403 |               382 |   -21 |

## Test plan

- [x] \`cargo build-sbf --tools-version v1.52 --manifest-path examples/anchor-v2-vault/Cargo.toml\` succeeds
- [x] \`cd examples/anchor-v2-vault && cargo test -- --nocapture --test-threads=1\` passes and prints CU numbers above
- [x] Existing \`anchor-vault\` and \`quasar-vault\` examples unchanged
- [ ] Reviewer verifies the v2 rev pin is acceptable (currently at prototype tip; may want to bump later)