### PR TITLE
FIX: map String<N> to DynString<P> in generated Rust client

### DIFF
--- a/examples/multisig/client/src/instructions/mod.rs
+++ b/examples/multisig/client/src/instructions/mod.rs
@@ -1,4 +1,4 @@
-use quasar_lang::client::DynBytes;
+use quasar_lang::client::DynString;
 pub mod create;
 pub mod deposit;
 pub mod execute_transfer;
@@ -9,7 +9,7 @@ pub use {create::*, deposit::*, execute_transfer::*, set_label::*};
 pub enum ProgramInstruction {
     Create { threshold: u8 },
     Deposit { amount: u64 },
-    SetLabel { label: DynBytes<u8> },
+    SetLabel { label: DynString<u8> },
     ExecuteTransfer { amount: u64 },
 }
 
@@ -28,7 +28,7 @@ pub fn decode_instruction(data: &[u8]) -> Option<ProgramInstruction> {
         }
         2 => {
             let payload = &data[1..];
-            let label: DynBytes<u8> = wincode::deserialize(payload).ok()?;
+            let label: DynString<u8> = wincode::deserialize(payload).ok()?;
             Some(ProgramInstruction::SetLabel { label })
         }
         3 => {

--- a/examples/multisig/client/src/instructions/set_label.rs
+++ b/examples/multisig/client/src/instructions/set_label.rs
@@ -1,6 +1,6 @@
 use {
     crate::ID,
-    quasar_lang::client::DynBytes,
+    quasar_lang::client::DynString,
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
 };
@@ -9,7 +9,7 @@ pub struct SetLabelInstruction {
     pub creator: Address,
     pub config: Address,
     pub system_program: Address,
-    pub label: DynBytes<u8>,
+    pub label: DynString<u8>,
 }
 
 impl From<SetLabelInstruction> for Instruction {

--- a/examples/multisig/client/src/state/multisig_config.rs
+++ b/examples/multisig/client/src/state/multisig_config.rs
@@ -1,5 +1,5 @@
 use {
-    quasar_lang::client::{DynBytes, DynVec},
+    quasar_lang::client::{DynString, DynVec},
     solana_address::Address,
     std::mem::MaybeUninit,
     wincode::{
@@ -17,14 +17,14 @@ pub struct MultisigConfig {
     pub creator: Address,
     pub threshold: u8,
     pub bump: u8,
-    pub label: DynBytes<u8>,
+    pub label: DynString<u8>,
     pub signers: DynVec<Address, u16>,
 }
 
 unsafe impl<C: ConfigCore> SchemaWrite<C> for MultisigConfig
 where
     Address: SchemaWrite<C, Src = Address>,
-    DynBytes<u8>: SchemaWrite<C, Src = DynBytes<u8>>,
+    DynString<u8>: SchemaWrite<C, Src = DynString<u8>>,
     DynVec<Address, u16>: SchemaWrite<C, Src = DynVec<Address, u16>>,
     u8: SchemaWrite<C, Src = u8>,
 {
@@ -34,7 +34,7 @@ where
         Ok(1 + <Address as SchemaWrite<C>>::size_of(&src.creator)?
             + <u8 as SchemaWrite<C>>::size_of(&src.threshold)?
             + <u8 as SchemaWrite<C>>::size_of(&src.bump)?
-            + <DynBytes<u8> as SchemaWrite<C>>::size_of(&src.label)?
+            + <DynString<u8> as SchemaWrite<C>>::size_of(&src.label)?
             + <DynVec<Address, u16> as SchemaWrite<C>>::size_of(&src.signers)?)
     }
 
@@ -43,7 +43,7 @@ where
         <Address as SchemaWrite<C>>::write(writer.by_ref(), &src.creator)?;
         <u8 as SchemaWrite<C>>::write(writer.by_ref(), &src.threshold)?;
         <u8 as SchemaWrite<C>>::write(writer.by_ref(), &src.bump)?;
-        <DynBytes<u8> as SchemaWrite<C>>::write(writer.by_ref(), &src.label)?;
+        <DynString<u8> as SchemaWrite<C>>::write(writer.by_ref(), &src.label)?;
         <DynVec<Address, u16> as SchemaWrite<C>>::write(writer.by_ref(), &src.signers)?;
         Ok(())
     }
@@ -52,7 +52,7 @@ where
 unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for MultisigConfig
 where
     Address: SchemaRead<'de, C, Dst = Address>,
-    DynBytes<u8>: SchemaRead<'de, C, Dst = DynBytes<u8>>,
+    DynString<u8>: SchemaRead<'de, C, Dst = DynString<u8>>,
     DynVec<Address, u16>: SchemaRead<'de, C, Dst = DynVec<Address, u16>>,
     u8: SchemaRead<'de, C, Dst = u8>,
 {
@@ -67,7 +67,7 @@ where
             creator: <Address as SchemaRead<'de, C>>::get(reader.by_ref())?,
             threshold: <u8 as SchemaRead<'de, C>>::get(reader.by_ref())?,
             bump: <u8 as SchemaRead<'de, C>>::get(reader.by_ref())?,
-            label: <DynBytes<u8> as SchemaRead<'de, C>>::get(reader.by_ref())?,
+            label: <DynString<u8> as SchemaRead<'de, C>>::get(reader.by_ref())?,
             signers: <DynVec<Address, u16> as SchemaRead<'de, C>>::get(reader.by_ref())?,
         });
         Ok(())

--- a/examples/multisig/src/tests.rs
+++ b/examples/multisig/src/tests.rs
@@ -1,7 +1,7 @@
 extern crate std;
 use {
     alloc::vec,
-    quasar_lang::client::{DynBytes, DynVec},
+    quasar_lang::client::{DynString, DynVec},
     quasar_multisig_client::*,
     quasar_svm::{Account, Instruction, Pubkey, QuasarSvm},
     solana_instruction::AccountMeta,
@@ -39,7 +39,7 @@ fn config_account(
         creator,
         threshold,
         bump,
-        label: DynBytes::<u8>::new(label.to_vec()),
+        label: DynString::<u8>::new(String::from_utf8(label.to_vec()).unwrap()),
         signers: DynVec::<Pubkey, u16>::new(signers.to_vec()),
     };
     Account {
@@ -165,7 +165,7 @@ fn test_set_label() {
         creator,
         config,
         system_program,
-        label: DynBytes::<u8>::new(label.as_bytes().to_vec()),
+        label: label.into(),
     }
     .into();
 

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -208,18 +208,17 @@ fn emit_instructions(
     let mut ix_files: Vec<(String, String)> = Vec::new();
 
     // Scan all instruction arg types for imports needed by mod.rs
-    let mut needs_dyn_bytes = false;
-    let mut needs_dyn_vec = false;
+    let mut needs = WrapperNeeds::default();
     let mut needs_address = false;
     for ix in &idl.instructions {
         for arg in &ix.args {
-            collect_wrapper_needs(&arg.ty, &mut needs_dyn_bytes, &mut needs_dyn_vec);
+            collect_wrapper_needs(&arg.ty, &mut needs);
             if field_needs_address(&arg.ty) {
                 needs_address = true;
             }
         }
     }
-    emit_wrapper_imports(&mut mod_rs, needs_dyn_bytes, needs_dyn_vec);
+    emit_wrapper_imports(&mut mod_rs, &needs);
     if needs_address {
         mod_rs.push_str("use solana_address::Address;\n");
     }
@@ -890,10 +889,9 @@ fn emit_field_imports<'a>(
     type_map: &HashMap<String, Vec<IdlField>>,
 ) {
     let mut needs_address = false;
-    let mut needs_dyn_bytes = false;
-    let mut needs_dyn_vec = false;
+    let mut needs = WrapperNeeds::default();
     for ty in types {
-        collect_wrapper_needs(ty, &mut needs_dyn_bytes, &mut needs_dyn_vec);
+        collect_wrapper_needs(ty, &mut needs);
         if field_needs_address(ty) {
             needs_address = true;
         }
@@ -902,7 +900,7 @@ fn emit_field_imports<'a>(
     if needs_address {
         out.push_str("use solana_address::Address;\n");
     }
-    emit_wrapper_imports(out, needs_dyn_bytes, needs_dyn_vec);
+    emit_wrapper_imports(out, &needs);
 }
 
 /// Emit struct definition + manual SchemaWrite/SchemaRead impls with
@@ -1058,7 +1056,7 @@ fn rust_field_type(ty: &IdlType) -> String {
             "publicKey" => "Address".to_string(),
             other => other.to_string(),
         },
-        IdlType::DynString { string } => prefix_generic("DynBytes", string.prefix_bytes),
+        IdlType::DynString { string } => prefix_generic("DynString", string.prefix_bytes),
         IdlType::DynVec { vec } => {
             let inner = rust_field_type(&vec.items);
             format!("DynVec<{}, {}>", inner, prefix_rust_type(vec.prefix_bytes))
@@ -1080,15 +1078,22 @@ fn prefix_rust_type(prefix_bytes: usize) -> &'static str {
     }
 }
 
-fn collect_wrapper_needs(ty: &IdlType, needs_dyn_bytes: &mut bool, needs_dyn_vec: &mut bool) {
+fn collect_wrapper_needs(ty: &IdlType, needs: &mut WrapperNeeds) {
     match ty {
-        IdlType::DynString { .. } => *needs_dyn_bytes = true,
+        IdlType::DynString { .. } => needs.dyn_string = true,
         IdlType::DynVec { vec } => {
-            *needs_dyn_vec = true;
-            collect_wrapper_needs(&vec.items, needs_dyn_bytes, needs_dyn_vec);
+            needs.dyn_vec = true;
+            collect_wrapper_needs(&vec.items, needs);
         }
         _ => {}
     }
+}
+
+#[derive(Default)]
+struct WrapperNeeds {
+    dyn_bytes: bool,
+    dyn_string: bool,
+    dyn_vec: bool,
 }
 
 fn format_disc_list(disc: &[u8]) -> String {
@@ -1180,12 +1185,15 @@ fn field_needs_address(ty: &IdlType) -> bool {
     }
 }
 
-fn emit_wrapper_imports(out: &mut String, needs_dyn_bytes: bool, needs_dyn_vec: bool) {
+fn emit_wrapper_imports(out: &mut String, needs: &WrapperNeeds) {
     let mut wrappers = Vec::new();
-    if needs_dyn_bytes {
+    if needs.dyn_bytes {
         wrappers.push("DynBytes");
     }
-    if needs_dyn_vec {
+    if needs.dyn_string {
+        wrappers.push("DynString");
+    }
+    if needs.dyn_vec {
         wrappers.push("DynVec");
     }
     if !wrappers.is_empty() {

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -809,11 +809,12 @@ fn rust_codegen_account_metas() {
 // Instruction codegen: dynamic types use wrapper types
 //
 // This is the critical wire compatibility test. String<N> maps to
-// DynBytes<u8> (u8 prefix) and Vec<T, N> maps to DynVec<T, u16> (u16 prefix).
+// DynString<u8> (u8 prefix, wire-compatible with DynBytes<u8>) and Vec<T, N>
+// maps to DynVec<T, u16> (u16 prefix).
 // ---------------------------------------------------------------------------
 
 #[test]
-fn rust_codegen_dynamic_string_uses_dyn_bytes() {
+fn rust_codegen_dynamic_string_uses_dyn_string() {
     let file = parse_file(
         r#"
         #[program]
@@ -832,12 +833,16 @@ fn rust_codegen_dynamic_string_uses_dyn_bytes() {
     let code = all_content(&files);
 
     assert!(
-        code.contains("pub name: DynBytes<u8>,"),
-        "String<N> must map to DynBytes<u8>, got:\n{code}"
+        code.contains("pub name: DynString<u8>,"),
+        "String<N> must map to DynString<u8>, got:\n{code}"
     );
     assert!(
         !code.contains("pub name: Vec<u8>"),
         "must NOT use Vec<u8> — different length prefix: {code}"
+    );
+    assert!(
+        !code.contains("pub name: DynBytes"),
+        "String<N> must use DynString, not DynBytes: {code}"
     );
 }
 
@@ -862,8 +867,8 @@ fn rust_codegen_dynamic_types_import() {
 
     // Only the actually-used wrapper type is imported
     assert!(
-        code.contains("DynBytes"),
-        "DynBytes must be imported: {code}"
+        code.contains("DynString"),
+        "DynString must be imported: {code}"
     );
     assert!(
         !code.contains("DynVec"),
@@ -902,8 +907,8 @@ fn rust_codegen_dyn_bytes_u8_prefix() {
     let code = all_content(&files);
 
     assert!(
-        code.contains("pub name: DynBytes<u8>,"),
-        "String<N> must map to DynBytes<u8>, got:\n{code}"
+        code.contains("pub name: DynString<u8>,"),
+        "String<N> must map to DynString<u8>, got:\n{code}"
     );
 }
 

--- a/lang/src/client.rs
+++ b/lang/src/client.rs
@@ -6,10 +6,13 @@
 //! | Type | Wire format |
 //! |------|-------------|
 //! | [`DynBytes<P>`] | `P` LE length prefix + raw bytes (`P` defaults to `u32`) |
+//! | [`DynString<P>`] | `P` LE length prefix + UTF-8 bytes (wire-identical to `DynBytes<P>`) |
 //! | [`DynVec<T, P>`] | `P` LE count prefix + each item serialized |
 //!
 //! The prefix type `P` (u8, u16, or u32) must match the on-chain declaration.
-//! For example, `String<u8, 100>` on-chain requires `DynBytes<u8>` off-chain.
+//! For example, `String<u8, 100>` on-chain maps to `DynString<u8>` off-chain
+//! (accepts `String`/`&str` directly), while `Vec<u8, u8, 100>` maps to
+//! `DynBytes<u8>`.
 //!
 //! **This is the only module in `quasar-lang` that allocates** — it uses
 //! `alloc::vec::Vec` for instruction data buffers since off-chain code runs
@@ -22,11 +25,11 @@ pub use solana_instruction::{AccountMeta, Instruction};
 // Re-export wincode for downstream derive macro codegen.
 pub use wincode;
 use {
-    alloc::vec::Vec,
+    alloc::{string::String, vec::Vec},
     core::{marker::PhantomData, mem::MaybeUninit},
     wincode::{
         config::ConfigCore,
-        error::{ReadResult, WriteResult},
+        error::{ReadError, ReadResult, WriteResult},
         io::{Reader, Writer},
         len::{SeqLen, UseIntLen},
         SchemaRead, SchemaWrite,
@@ -115,6 +118,74 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// DynString<P> — length-prefixed UTF-8 string
+// ---------------------------------------------------------------------------
+
+/// A dynamically-sized UTF-8 string with a little-endian length prefix.
+///
+/// Wire format is identical to [`DynBytes<P>`] — a length prefix followed by
+/// raw UTF-8 bytes. The distinct type exists so generated clients can accept
+/// `String`/`&str` directly for on-chain `String<N>` / `String<P, N>` fields
+/// instead of forcing callers to go through `Vec<u8>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynString<P = u32>(pub String, PhantomData<P>);
+
+impl<P> DynString<P> {
+    pub fn new(s: String) -> Self {
+        Self(s, PhantomData)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<P> From<String> for DynString<P> {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl<P> From<&str> for DynString<P> {
+    fn from(s: &str) -> Self {
+        Self::new(String::from(s))
+    }
+}
+
+unsafe impl<P, C: ConfigCore> SchemaWrite<C> for DynString<P>
+where
+    UseIntLen<P>: SeqLen<C>,
+{
+    type Src = Self;
+
+    fn size_of(src: &Self) -> WriteResult<usize> {
+        Ok(<UseIntLen<P>>::write_bytes_needed(src.0.len())? + src.0.len())
+    }
+
+    fn write(mut writer: impl Writer, src: &Self) -> WriteResult<()> {
+        <UseIntLen<P>>::write(writer.by_ref(), src.0.len())?;
+        writer.write(src.0.as_bytes())?;
+        Ok(())
+    }
+}
+
+unsafe impl<'de, P, C: ConfigCore> SchemaRead<'de, C> for DynString<P>
+where
+    UseIntLen<P>: SeqLen<C>,
+{
+    type Dst = Self;
+
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self>) -> ReadResult<()> {
+        let len = <UseIntLen<P>>::read(reader.by_ref())?;
+        let bytes = reader.take_scoped(len)?;
+        let s = core::str::from_utf8(bytes)
+            .map_err(|_| ReadError::InvalidValue("DynString: invalid UTF-8"))?;
+        dst.write(DynString(String::from(s), PhantomData));
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DynVec<T, P> — length-prefixed sequence of T
 // ---------------------------------------------------------------------------
 
@@ -193,6 +264,15 @@ where
 {
     fn serialize_arg(&self) -> Vec<u8> {
         wincode::serialize(self).expect("DynBytes serialization")
+    }
+}
+
+impl<P> SerializeArg for DynString<P>
+where
+    UseIntLen<P>: SeqLen<wincode::config::DefaultConfig>,
+{
+    fn serialize_arg(&self) -> Vec<u8> {
+        wincode::serialize(self).expect("DynString serialization")
     }
 }
 

--- a/lang/tests/client.rs
+++ b/lang/tests/client.rs
@@ -1,4 +1,4 @@
-use quasar_lang::client::{wincode, DynBytes, DynVec};
+use quasar_lang::client::{wincode, DynBytes, DynString, DynVec};
 
 // ===================================================================
 // Wire format oracle tests — u32 prefix (default)
@@ -439,4 +439,50 @@ fn dyn_vec_prefix_sizes() {
     assert_eq!(wire_u8.len(), 1 + 24);
     assert_eq!(wire_u16.len(), 2 + 24);
     assert_eq!(wire_u32.len(), 4 + 24);
+}
+
+// ===================================================================
+// DynString<P> — wire-compatible with DynBytes<P> for UTF-8 payloads
+// ===================================================================
+
+#[test]
+fn dyn_string_u8_wire_matches_dyn_bytes() {
+    let s: DynString<u8> = "abc".into();
+    let b: DynBytes<u8> = b"abc".to_vec().into();
+    assert_eq!(
+        wincode::serialize(&s).unwrap(),
+        wincode::serialize(&b).unwrap()
+    );
+}
+
+#[test]
+fn dyn_string_u8_from_string() {
+    let s: DynString<u8> = String::from("hello").into();
+    let wire = wincode::serialize(&s).unwrap();
+    assert_eq!(wire, [5, b'h', b'e', b'l', b'l', b'o']);
+}
+
+#[test]
+fn dyn_string_u32_roundtrip() {
+    let original: DynString<u32> = "round trip ✓".into();
+    let wire = wincode::serialize(&original).unwrap();
+    let decoded: DynString<u32> = wincode::deserialize(&wire).unwrap();
+    assert_eq!(decoded.as_str(), original.as_str());
+}
+
+#[test]
+fn dyn_string_u8_roundtrip_empty() {
+    let original: DynString<u8> = "".into();
+    let wire = wincode::serialize(&original).unwrap();
+    assert_eq!(wire, [0u8]);
+    let decoded: DynString<u8> = wincode::deserialize(&wire).unwrap();
+    assert_eq!(decoded.as_str(), "");
+}
+
+#[test]
+fn dyn_string_rejects_invalid_utf8() {
+    // u8 prefix = 2, followed by invalid UTF-8 bytes
+    let wire = vec![2u8, 0xFF, 0xFE];
+    let result = wincode::deserialize::<DynString<u8>>(&wire);
+    assert!(result.is_err(), "invalid UTF-8 must be rejected");
 }


### PR DESCRIPTION
Fixes #143 
generated Rust client now maps on-chain `String<N>` to `DynString<P>` instead of `DynBytes<u8>`, so callers can pass `String`/`&str` directly (e.g. `"hello".into()`). Wire format unchanged.