### PR TITLE
test: add CPI pointer tests

### DIFF
--- a/lang/tests/miri.rs
+++ b/lang/tests/miri.rs
@@ -2673,10 +2673,7 @@ fn cpi_aliasing_data_and_lamports_then_cpi_call() {
     );
 
     let data = unsafe { cpi_view.borrow_unchecked() };
-    assert_eq!(
-        u64::from_le_bytes(data[4..12].try_into().unwrap()),
-        777
-    );
+    assert_eq!(u64::from_le_bytes(data[4..12].try_into().unwrap()), 777);
     assert_eq!(cpi_view.lamports(), 5_000_000);
 }
 
@@ -2729,9 +2726,8 @@ fn cpi_aliasing_two_views_write_one_cpi_other() {
     let view_for_cpi = unsafe { buf.view() };
     let mut view_for_write = unsafe { AccountView::new_unchecked(buf.raw()) };
 
-    let account = unsafe {
-        Account::<TestAccountType>::from_account_view_unchecked_mut(&mut view_for_write)
-    };
+    let account =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut view_for_write) };
 
     // Write through account (view_for_write path)
     set_lamports(account.to_account_view(), 99_999);

--- a/lang/tests/miri.rs
+++ b/lang/tests/miri.rs
@@ -50,6 +50,11 @@
 //! | `slice::from_raw_parts_mut` for Vec in-place mutation | Sound |
 //! | Offset-cached view parse + O(1) accessor | Sound |
 //! | Tail &str / &[u8] to end of buffer | Sound |
+//! | DerefMut (data_mut_ptr) write + cpi_account_from_view on same view | Sound under Tree Borrows |
+//! | set_lamports write + cpi_account_from_view on same view | Sound under Tree Borrows |
+//! | Interleaved data write + CpiCall construction (20 cycles) | Sound under Tree Borrows |
+//! | Two views: write via one, cpi_account_from_view via the other | Sound under Tree Borrows |
+//! | Multi-account CPI after writes to all accounts | Sound under Tree Borrows |
 //!
 //! Note: these aliasing tests exercise low-level internal constructors only.
 //! The public `#[account(dup)]` API rejects writable duplicate field bindings
@@ -2554,4 +2559,286 @@ fn adversarial_dynamic_header_only_no_tail() {
     let slice: &[Address] =
         unsafe { core::slice::from_raw_parts(data[offset..].as_ptr() as *const Address, 0) };
     assert_eq!(slice.len(), 0);
+}
+
+// ###########################################################################
+// SECTION 10: CPI pointer aliasing
+//
+// These tests exercise the interaction between mutable data writes
+// (set_lamports / DerefMut via data_mut_ptr) and cpi_account_from_view(),
+// which extracts *const pointers and shared references from the same
+// RuntimeAccount. This is the aliasing pattern that set_inner() +
+// CPI invocation creates in real programs: write account data through a
+// raw mutable pointer, then pass the same AccountView into CpiCall::new
+// which internally calls cpi_account_from_view() to create &-references
+// to the RuntimeAccount fields.
+//
+// If any of these are UB under Tree Borrows, Miri will report it.
+// ###########################################################################
+
+/// Write to account data via DerefMut (same path as set_inner's
+/// data_mut_ptr write), then construct a CpiCall from an aliased view.
+/// cpi_account_from_view extracts shared refs to the RuntimeAccount —
+/// Miri checks that the prior mutable write didn't invalidate them.
+#[test]
+fn cpi_aliasing_deref_mut_then_cpi_call() {
+    let mut buf = make_zc_buffer();
+    // Two views to the same RuntimeAccount: one for mutation, one for CPI
+    let cpi_view = unsafe { buf.view() };
+    let mut mut_view = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view) };
+
+    // Write through DerefMut (raw pointer cast from data_ptr -> *mut)
+    {
+        let zc: &mut TestZcData = &mut *account;
+        zc.value = PodU64::from(123_456_789u64);
+    }
+
+    // Construct CpiCall — internally calls cpi_account_from_view which
+    // creates &(*raw).lamports, &(*raw).address etc. from the same
+    // RuntimeAccount we just wrote to.
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+        &program_id,
+        [InstructionAccount::writable(cpi_view.address())],
+        [&cpi_view],
+        [0u8],
+    );
+
+    // Read back through aliased view to verify data is intact
+    let data = unsafe { cpi_view.borrow_unchecked() };
+    let written = u64::from_le_bytes(data[4..12].try_into().unwrap());
+    assert_eq!(written, 123_456_789);
+}
+
+/// Write lamports via set_lamports (raw *const -> *mut cast on
+/// RuntimeAccount), then construct CpiCall. cpi_account_from_view
+/// creates `&(*raw).lamports` — a shared ref to the same field
+/// we just mutated through a const-to-mut cast.
+#[test]
+fn cpi_aliasing_set_lamports_then_cpi_call() {
+    let mut buf = AccountBuffer::new(64);
+    buf.init([1u8; 32], TEST_OWNER.to_bytes(), 100, 64, true, true);
+    let cpi_view = unsafe { buf.view() };
+    let mut mut_view = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view) };
+
+    set_lamports(account.to_account_view(), 42_000);
+
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+        &program_id,
+        [InstructionAccount::writable(cpi_view.address())],
+        [&cpi_view],
+        [0u8],
+    );
+
+    assert_eq!(cpi_view.lamports(), 42_000);
+}
+
+/// Combined: write data via DerefMut AND lamports via set_lamports,
+/// then construct CpiCall. Both the data region and the lamports field
+/// in RuntimeAccount have been mutated through raw pointers before
+/// cpi_account_from_view extracts shared references to them.
+#[test]
+fn cpi_aliasing_data_and_lamports_then_cpi_call() {
+    let mut buf = make_zc_buffer();
+    let cpi_view = unsafe { buf.view() };
+    let mut mut_view = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view) };
+
+    // Mutate data
+    {
+        let zc: &mut TestZcData = &mut *account;
+        zc.value = PodU64::from(777u64);
+        zc.flag = PodBool::from(true);
+    }
+
+    // Mutate lamports
+    set_lamports(account.to_account_view(), 5_000_000);
+
+    // CpiCall construction reads both regions
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+        &program_id,
+        [InstructionAccount::writable(cpi_view.address())],
+        [&cpi_view],
+        [0u8],
+    );
+
+    let data = unsafe { cpi_view.borrow_unchecked() };
+    assert_eq!(
+        u64::from_le_bytes(data[4..12].try_into().unwrap()),
+        777
+    );
+    assert_eq!(cpi_view.lamports(), 5_000_000);
+}
+
+/// Interleaved: write → CpiCall → write → CpiCall for N cycles.
+/// Each cycle creates new shared refs via cpi_account_from_view after
+/// a mutable write, stressing Tree Borrows tag tracking.
+#[test]
+fn cpi_aliasing_interleaved_write_cpi_cycles() {
+    let mut buf = make_zc_buffer();
+    let cpi_view = unsafe { buf.view() };
+    let mut mut_view = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view) };
+
+    let program_id = Address::new_from_array([0u8; 32]);
+
+    for i in 0u64..20 {
+        // Mutable write
+        {
+            let zc: &mut TestZcData = &mut *account;
+            zc.value = PodU64::from(i);
+        }
+        set_lamports(account.to_account_view(), i * 1000);
+
+        // CpiCall construction (cpi_account_from_view extracts shared refs)
+        let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+            &program_id,
+            [InstructionAccount::writable(cpi_view.address())],
+            [&cpi_view],
+            [0u8],
+        );
+
+        // Verify through aliased view
+        let data = unsafe { cpi_view.borrow_unchecked() };
+        assert_eq!(u64::from_le_bytes(data[4..12].try_into().unwrap()), i);
+        assert_eq!(cpi_view.lamports(), i * 1000);
+    }
+}
+
+/// Two separate AccountView instances to the same RuntimeAccount:
+/// write via one, construct CpiCall via the other.
+/// This is the most aggressive aliasing variant — completely separate
+/// view objects sharing the same underlying raw pointer.
+#[test]
+fn cpi_aliasing_two_views_write_one_cpi_other() {
+    let mut buf = AccountBuffer::new(64);
+    buf.init([1u8; 32], TEST_OWNER.to_bytes(), 100, 64, true, true);
+
+    let view_for_cpi = unsafe { buf.view() };
+    let mut view_for_write = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account = unsafe {
+        Account::<TestAccountType>::from_account_view_unchecked_mut(&mut view_for_write)
+    };
+
+    // Write through account (view_for_write path)
+    set_lamports(account.to_account_view(), 99_999);
+
+    // CpiCall from the OTHER view (view_for_cpi path)
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+        &program_id,
+        [InstructionAccount::writable(view_for_cpi.address())],
+        [&view_for_cpi],
+        [0u8],
+    );
+
+    assert_eq!(view_for_cpi.lamports(), 99_999);
+}
+
+/// Multi-account CPI: write to multiple accounts, then construct a
+/// single CpiCall referencing all of them. Exercises init_cpi_accounts
+/// which calls cpi_account_from_view for each view.
+#[test]
+fn cpi_aliasing_multi_account_cpi_after_writes() {
+    let mut buf0 = AccountBuffer::new(64);
+    buf0.init([1u8; 32], TEST_OWNER.to_bytes(), 100, 64, true, true);
+    let mut buf1 = AccountBuffer::new(64);
+    buf1.init([2u8; 32], TEST_OWNER.to_bytes(), 200, 64, false, true);
+
+    let cpi_view0 = unsafe { buf0.view() };
+    let mut mut_view0 = unsafe { AccountView::new_unchecked(buf0.raw()) };
+    let cpi_view1 = unsafe { buf1.view() };
+    let mut mut_view1 = unsafe { AccountView::new_unchecked(buf1.raw()) };
+
+    let account0 =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view0) };
+    let account1 =
+        unsafe { Account::<TestAccountType>::from_account_view_unchecked_mut(&mut mut_view1) };
+
+    // Write to both accounts
+    set_lamports(account0.to_account_view(), 1_000);
+    set_lamports(account1.to_account_view(), 2_000);
+
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 2, 1> = CpiCall::new(
+        &program_id,
+        [
+            InstructionAccount::writable(cpi_view0.address()),
+            InstructionAccount::readonly(cpi_view1.address()),
+        ],
+        [&cpi_view0, &cpi_view1],
+        [0u8],
+    );
+
+    assert_eq!(cpi_view0.lamports(), 1_000);
+    assert_eq!(cpi_view1.lamports(), 2_000);
+}
+
+/// Boundary: write to account with exact minimum buffer size,
+/// then construct CpiCall. Tests that cpi_account_from_view's pointer
+/// arithmetic (data ptr = raw + RUNTIME_ACCOUNT_SIZE) doesn't go OOB
+/// when the data region is zero-length.
+#[test]
+fn cpi_aliasing_zero_data_len() {
+    let mut buf = AccountBuffer::new(0);
+    buf.init([1u8; 32], TEST_OWNER.to_bytes(), 500, 0, true, true);
+    let view = unsafe { buf.view() };
+
+    set_lamports(&view, 12_345);
+
+    let program_id = Address::new_from_array([0u8; 32]);
+    let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+        &program_id,
+        [InstructionAccount::writable(view.address())],
+        [&view],
+        [0u8],
+    );
+
+    assert_eq!(view.lamports(), 12_345);
+}
+
+/// Sweep all flag combinations with data write + CPI aliasing.
+/// cpi_account_from_view reads flags as a u32 from the header —
+/// ensure this unaligned read doesn't conflict with prior writes.
+#[test]
+fn cpi_aliasing_flag_sweep() {
+    for &(is_signer, is_writable, executable) in SWEEP_FLAG_COMBOS {
+        let data_len = 64usize;
+        let mut buf = AccountBuffer::new(data_len);
+        buf.init_with_executable(
+            [1u8; 32],
+            TEST_OWNER.to_bytes(),
+            100,
+            data_len as u64,
+            is_signer,
+            is_writable,
+            executable,
+        );
+
+        let view = unsafe { buf.view() };
+        set_lamports(&view, 7777);
+
+        let program_id = Address::new_from_array([0u8; 32]);
+        let _call: CpiCall<'_, 1, 1> = CpiCall::new(
+            &program_id,
+            [InstructionAccount::writable(view.address())],
+            [&view],
+            [0u8],
+        );
+
+        assert_eq!(view.lamports(), 7777);
+    }
 }

--- a/tests/programs/test-misc/src/instructions/cpi_mut_readback.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_mut_readback.rs
@@ -11,8 +11,8 @@ use {
 /// `cpi_account_from_view()` extracts raw `*const` pointers from the
 /// `AccountView` without checking `borrow_state`. This test verifies:
 ///
-///   1. The data write from `set_inner()` survives the CPI round-trip
-///      (SVM serialize → execute → deserialize doesn't clobber it).
+///   1. The data write from `set_inner()` survives the CPI round-trip (SVM
+///      serialize → execute → deserialize doesn't clobber it).
 ///   2. The CPI's lamport change is visible through the same `AccountView`
 ///      after CPI returns.
 ///   3. A second `set_inner()` after CPI still writes correctly (the

--- a/tests/programs/test-misc/src/instructions/cpi_mut_readback.rs
+++ b/tests/programs/test-misc/src/instructions/cpi_mut_readback.rs
@@ -1,0 +1,83 @@
+use {
+    crate::state::{SimpleAccount, SimpleAccountInner},
+    quasar_lang::prelude::*,
+};
+
+/// CPI pointer safety under mutable data access: the handler writes to
+/// account data via `set_inner()` (which uses `data_mut_ptr()` — raw pointer
+/// write, no borrow tracking), then passes the SAME account into a system
+/// transfer CPI as the writable destination.
+///
+/// `cpi_account_from_view()` extracts raw `*const` pointers from the
+/// `AccountView` without checking `borrow_state`. This test verifies:
+///
+///   1. The data write from `set_inner()` survives the CPI round-trip
+///      (SVM serialize → execute → deserialize doesn't clobber it).
+///   2. The CPI's lamport change is visible through the same `AccountView`
+///      after CPI returns.
+///   3. A second `set_inner()` after CPI still writes correctly (the
+///      `data_mut_ptr()` is still valid).
+#[derive(Accounts)]
+pub struct CpiMutReadback {
+    #[account(mut)]
+    pub account: Account<SimpleAccount>,
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+}
+
+impl CpiMutReadback {
+    #[inline(always)]
+    pub fn handler(&mut self, new_value: u64) -> Result<(), ProgramError> {
+        let authority = self.account.authority;
+        let bump = self.account.bump;
+        let initial_lamports = self.account.to_account_view().lamports();
+
+        // --- Step 1: Write to account data via set_inner ---
+        // Uses data_mut_ptr() internally — raw pointer, no borrow tracking.
+        self.account.set_inner(SimpleAccountInner {
+            authority,
+            value: new_value,
+            bump,
+        });
+
+        // Verify the write landed
+        if self.account.value != new_value {
+            return Err(ProgramError::Custom(1)); // set_inner write failed
+        }
+
+        // --- Step 2: CPI transfer lamports TO the same account ---
+        // cpi_account_from_view() extracts raw pointers from the AccountView
+        // without checking borrow_state. The SVM writes to the same
+        // RuntimeAccount memory that set_inner just wrote to.
+        self.system_program
+            .transfer(&self.payer, &self.account, 1_000u64)
+            .invoke()?;
+
+        // --- Step 3: Read back through the same references ---
+        // Custom(2): lamports not updated after CPI
+        if self.account.to_account_view().lamports() != initial_lamports + 1_000 {
+            return Err(ProgramError::Custom(2));
+        }
+        // Custom(3): data clobbered by CPI round-trip
+        if self.account.value != new_value {
+            return Err(ProgramError::Custom(3));
+        }
+
+        // --- Step 4: Second set_inner after CPI ---
+        // data_mut_ptr() must still point to valid memory.
+        let second_value = new_value.wrapping_add(1);
+        self.account.set_inner(SimpleAccountInner {
+            authority,
+            value: second_value,
+            bump,
+        });
+
+        // Custom(4): second set_inner failed
+        if self.account.value != second_value {
+            return Err(ProgramError::Custom(4));
+        }
+
+        Ok(())
+    }
+}

--- a/tests/programs/test-misc/src/instructions/mod.rs
+++ b/tests/programs/test-misc/src/instructions/mod.rs
@@ -139,3 +139,6 @@ pub mod dynamic_view_mut;
 pub use dynamic_view_mut::*;
 pub mod dynamic_view_mut_missing_field;
 pub use dynamic_view_mut_missing_field::*;
+
+pub mod cpi_mut_readback;
+pub use cpi_mut_readback::*;

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -323,10 +323,7 @@ mod quasar_test_misc {
     }
 
     #[instruction(discriminator = 60)]
-    pub fn cpi_mut_readback(
-        ctx: Ctx<CpiMutReadback>,
-        new_value: u64,
-    ) -> Result<(), ProgramError> {
+    pub fn cpi_mut_readback(ctx: Ctx<CpiMutReadback>, new_value: u64) -> Result<(), ProgramError> {
         ctx.accounts.handler(new_value)
     }
 }

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -321,4 +321,12 @@ mod quasar_test_misc {
     ) -> Result<(), ProgramError> {
         ctx.accounts.handler(new_name)
     }
+
+    #[instruction(discriminator = 60)]
+    pub fn cpi_mut_readback(
+        ctx: Ctx<CpiMutReadback>,
+        new_value: u64,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler(new_value)
+    }
 }

--- a/tests/suite/src/cpi_pointer_safety.rs
+++ b/tests/suite/src/cpi_pointer_safety.rs
@@ -1,0 +1,108 @@
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_misc::cpi::*,
+};
+
+// ============================================================================
+// CPI pointer safety: mutable data write + CPI on the same account
+//
+// The handler writes to Account<SimpleAccount> data via set_inner() (raw
+// pointer write through data_mut_ptr, no borrow tracking), then passes
+// the SAME account into a system transfer CPI as the writable destination.
+// cpi_account_from_view() extracts raw pointers without checking
+// borrow_state.
+//
+// Verifies:
+//   - set_inner data write survives the CPI round-trip (SVM
+//     serialize -> execute -> deserialize doesn't clobber it)
+//   - CPI lamport change is visible through the same AccountView
+//   - A second set_inner after CPI still writes correctly
+//     (data_mut_ptr still valid)
+// ============================================================================
+
+#[test]
+fn mut_readback_data_and_lamports() {
+    let mut svm = svm_misc();
+    let payer = Pubkey::new_unique();
+    let account = Pubkey::new_unique();
+
+    let ix: Instruction = CpiMutReadbackInstruction {
+        account,
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        new_value: 999,
+    }
+    .into();
+
+    let initial_lamports = 1_000_000u64;
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            simple_account(account, payer, 42, 0),
+            rich_signer_account(payer),
+        ],
+    );
+    assert!(result.is_ok(), "mut readback: {:?}", result.raw_result);
+
+    // Off-chain: verify data reflects the SECOND set_inner (value = 999 + 1 = 1000)
+    let acc = result.account(&account).expect("account");
+    let final_value = u64::from_le_bytes(acc.data[33..41].try_into().unwrap());
+    assert_eq!(final_value, 1000, "second set_inner value");
+
+    // Off-chain: verify lamports include the 1000 from CPI transfer
+    assert_eq!(acc.lamports, initial_lamports + 1_000, "lamports after CPI");
+}
+
+#[test]
+fn mut_readback_wrapping_overflow() {
+    let mut svm = svm_misc();
+    let payer = Pubkey::new_unique();
+    let account = Pubkey::new_unique();
+
+    let ix: Instruction = CpiMutReadbackInstruction {
+        account,
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        new_value: u64::MAX,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            simple_account(account, payer, 42, 0),
+            rich_signer_account(payer),
+        ],
+    );
+    assert!(result.is_ok(), "mut max value: {:?}", result.raw_result);
+
+    // u64::MAX wrapping_add(1) == 0
+    let acc = result.account(&account).expect("account");
+    let final_value = u64::from_le_bytes(acc.data[33..41].try_into().unwrap());
+    assert_eq!(final_value, 0, "wrapping add overflow");
+}
+
+#[test]
+fn mut_readback_zero_value() {
+    let mut svm = svm_misc();
+    let payer = Pubkey::new_unique();
+    let account = Pubkey::new_unique();
+
+    let ix: Instruction = CpiMutReadbackInstruction {
+        account,
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        new_value: 0,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            simple_account(account, payer, 42, 0),
+            rich_signer_account(payer),
+        ],
+    );
+    assert!(result.is_ok(), "mut zero: {:?}", result.raw_result);
+}

--- a/tests/suite/src/cpi_pointer_safety.rs
+++ b/tests/suite/src/cpi_pointer_safety.rs
@@ -14,11 +14,11 @@ use {
 // borrow_state.
 //
 // Verifies:
-//   - set_inner data write survives the CPI round-trip (SVM
-//     serialize -> execute -> deserialize doesn't clobber it)
+//   - set_inner data write survives the CPI round-trip (SVM serialize ->
+//     execute -> deserialize doesn't clobber it)
 //   - CPI lamport change is visible through the same AccountView
-//   - A second set_inner after CPI still writes correctly
-//     (data_mut_ptr still valid)
+//   - A second set_inner after CPI still writes correctly (data_mut_ptr still
+//     valid)
 // ============================================================================
 
 #[test]

--- a/tests/suite/src/lib.rs
+++ b/tests/suite/src/lib.rs
@@ -42,6 +42,8 @@ mod constraints;
 
 // CPI & errors
 #[cfg(test)]
+mod cpi_pointer_safety;
+#[cfg(test)]
 mod cpi_return;
 #[cfg(test)]
 mod cpi_system;


### PR DESCRIPTION
## What this does

Adds tests for CPI pointer aliasing safety — verifying that raw pointer writes via `data_mut_ptr()` / `set_lamports()` don't cause undefined behavior when the same `AccountView` is subsequently passed to `cpi_account_from_view()`, which extracts shared `&`-references to the same `RuntimeAccount` memory.

## Miri UB tests (new)

`lang/tests/miri.rs` — Section 10: CPI pointer aliasing

8 new Miri tests that exercise the `set_inner()` + CPI aliasing pattern under Tree Borrows:

| Test | Pattern |
|------|---------|
| `cpi_aliasing_deref_mut_then_cpi_call` | DerefMut write (data_mut_ptr path) → CpiCall construction |
| `cpi_aliasing_set_lamports_then_cpi_call` | Lamports write via const-to-mut cast → CpiCall |
| `cpi_aliasing_data_and_lamports_then_cpi_call` | Both data + lamports mutation → CpiCall |
| `cpi_aliasing_interleaved_write_cpi_cycles` | 20 cycles of write → CpiCall → verify |
| `cpi_aliasing_two_views_write_one_cpi_other` | Two separate views: mutate via one, CpiCall via the other |
| `cpi_aliasing_multi_account_cpi_after_writes` | Multiple accounts mutated → single CpiCall |
| `cpi_aliasing_zero_data_len` | Zero-length data region boundary case |
| `cpi_aliasing_flag_sweep` | All 8 flag combinations with write + CPI aliasing |

All pass under both `-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check` and `-Zmiri-strict-provenance`.

## SVM integration tests

`tests/suite/src/cpi_pointer_safety.rs`

3 integration tests that verify correctness (not UB) of the same pattern at the SVM level:

- `mut_readback_data_and_lamports` — verifies data and lamports survive the full `set_inner` → CPI → `set_inner` sequence
- `mut_readback_wrapping_overflow` — `u64::MAX` input, wrapping_add(1) → 0
- `mut_readback_zero_value` — zero-write edge case

## CPI mutable readback instruction

`tests/programs/test-misc/src/instructions/cpi_mut_readback.rs`

Test instruction that exercises the exact interleaving:

1. `set_inner()` — raw pointer write through `data_mut_ptr()`
2. System transfer CPI on the SAME account — `cpi_account_from_view()` extracts raw `*const` pointers without checking `borrow_state`
3. Read back — verifies data survived the SVM serialize → execute → deserialize round-trip
4. Second `set_inner()` — verifies `data_mut_ptr()` still valid after CPI
