### PR TITLE
fix(cli): detect incompatible cargo-build-sbf before it panics

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -6,9 +6,8 @@ mod lockfile;
 mod watch;
 
 pub(crate) use watch::watch_loop;
-/// platform-tools v1.52 ships Cargo 1.89 which supports Cargo.lock v4.
-/// v1.51 ships Cargo 1.84 which does not, causing "duplicate lang item" errors
-/// when its stale host-target artifacts conflict with the system toolchain.
+/// platform-tools v1.52 ships Cargo 1.89 which supports Cargo.lock v4
+/// and handles edition-2024 crate manifests in the Solana dep tree.
 const PLATFORM_TOOLS_VERSION: &str = "v1.52";
 
 use {
@@ -50,6 +49,10 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
     let sp = style::spinner("Building...");
 
     if config.is_solana_toolchain() {
+        toolchain::check_build_sbf_supports(PLATFORM_TOOLS_VERSION).map_err(|e| {
+            sp.finish_and_clear();
+            CliError::message(e)
+        })?;
         ensure_lockfile(&sp)?;
     }
 
@@ -175,6 +178,10 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
     let sp = style::spinner("Profile build...");
 
     if config.is_solana_toolchain() {
+        toolchain::check_build_sbf_supports(PLATFORM_TOOLS_VERSION).map_err(|e| {
+            sp.finish_and_clear();
+            CliError::message(e)
+        })?;
         ensure_lockfile(&sp)?;
     }
 
@@ -183,8 +190,12 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
 
     let output = if config.is_solana_toolchain() {
         let mut cmd = Command::new("cargo");
-        cmd.args(["build-sbf", "--tools-version", PLATFORM_TOOLS_VERSION]);
-        cmd.arg("--debug");
+        cmd.args([
+            "build-sbf",
+            "--tools-version",
+            PLATFORM_TOOLS_VERSION,
+            "--debug",
+        ]);
         if scoped {
             cmd.args(["--manifest-path", &manifest.to_string_lossy()]);
         }

--- a/cli/src/toolchain.rs
+++ b/cli/src/toolchain.rs
@@ -8,3 +8,40 @@ pub fn has_sbpf_linker() -> bool {
         .ok()
         .is_some_and(|o| o.status.success())
 }
+
+/// Ensure the installed `cargo-build-sbf` supports the given platform-tools
+/// version. Older Agave releases panic with an opaque `unwrap()` when asked
+/// for a version they don't know about.
+pub fn check_build_sbf_supports(required: &str) -> Result<(), String> {
+    let output = Command::new("cargo")
+        .args(["build-sbf", "--version"])
+        .output()
+        .map_err(|_| {
+            "cargo-build-sbf is not installed.\n\
+             Install Agave CLI: https://docs.anza.xyz/cli/install"
+                .to_string()
+        })?;
+
+    let version_text = String::from_utf8_lossy(&output.stdout);
+
+    // Parse "platform-tools vX.YZ" from the version output.
+    let bundled = version_text
+        .lines()
+        .find_map(|line| line.strip_prefix("platform-tools "))
+        .unwrap_or("unknown");
+
+    if parse_tools_version(bundled) < parse_tools_version(required) {
+        return Err(format!(
+            "quasar requires platform-tools {required}, but the installed cargo-build-sbf only \
+             supports {bundled}.\nUpdate Agave CLI:  agave-install update",
+        ));
+    }
+    Ok(())
+}
+
+/// Parse "vX.YZ" → numeric value for comparison (e.g. "v1.52" → 152).
+fn parse_tools_version(s: &str) -> u32 {
+    let s = s.strip_prefix('v').unwrap_or(s);
+    let (major, minor) = s.split_once('.').unwrap_or(("0", "0"));
+    major.parse::<u32>().unwrap_or(0) * 100 + minor.parse::<u32>().unwrap_or(0)
+}

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -19,7 +19,7 @@ quasar-pod = { version = "0.0", path = "../pod" }
 const-crypto = "0.3.0"
 solana-program-error = "3.0.0"
 solana-account-view = "2.0.0"
-solana-address = { version = "2.2.0", features = ["wincode", "decode", "copy"] }
+solana-address = { version = ">=2.2, <2.6", features = ["wincode", "decode", "copy"] }
 solana-instruction-view = { version = "2.0.0", features = ["cpi"] }
 solana-program-log = "1.0.0"
 


### PR DESCRIPTION
## Summary
- Add pre-flight version check before invoking `cargo build-sbf --tools-version v1.52`
- When Agave is too old (e.g. 3.0.0 with platform-tools v1.51), show a clear error instead of letting it panic with `unwrap() on None`

## Context
`quasar build` panicked with an opaque `unwrap() on None` in `generate_toolchain_name` for users on Agave 3.0.0. The v1.52 pin is necessary because the Solana dep tree now includes edition-2024 crates (`wincode 0.5.1`, `indexmap 2.14`, etc.) that v1.51's Cargo 1.84 cannot parse. Pinning individual deps was explored but is whack-a-mole — requiring Agave >= 3.1 with a clear error message is the sustainable fix.

**Before:** `thread 'main' panicked at ... called Option::unwrap() on a None value`
**After:** `quasar requires platform-tools v1.52, but the installed cargo-build-sbf only supports v1.51. Update Agave CLI: agave-install update`

## Test plan
- [x] `cargo check` passes for full workspace
- [x] Pre-push hooks (fmt + clippy) pass
- [x] Verified error message triggers correctly with Agave 3.0.0