### PR TITLE
fix(cli): detect incompatible cargo-build-sbf + code quality improvements

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -6,9 +6,8 @@ mod lockfile;
 mod watch;
 
 pub(crate) use watch::watch_loop;
-/// platform-tools v1.52 ships Cargo 1.89 which supports Cargo.lock v4.
-/// v1.51 ships Cargo 1.84 which does not, causing "duplicate lang item" errors
-/// when its stale host-target artifacts conflict with the system toolchain.
+/// platform-tools v1.52 ships Cargo 1.89 which supports Cargo.lock v4
+/// and handles edition-2024 crate manifests in the Solana dep tree.
 const PLATFORM_TOOLS_VERSION: &str = "v1.52";
 
 use {
@@ -50,6 +49,10 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
     let sp = style::spinner("Building...");
 
     if config.is_solana_toolchain() {
+        toolchain::check_build_sbf_supports(PLATFORM_TOOLS_VERSION).map_err(|e| {
+            sp.finish_and_clear();
+            CliError::message(e)
+        })?;
         ensure_lockfile(&sp)?;
     }
 
@@ -175,6 +178,10 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
     let sp = style::spinner("Profile build...");
 
     if config.is_solana_toolchain() {
+        toolchain::check_build_sbf_supports(PLATFORM_TOOLS_VERSION).map_err(|e| {
+            sp.finish_and_clear();
+            CliError::message(e)
+        })?;
         ensure_lockfile(&sp)?;
     }
 
@@ -183,8 +190,12 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
 
     let output = if config.is_solana_toolchain() {
         let mut cmd = Command::new("cargo");
-        cmd.args(["build-sbf", "--tools-version", PLATFORM_TOOLS_VERSION]);
-        cmd.arg("--debug");
+        cmd.args([
+            "build-sbf",
+            "--tools-version",
+            PLATFORM_TOOLS_VERSION,
+            "--debug",
+        ]);
         if scoped {
             cmd.args(["--manifest-path", &manifest.to_string_lossy()]);
         }

--- a/cli/src/clean.rs
+++ b/cli/src/clean.rs
@@ -35,10 +35,7 @@ pub fn run(all: bool) -> CliResult {
     }
 
     if all {
-        let output = Command::new("cargo")
-            .arg("clean")
-            .output()
-            .map_err(anyhow::Error::from)?;
+        let output = Command::new("cargo").arg("clean").output()?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(CliError::process_failure(

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -21,10 +21,8 @@ pub fn run(command: ClientCommand) -> CliResult {
         )));
     }
 
-    let json = std::fs::read_to_string(idl_path)
-        .map_err(|e| anyhow::anyhow!("failed to read IDL: {e}"))?;
-    let idl: quasar_idl::types::Idl =
-        serde_json::from_str(&json).map_err(|e| anyhow::anyhow!("failed to parse IDL: {e}"))?;
+    let json = std::fs::read_to_string(idl_path)?;
+    let idl: quasar_idl::types::Idl = serde_json::from_str(&json)?;
 
     let languages: Vec<&str> = if command.lang.is_empty() {
         ALL_LANGUAGES.to_vec()

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -4,13 +4,17 @@ pub type CliResult = Result<(), CliError>;
 
 #[derive(Debug, Error)]
 pub enum CliError {
-    #[error("Io error")]
+    #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
-    #[error("Toml parse error")]
+    #[error("TOML parse error: {0}")]
     TomlParseError(#[from] toml::de::Error),
-    #[error("Toml serialize error")]
+    #[error("TOML serialize error: {0}")]
     TomlSerError(#[from] toml::ser::Error),
-    #[error("Anyhow error")]
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("prompt error: {0}")]
+    Dialoguer(#[from] dialoguer::Error),
+    #[error("{0}")]
     Anyhow(#[from] anyhow::Error),
     #[error("{0}")]
     Message(String),

--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -28,8 +28,7 @@ fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error
     let idl_dir = PathBuf::from("target").join("idl");
     std::fs::create_dir_all(&idl_dir)?;
     let idl_path = idl_dir.join(format!("{}.json", idl.metadata.name));
-    let json = serde_json::to_string_pretty(&idl)
-        .map_err(|e| anyhow::anyhow!("failed to serialize IDL: {e}"))?;
+    let json = serde_json::to_string_pretty(&idl)?;
     std::fs::write(&idl_path, &json)?;
 
     // Write Rust client

--- a/cli/src/init/banner.rs
+++ b/cli/src/init/banner.rs
@@ -11,17 +11,27 @@ pub(super) fn print_banner() {
         return;
     }
 
-    use std::{thread, time::Duration};
+    // Terminal animation — if writes fail the banner is non-essential, so we
+    // just skip it rather than propagating the error to the caller.
+    if animate_banner(&stdout).is_err() {
+        // Ensure cursor is visible even if the animation failed partway through
+        let _ = write!(stdout.lock(), "\x1b[?25h");
+        let _ = stdout.lock().flush();
+    }
+}
+
+fn animate_banner(stdout: &std::io::Stdout) -> std::io::Result<()> {
+    use std::{io::Write, thread, time::Duration};
 
     // Restore cursor if interrupted during animation
     ctrlc::set_handler(move || {
         print!("\x1b[?25h");
         std::process::exit(130);
     })
-    .ok();
+    .ok(); // ctrlc handler registration is best-effort (may already be set)
 
     let mut out = stdout.lock();
-    write!(out, "\x1b[?25l").ok();
+    write!(out, "\x1b[?25l")?;
 
     let w: usize = 70;
     let h: usize = 11; // 1 blank + 7 figlet + 1 blank + 1 tagline + 1 byline
@@ -52,14 +62,14 @@ pub(super) fn print_banner() {
     let by_off = w.saturating_sub(by_chars.len()) / 2;
 
     // Reserve space
-    writeln!(out).ok();
+    writeln!(out)?;
     for _ in 0..h {
-        writeln!(out).ok();
+        writeln!(out)?;
     }
-    out.flush().ok();
+    out.flush()?;
 
     for frame in 0..n_frames {
-        write!(out, "\x1b[{h}A").ok();
+        write!(out, "\x1b[{h}A")?;
         let is_final = frame == n_frames - 1;
 
         // Leading edge sweeps left → right, revealing text in its wake
@@ -68,7 +78,7 @@ pub(super) fn print_banner() {
 
         #[allow(clippy::needless_range_loop)]
         for li in 0..h {
-            write!(out, "\x1b[2K  ").ok();
+            write!(out, "\x1b[2K  ")?;
 
             if is_final {
                 // ── Final clean frame ──
@@ -76,27 +86,27 @@ pub(super) fn print_banner() {
                     1..=7 => {
                         let row = &fig[li - 1];
                         for _ in 0..fig_off {
-                            write!(out, " ").ok();
+                            write!(out, " ")?;
                         }
                         for &ch in row.iter() {
                             if ch != ' ' {
-                                write!(out, "\x1b[36m{ch}\x1b[0m").ok();
+                                write!(out, "\x1b[36m{ch}\x1b[0m")?;
                             } else {
-                                write!(out, " ").ok();
+                                write!(out, " ")?;
                             }
                         }
                     }
                     9 => {
                         for _ in 0..tag_off {
-                            write!(out, " ").ok();
+                            write!(out, " ")?;
                         }
-                        write!(out, "\x1b[1m{tagline}\x1b[0m").ok();
+                        write!(out, "\x1b[1m{tagline}\x1b[0m")?;
                     }
                     10 => {
                         for _ in 0..by_off {
-                            write!(out, " ").ok();
+                            write!(out, " ")?;
                         }
-                        write!(out, "\x1b[90mby \x1b[36mblueshift.gg\x1b[0m").ok();
+                        write!(out, "\x1b[90mby \x1b[36mblueshift.gg\x1b[0m")?;
                     }
                     _ => {}
                 }
@@ -119,7 +129,7 @@ pub(super) fn print_banner() {
 
                     if dist < -nebula_w {
                         // Behind the nebula: text fully revealed
-                        write_text_char(&mut out, text_ch, li, ci, by_off);
+                        write_text_char(&mut out, text_ch, li, ci, by_off)?;
                     } else if dist < nebula_w {
                         // Inside the nebula band
                         let blend = (dist + nebula_w) / (nebula_w * 2.0);
@@ -128,28 +138,29 @@ pub(super) fn print_banner() {
 
                         if blend < 0.3 && text_ch != ' ' {
                             // Trailing edge: text bleeds through
-                            write_text_char(&mut out, text_ch, li, ci, by_off);
+                            write_text_char(&mut out, text_ch, li, ci, by_off)?;
                         } else {
-                            write_nebula_char(&mut out, d);
+                            write_nebula_char(&mut out, d)?;
                         }
                     } else {
                         // Ahead of nebula: dark
-                        write!(out, " ").ok();
+                        write!(out, " ")?;
                     }
                 }
             }
-            writeln!(out).ok();
+            writeln!(out)?;
         }
-        out.flush().ok();
+        out.flush()?;
 
         if !is_final {
             thread::sleep(Duration::from_millis(55));
         }
     }
 
-    write!(out, "\x1b[?25h").ok();
-    writeln!(out).ok();
-    out.flush().ok();
+    write!(out, "\x1b[?25h")?;
+    writeln!(out)?;
+    out.flush()?;
+    Ok(())
 }
 
 fn write_text_char(
@@ -158,45 +169,47 @@ fn write_text_char(
     line: usize,
     col: usize,
     by_off: usize,
-) {
+) -> std::io::Result<()> {
     if ch == ' ' {
-        write!(out, " ").ok();
+        write!(out, " ")?;
     } else {
         match line {
             1..=7 => {
-                write!(out, "\x1b[36m{ch}\x1b[0m").ok();
+                write!(out, "\x1b[36m{ch}\x1b[0m")?;
             }
             9 => {
-                write!(out, "\x1b[1m{ch}\x1b[0m").ok();
+                write!(out, "\x1b[1m{ch}\x1b[0m")?;
             }
             10 => {
                 if col - by_off < 3 {
-                    write!(out, "\x1b[90m{ch}\x1b[0m").ok();
+                    write!(out, "\x1b[90m{ch}\x1b[0m")?;
                 } else {
-                    write!(out, "\x1b[36m{ch}\x1b[0m").ok();
+                    write!(out, "\x1b[36m{ch}\x1b[0m")?;
                 }
             }
             _ => {
-                write!(out, " ").ok();
+                write!(out, " ")?;
             }
         };
     }
+    Ok(())
 }
 
-fn write_nebula_char(out: &mut impl std::io::Write, d: f32) {
+fn write_nebula_char(out: &mut impl std::io::Write, d: f32) -> std::io::Result<()> {
     if d < 0.10 {
-        write!(out, " ").ok();
+        write!(out, " ")?;
     } else if d < 0.25 {
-        write!(out, "\x1b[38;2;15;25;85m░\x1b[0m").ok();
+        write!(out, "\x1b[38;2;15;25;85m░\x1b[0m")?;
     } else if d < 0.42 {
-        write!(out, "\x1b[38;2;30;55;145m░\x1b[0m").ok();
+        write!(out, "\x1b[38;2;30;55;145m░\x1b[0m")?;
     } else if d < 0.60 {
-        write!(out, "\x1b[38;2;50;95;200m▒\x1b[0m").ok();
+        write!(out, "\x1b[38;2;50;95;200m▒\x1b[0m")?;
     } else if d < 0.78 {
-        write!(out, "\x1b[38;2;75;140;235m▓\x1b[0m").ok();
+        write!(out, "\x1b[38;2;75;140;235m▓\x1b[0m")?;
     } else {
-        write!(out, "\x1b[38;2;100;170;255m█\x1b[0m").ok();
+        write!(out, "\x1b[38;2;100;170;255m█\x1b[0m")?;
     }
+    Ok(())
 }
 
 /// Aurora density — sine waves flowing rightward, tuned for sparse output.

--- a/cli/src/init/mod.rs
+++ b/cli/src/init/mod.rs
@@ -108,7 +108,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
         if let Some(default) = name {
             prompt = prompt.default(default);
         }
-        prompt.interact_text().map_err(anyhow::Error::from)?
+        prompt.interact_text()?
     };
 
     // Validate the target directory before prompting for remaining options
@@ -143,8 +143,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             .with_prompt("Toolchain")
             .items(toolchain_items)
             .default(toolchain_default)
-            .interact()
-            .map_err(anyhow::Error::from)?
+            .interact()?
     };
     let toolchain = match toolchain_idx {
         0 => Toolchain::Solana,
@@ -190,8 +189,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             .with_prompt("Test language")
             .items(lang_items)
             .default(lang_default)
-            .interact()
-            .map_err(anyhow::Error::from)?
+            .interact()?
     };
     let test_language = match test_lang_idx {
         1 => TestLanguage::Rust,
@@ -209,8 +207,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
                 .with_prompt("Rust test framework")
                 .items(items)
                 .default(rust_fw_default)
-                .interact()
-                .map_err(anyhow::Error::from)?
+                .interact()?
         };
         Some(match idx {
             1 => RustFramework::Mollusk,
@@ -230,8 +227,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
                 .with_prompt("TypeScript SDK")
                 .items(items)
                 .default(ts_sdk_default)
-                .interact()
-                .map_err(anyhow::Error::from)?
+                .interact()?
         };
         Some(match idx {
             1 => TypeScriptSdk::Web3js,
@@ -252,8 +248,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
                 .with_prompt("Package manager")
                 .items(pm_items)
                 .default(pm_default)
-                .interact()
-                .map_err(anyhow::Error::from)?
+                .interact()?
         };
         Some(match pm_idx {
             0 => PackageManager::Pnpm,
@@ -264,13 +259,11 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
                 let install: String = Input::with_theme(&theme)
                     .with_prompt("Install command")
                     .default("pnpm install".into())
-                    .interact_text()
-                    .map_err(anyhow::Error::from)?;
+                    .interact_text()?;
                 let test: String = Input::with_theme(&theme)
                     .with_prompt("Test command")
                     .default("pnpm test".into())
-                    .interact_text()
-                    .map_err(anyhow::Error::from)?;
+                    .interact_text()?;
                 PackageManager::Other { install, test }
             }
         })
@@ -313,8 +306,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
         let selected = MultiSelect::with_theme(&theme)
             .with_prompt(&prompt)
             .items(&display_items)
-            .interact()
-            .map_err(anyhow::Error::from)?;
+            .interact()?;
 
         let mut langs: Vec<String> = vec!["rust".to_string()];
         if ts_tests {
@@ -345,8 +337,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             .with_prompt("Template")
             .items(template_items)
             .default(template_default)
-            .interact()
-            .map_err(anyhow::Error::from)?
+            .interact()?
     };
     let template = match template_idx {
         0 => Template::Minimal,
@@ -369,8 +360,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             .with_prompt("Initialize a new git repo?")
             .items(git_items)
             .default(git_default.index())
-            .interact()
-            .map_err(anyhow::Error::from)?;
+            .interact()?;
         GitSetup::from_index(git_idx)
     };
 

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -66,7 +66,7 @@ pub(super) fn scaffold(
     let root = Path::new(dir);
 
     let src = root.join("src");
-    fs::create_dir_all(&src).map_err(anyhow::Error::from)?;
+    fs::create_dir_all(&src)?;
 
     // Quasar.toml
     let config = QuasarToml {
@@ -102,29 +102,28 @@ pub(super) fn scaffold(
             languages: client_languages.to_vec(),
         },
     };
-    let toml_str = toml::to_string_pretty(&config).map_err(anyhow::Error::from)?;
-    fs::write(root.join("Quasar.toml"), toml_str).map_err(anyhow::Error::from)?;
+    let toml_str = toml::to_string_pretty(&config)?;
+    fs::write(root.join("Quasar.toml"), toml_str)?;
 
     // Cargo.toml
     fs::write(
         root.join("Cargo.toml"),
         generate_cargo_toml(name, toolchain, test_language, rust_framework),
-    )
-    .map_err(anyhow::Error::from)?;
+    )?;
 
     // .cargo/config.toml (upstream only)
     if matches!(toolchain, Toolchain::Upstream) {
         let cargo_dir = root.join(".cargo");
-        fs::create_dir_all(&cargo_dir).map_err(anyhow::Error::from)?;
-        fs::write(cargo_dir.join("config.toml"), CARGO_CONFIG).map_err(anyhow::Error::from)?;
+        fs::create_dir_all(&cargo_dir)?;
+        fs::write(cargo_dir.join("config.toml"), CARGO_CONFIG)?;
     }
 
     // .gitignore
-    fs::write(root.join(".gitignore"), GITIGNORE).map_err(anyhow::Error::from)?;
+    fs::write(root.join(".gitignore"), GITIGNORE)?;
 
     // Generate program keypair
     let deploy_dir = root.join("target").join("deploy");
-    fs::create_dir_all(&deploy_dir).map_err(anyhow::Error::from)?;
+    fs::create_dir_all(&deploy_dir)?;
 
     let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
     let program_id = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
@@ -133,12 +132,11 @@ pub(super) fn scaffold(
     let mut keypair_bytes = Vec::with_capacity(64);
     keypair_bytes.extend_from_slice(signing_key.as_bytes());
     keypair_bytes.extend_from_slice(signing_key.verifying_key().as_bytes());
-    let keypair_json = serde_json::to_string(&keypair_bytes).map_err(anyhow::Error::from)?;
+    let keypair_json = serde_json::to_string(&keypair_bytes)?;
     fs::write(
         deploy_dir.join(format!("{name}-keypair.json")),
         &keypair_json,
-    )
-    .map_err(anyhow::Error::from)?;
+    )?;
 
     // src/lib.rs
     let module_name = name.replace('-', "_");
@@ -146,8 +144,7 @@ pub(super) fn scaffold(
     fs::write(
         src.join("lib.rs"),
         generate_lib_rs(&module_name, &program_id, template, has_rust_tests),
-    )
-    .map_err(anyhow::Error::from)?;
+    )?;
 
     // Template-specific files
     match template {
@@ -156,16 +153,14 @@ pub(super) fn scaffold(
         }
         Template::Full => {
             let instructions_dir = src.join("instructions");
-            fs::create_dir_all(&instructions_dir).map_err(anyhow::Error::from)?;
-            fs::write(instructions_dir.join("mod.rs"), INSTRUCTIONS_MOD)
-                .map_err(anyhow::Error::from)?;
+            fs::create_dir_all(&instructions_dir)?;
+            fs::write(instructions_dir.join("mod.rs"), INSTRUCTIONS_MOD)?;
             fs::write(
                 instructions_dir.join("initialize.rs"),
                 INSTRUCTION_INITIALIZE,
-            )
-            .map_err(anyhow::Error::from)?;
-            fs::write(src.join("state.rs"), STATE_RS).map_err(anyhow::Error::from)?;
-            fs::write(src.join("errors.rs"), ERRORS_RS).map_err(anyhow::Error::from)?;
+            )?;
+            fs::write(src.join("state.rs"), STATE_RS)?;
+            fs::write(src.join("errors.rs"), ERRORS_RS)?;
         }
     }
 
@@ -174,24 +169,21 @@ pub(super) fn scaffold(
         fs::write(
             src.join("tests.rs"),
             generate_tests_rs(&module_name, fw, template, toolchain),
-        )
-        .map_err(anyhow::Error::from)?;
+        )?;
     }
 
     // TypeScript test scaffold
     if let Some(sdk) = ts_sdk {
         let tests_dir = root.join("tests");
-        fs::create_dir_all(&tests_dir).map_err(anyhow::Error::from)?;
+        fs::create_dir_all(&tests_dir)?;
 
-        fs::write(root.join("package.json"), generate_package_json(name, sdk))
-            .map_err(anyhow::Error::from)?;
-        fs::write(root.join("tsconfig.json"), TS_TEST_TSCONFIG).map_err(anyhow::Error::from)?;
+        fs::write(root.join("package.json"), generate_package_json(name, sdk))?;
+        fs::write(root.join("tsconfig.json"), TS_TEST_TSCONFIG)?;
 
         fs::write(
             tests_dir.join(format!("{}.test.ts", name)),
             generate_test_ts(name, sdk, toolchain),
-        )
-        .map_err(anyhow::Error::from)?;
+        )?;
     }
 
     // Generate Cargo.lock with the system cargo.  The Solana toolchain

--- a/cli/src/keys.rs
+++ b/cli/src/keys.rs
@@ -33,8 +33,8 @@ fn keypair_path(config: &QuasarConfig) -> PathBuf {
 /// Read the public key (program ID) from a Solana CLI-compatible keypair file.
 /// The file contains a 64-byte JSON array: [secret(32) | public(32)].
 fn read_program_id(path: &Path) -> Result<String, crate::error::CliError> {
-    let json = fs::read_to_string(path).map_err(anyhow::Error::from)?;
-    let bytes: Vec<u8> = serde_json::from_str(&json).map_err(anyhow::Error::from)?;
+    let json = fs::read_to_string(path)?;
+    let bytes: Vec<u8> = serde_json::from_str(&json)?;
     Ok(bs58::encode(&bytes[32..64]).into_string())
 }
 
@@ -48,12 +48,12 @@ fn current_program_id() -> Option<String> {
 
 /// Replace the address inside `declare_id!("...")` in src/lib.rs.
 fn replace_program_id(old_id: &str, new_id: &str) -> Result<(), crate::error::CliError> {
-    let source = fs::read_to_string("src/lib.rs").map_err(anyhow::Error::from)?;
+    let source = fs::read_to_string("src/lib.rs")?;
     let updated = source.replace(
         &format!("declare_id!(\"{old_id}\")"),
         &format!("declare_id!(\"{new_id}\")"),
     );
-    fs::write("src/lib.rs", updated).map_err(anyhow::Error::from)?;
+    fs::write("src/lib.rs", updated)?;
     Ok(())
 }
 
@@ -130,16 +130,16 @@ pub fn new(force: bool) -> CliResult {
     }
 
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(anyhow::Error::from)?;
+        fs::create_dir_all(parent)?;
     }
 
     let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
     let mut keypair_bytes = Vec::with_capacity(64);
     keypair_bytes.extend_from_slice(signing_key.as_bytes());
     keypair_bytes.extend_from_slice(signing_key.verifying_key().as_bytes());
-    let keypair_json = serde_json::to_string(&keypair_bytes).map_err(anyhow::Error::from)?;
+    let keypair_json = serde_json::to_string(&keypair_bytes)?;
 
-    fs::write(&path, &keypair_json).map_err(anyhow::Error::from)?;
+    fs::write(&path, &keypair_json)?;
 
     let id = bs58::encode(signing_key.verifying_key().as_bytes()).into_string();
     println!(

--- a/cli/src/new.rs
+++ b/cli/src/new.rs
@@ -32,10 +32,10 @@ pub fn run_instruction(name: &str) -> CliResult {
 
     // Create instructions directory if it doesn't exist (minimal template)
     if !instructions_dir.exists() {
-        fs::create_dir_all(&instructions_dir).map_err(anyhow::Error::from)?;
+        fs::create_dir_all(&instructions_dir)?;
 
         // Wire up `mod instructions;` and `use instructions::*;` in lib.rs
-        let lib_content = fs::read_to_string(&lib_path).map_err(anyhow::Error::from)?;
+        let lib_content = fs::read_to_string(&lib_path)?;
         if !lib_content.contains("mod instructions;") {
             // Insert after the last `use` or `mod` line at the top
             let insert = "mod instructions;\nuse instructions::*;\n";
@@ -49,7 +49,7 @@ pub fn run_instruction(name: &str) -> CliResult {
             } else {
                 format!("{insert}\n{lib_content}")
             };
-            fs::write(&lib_path, updated).map_err(anyhow::Error::from)?;
+            fs::write(&lib_path, updated)?;
             println!("  {} src/instructions/", style::success("created"));
         }
     }
@@ -80,7 +80,7 @@ impl<'info> {pascal}<'info> {{
 }}
 "#
     );
-    fs::write(&file_path, content).map_err(anyhow::Error::from)?;
+    fs::write(&file_path, content)?;
 
     // Update mod.rs
     let mod_path = instructions_dir.join("mod.rs");
@@ -89,14 +89,14 @@ impl<'info> {pascal}<'info> {{
     if !existing_mod.contains(&format!("mod {snake};")) {
         let new_line = format!("mod {snake};\npub use {snake}::*;\n");
         let updated = format!("{existing_mod}{new_line}");
-        fs::write(&mod_path, updated).map_err(anyhow::Error::from)?;
+        fs::write(&mod_path, updated)?;
     }
 
     // Update lib.rs — add instruction to #[program] block
     if lib_path.exists() {
-        let lib_content = fs::read_to_string(&lib_path).map_err(anyhow::Error::from)?;
+        let lib_content = fs::read_to_string(&lib_path)?;
         if let Some(updated) = add_instruction_to_entrypoint(&lib_content, &snake, &pascal) {
-            fs::write(&lib_path, updated).map_err(anyhow::Error::from)?;
+            fs::write(&lib_path, updated)?;
             println!("  {} src/lib.rs", style::success("updated"));
         }
     }
@@ -203,7 +203,7 @@ pub fn run_state(name: &str) -> CliResult {
     let already_exists = state_path.exists();
 
     if already_exists {
-        let existing = fs::read_to_string(&state_path).map_err(anyhow::Error::from)?;
+        let existing = fs::read_to_string(&state_path)?;
 
         // Find the highest existing discriminator in state.rs
         let mut max_disc: i64 = 0;
@@ -229,7 +229,7 @@ pub fn run_state(name: &str) -> CliResult {
         );
 
         let updated = format!("{existing}{new_struct}");
-        fs::write(&state_path, updated).map_err(anyhow::Error::from)?;
+        fs::write(&state_path, updated)?;
     } else {
         let content = format!(
             r#"use quasar_lang::prelude::*;
@@ -240,7 +240,7 @@ pub struct {pascal} {{
 }}
 "#
         );
-        fs::write(&state_path, content).map_err(anyhow::Error::from)?;
+        fs::write(&state_path, content)?;
     }
 
     println!(
@@ -270,12 +270,12 @@ pub fn run_error(name: &str) -> CliResult {
     let already_exists = errors_path.exists();
 
     if already_exists {
-        let existing = fs::read_to_string(&errors_path).map_err(anyhow::Error::from)?;
+        let existing = fs::read_to_string(&errors_path)?;
 
         let new_enum = format!("\n#[error_code]\npub enum {pascal} {{\n    Unknown,\n}}\n");
 
         let updated = format!("{existing}{new_enum}");
-        fs::write(&errors_path, updated).map_err(anyhow::Error::from)?;
+        fs::write(&errors_path, updated)?;
     } else {
         let content = format!(
             r#"use quasar_lang::prelude::*;
@@ -286,7 +286,7 @@ pub enum {pascal} {{
 }}
 "#
         );
-        fs::write(&errors_path, content).map_err(anyhow::Error::from)?;
+        fs::write(&errors_path, content)?;
     }
 
     println!(

--- a/cli/src/toolchain.rs
+++ b/cli/src/toolchain.rs
@@ -8,3 +8,40 @@ pub fn has_sbpf_linker() -> bool {
         .ok()
         .is_some_and(|o| o.status.success())
 }
+
+/// Ensure the installed `cargo-build-sbf` supports the given platform-tools
+/// version. Older Agave releases panic with an opaque `unwrap()` when asked
+/// for a version they don't know about.
+pub fn check_build_sbf_supports(required: &str) -> Result<(), String> {
+    let output = Command::new("cargo")
+        .args(["build-sbf", "--version"])
+        .output()
+        .map_err(|_| {
+            "cargo-build-sbf is not installed.\n\
+             Install Agave CLI: https://docs.anza.xyz/cli/install"
+                .to_string()
+        })?;
+
+    let version_text = String::from_utf8_lossy(&output.stdout);
+
+    // Parse "platform-tools vX.YZ" from the version output.
+    let bundled = version_text
+        .lines()
+        .find_map(|line| line.strip_prefix("platform-tools "))
+        .unwrap_or("unknown");
+
+    if parse_tools_version(bundled) < parse_tools_version(required) {
+        return Err(format!(
+            "quasar requires platform-tools {required}, but the installed cargo-build-sbf only \
+             supports {bundled}.\nUpdate Agave CLI:  agave-install update",
+        ));
+    }
+    Ok(())
+}
+
+/// Parse "vX.YZ" → numeric value for comparison (e.g. "v1.52" → 152).
+fn parse_tools_version(s: &str) -> u32 {
+    let s = s.strip_prefix('v').unwrap_or(s);
+    let (major, minor) = s.split_once('.').unwrap_or(("0", "0"));
+    major.parse::<u32>().unwrap_or(0) * 100 + minor.parse::<u32>().unwrap_or(0)
+}

--- a/derive/src/declare_program.rs
+++ b/derive/src/declare_program.rs
@@ -31,9 +31,9 @@ fn build_type_sizes(types: &[IdlTypeDef]) -> Result<HashMap<String, usize>, Stri
 
     // Validate all types are structs (enum kind would produce wrong sizes).
     for td in types {
-        if td.ty.kind != "struct" {
+        if !matches!(td.ty.kind, quasar_idl::types::TypeDefKind::Struct) {
             return Err(format!(
-                "type '{}' has kind '{}' — only structs are supported in CPI",
+                "type '{}' has kind '{:?}' — only structs are supported in CPI",
                 td.name, td.ty.kind
             ));
         }

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -1,4 +1,5 @@
 use {
+    super::format_disc_hex,
     crate::types::{Idl, IdlType, IdlTypeDef},
     std::fmt::Write,
 };
@@ -59,7 +60,7 @@ pub fn generate_go_client(idl: &Idl) -> String {
             "var {}Discriminator = [{}]byte{{{}}}",
             name,
             ix.discriminator.len(),
-            format_disc(&ix.discriminator),
+            format_disc_hex(&ix.discriminator),
         )
         .unwrap();
     }
@@ -74,7 +75,7 @@ pub fn generate_go_client(idl: &Idl) -> String {
             "var {}AccountDiscriminator = [{}]byte{{{}}}",
             name,
             acc.discriminator.len(),
-            format_disc(&acc.discriminator),
+            format_disc_hex(&acc.discriminator),
         )
         .unwrap();
     }
@@ -89,7 +90,7 @@ pub fn generate_go_client(idl: &Idl) -> String {
             "var {}EventDiscriminator = [{}]byte{{{}}}",
             name,
             ev.discriminator.len(),
-            format_disc(&ev.discriminator),
+            format_disc_hex(&ev.discriminator),
         )
         .unwrap();
     }
@@ -179,7 +180,7 @@ pub fn generate_go_client(idl: &Idl) -> String {
                 for seed in &pda.seeds {
                     match seed {
                         crate::types::IdlSeed::Const { value } => {
-                            seeds.push(format!("[]byte{{{}}}", format_disc(value)));
+                            seeds.push(format!("[]byte{{{}}}", format_disc_hex(value)));
                         }
                         crate::types::IdlSeed::Account { path } => {
                             seeds.push(format!("input.{}[:]", to_pascal(path)));
@@ -316,7 +317,7 @@ fn go_type(ty: &IdlType) -> String {
             "publicKey" => "solana.PublicKey".to_string(),
             "string" => "string".to_string(),
             other if other.starts_with('[') => {
-                let size = parse_fixed_array_size(other).unwrap_or(0);
+                let size = parse_fixed_array_size(other).expect("invalid fixed array size in IDL");
                 format!("[{}]byte", size)
             }
             _ => "[]byte".to_string(),
@@ -549,7 +550,7 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 n = name,
             ),
             _ if p.starts_with('[') => {
-                let size = parse_fixed_array_size(p).unwrap_or(0);
+                let size = parse_fixed_array_size(p).expect("invalid fixed array size in IDL");
                 format!(
                     "{t}var {n} [{sz}]byte\n{t}copy({n}[:], data[offset:offset+{sz}])\n{t}offset \
                      += {sz}\n",
@@ -664,13 +665,6 @@ fn parse_fixed_array_size(p: &str) -> Option<usize> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn format_disc(disc: &[u8]) -> String {
-    disc.iter()
-        .map(|b| format!("0x{:02x}", b))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
 
 /// camelCase or snake_case → PascalCase (exported in Go)
 fn to_pascal(s: &str) -> String {

--- a/idl/src/codegen/mod.rs
+++ b/idl/src/codegen/mod.rs
@@ -2,3 +2,40 @@ pub mod golang;
 pub mod python;
 pub mod rust;
 pub mod typescript;
+
+use std::fmt::Write;
+
+/// Format discriminator bytes as a comma-separated decimal list: `1, 2, 3`.
+pub fn format_disc_decimal(disc: &[u8]) -> String {
+    let mut s = String::with_capacity(disc.len() * 4);
+    for (i, b) in disc.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        write!(s, "{}", b).expect("write to String");
+    }
+    s
+}
+
+/// Format discriminator bytes as a comma-separated hex list: `0x01, 0x02,
+/// 0x03`.
+pub fn format_disc_hex(disc: &[u8]) -> String {
+    disc.iter()
+        .map(|b| format!("0x{:02x}", b))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Format discriminator bytes as a bracketed decimal array: `[1, 2, 3]`.
+pub fn format_disc_array_decimal(disc: &[u8]) -> String {
+    let mut s = String::with_capacity(disc.len() * 4 + 2);
+    s.push('[');
+    for (i, b) in disc.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        write!(s, "{}", b).expect("write to String");
+    }
+    s.push(']');
+    s
+}

--- a/idl/src/codegen/python.rs
+++ b/idl/src/codegen/python.rs
@@ -1,4 +1,5 @@
 use {
+    super::format_disc_decimal,
     crate::types::{Idl, IdlType, IdlTypeDef},
     std::fmt::Write,
 };
@@ -57,7 +58,7 @@ pub fn generate_python_client(idl: &Idl) -> String {
             out,
             "{}_DISCRIMINATOR = bytes([{}])",
             const_name,
-            format_disc(&ix.discriminator)
+            format_disc_decimal(&ix.discriminator)
         )
         .unwrap();
     }
@@ -72,7 +73,7 @@ pub fn generate_python_client(idl: &Idl) -> String {
             out,
             "{}_ACCOUNT_DISCRIMINATOR = bytes([{}])",
             const_name,
-            format_disc(&acc.discriminator)
+            format_disc_decimal(&acc.discriminator)
         )
         .unwrap();
     }
@@ -87,7 +88,7 @@ pub fn generate_python_client(idl: &Idl) -> String {
             out,
             "{}_EVENT_DISCRIMINATOR = bytes([{}])",
             const_name,
-            format_disc(&ev.discriminator)
+            format_disc_decimal(&ev.discriminator)
         )
         .unwrap();
     }
@@ -203,7 +204,7 @@ pub fn generate_python_client(idl: &Idl) -> String {
                 for seed in &pda.seeds {
                     match seed {
                         crate::types::IdlSeed::Const { value } => {
-                            seeds.push(format!("bytes([{}])", format_disc(value)));
+                            seeds.push(format!("bytes([{}])", format_disc_decimal(value)));
                         }
                         crate::types::IdlSeed::Account { path } => {
                             seeds.push(format!("bytes(input.{})", to_snake(path)));
@@ -466,7 +467,7 @@ fn decode_field_expr(name: &str, ty: &IdlType, indent: usize, types: &[IdlTypeDe
                 n = name,
             ),
             other if other.starts_with('[') => {
-                let size = parse_fixed_array_size(other).unwrap_or(0);
+                let size = parse_fixed_array_size(other).expect("invalid fixed array size in IDL");
                 format!(
                     "{pad}{n} = data[offset:offset + {sz}]\n{pad}offset += {sz}\n",
                     pad = pad,
@@ -607,13 +608,6 @@ fn primitive_size(p: &str) -> usize {
         "publicKey" => 32,
         _ => 0,
     }
-}
-
-fn format_disc(disc: &[u8]) -> String {
-    disc.iter()
-        .map(|b| b.to_string())
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 fn py_bool(b: bool) -> &'static str {

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -1,4 +1,5 @@
 use {
+    super::format_disc_decimal,
     crate::types::{Idl, IdlAccountItem, IdlField, IdlSeed, IdlType},
     std::{
         collections::{HashMap, HashSet},
@@ -287,7 +288,7 @@ fn emit_instructions(
 
     for ix in &idl.instructions {
         let pascal = camel_to_pascal(&ix.name);
-        let disc_str = format_disc_list(&ix.discriminator);
+        let disc_str = format_disc_decimal(&ix.discriminator);
 
         if disc_len == 1 {
             write!(mod_rs, "        {} => ", disc_str).expect("write to String");
@@ -436,7 +437,7 @@ fn emit_single_instruction(
     }
 
     // Instruction data
-    let disc_str = format_disc_list(&ix.discriminator);
+    let disc_str = format_disc_decimal(&ix.discriminator);
 
     if ix.args.is_empty() {
         writeln!(out, "        let data = vec![{}];", disc_str).expect("write to String");
@@ -531,7 +532,7 @@ fn emit_discriminated_module<T: DiscriminatedItem>(
     for item in &without_fields {
         let base = disc_base_name(item.name(), kind);
         let const_name = pascal_to_screaming_snake(base);
-        let disc_str = format_disc_list(item.discriminator());
+        let disc_str = format_disc_decimal(item.discriminator());
         writeln!(
             mod_rs,
             "pub const {}_{}_DISCRIMINATOR: &[u8] = &[{}];",
@@ -641,7 +642,7 @@ fn emit_single_state_or_event(
     let base = disc_base_name(name, kind);
     let const_name = pascal_to_screaming_snake(base);
     let kind_upper = kind.to_ascii_uppercase();
-    let disc_str = format_disc_list(discriminator);
+    let disc_str = format_disc_decimal(discriminator);
     writeln!(
         out,
         "pub const {}_{}_DISCRIMINATOR: &[u8] = &[{}];",
@@ -1011,7 +1012,7 @@ fn emit_manual_impls(
             discriminator.len()
         )
         .expect("write to String");
-        let disc_str = format_disc_list(discriminator);
+        let disc_str = format_disc_decimal(discriminator);
         writeln!(out, "        if disc != [{disc_str}] {{").expect("write to String");
     }
     let disc_kind = if kind == "account" {
@@ -1089,17 +1090,6 @@ fn collect_wrapper_needs(ty: &IdlType, needs_dyn_bytes: &mut bool, needs_dyn_vec
         }
         _ => {}
     }
-}
-
-fn format_disc_list(disc: &[u8]) -> String {
-    let mut s = String::with_capacity(disc.len() * 4);
-    for (i, b) in disc.iter().enumerate() {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        write!(s, "{}", b).expect("write to String");
-    }
-    s
 }
 
 fn pascal_to_screaming_snake(s: &str) -> String {

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -1,4 +1,5 @@
 use {
+    super::{format_disc_array_decimal, format_disc_decimal},
     crate::types::{Idl, IdlSeed, IdlType},
     std::{collections::HashSet, fmt::Write},
 };
@@ -167,7 +168,7 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     // Account discriminators
     for account in &idl.accounts {
         let const_name = pascal_to_screaming_snake(&account.name);
-        let disc_str = format_disc_array(&account.discriminator);
+        let disc_str = format_disc_array_decimal(&account.discriminator);
         writeln!(
             out,
             "export const {}_DISCRIMINATOR = new Uint8Array({});",
@@ -179,7 +180,7 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     // Event discriminators
     for event in &idl.events {
         let const_name = pascal_to_screaming_snake(&event.name);
-        let disc_str = format_disc_array(&event.discriminator);
+        let disc_str = format_disc_array_decimal(&event.discriminator);
         writeln!(
             out,
             "export const {}_DISCRIMINATOR = new Uint8Array({});",
@@ -192,7 +193,7 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     for ix in &idl.instructions {
         let pascal = snake_to_pascal(&ix.name);
         let const_name = pascal_to_screaming_snake(&pascal);
-        let disc_str = format_disc_array(&ix.discriminator);
+        let disc_str = format_disc_array_decimal(&ix.discriminator);
         writeln!(
             out,
             "export const {}_INSTRUCTION_DISCRIMINATOR = new Uint8Array({});",
@@ -588,7 +589,7 @@ fn generate_instruction_builders_web3js(out: &mut String, idl: &Idl) {
         }
 
         // Encode instruction data
-        let disc_str = format_disc_list(&ix.discriminator);
+        let disc_str = format_disc_decimal(&ix.discriminator);
         if ix.args.is_empty() {
             writeln!(out, "    const data = Buffer.from([{}]);", disc_str)
                 .expect("write to String");
@@ -744,7 +745,7 @@ fn generate_instruction_builders_kit(out: &mut String, idl: &Idl) {
         }
 
         // Encode instruction data
-        let disc_str = format_disc_list(&ix.discriminator);
+        let disc_str = format_disc_decimal(&ix.discriminator);
         if ix.args.is_empty() {
             writeln!(out, "    const data = Uint8Array.from([{}]);", disc_str)
                 .expect("write to String");
@@ -844,7 +845,7 @@ fn ts_codec(ty: &IdlType, target: TsTarget) -> String {
                 TsTarget::Kit => "getAddressCodec()".to_string(),
             },
             other if other.starts_with('[') => {
-                let size = parse_fixed_array_size(other).unwrap_or(0);
+                let size = parse_fixed_array_size(other).expect("invalid fixed array size in IDL");
                 format!("fixCodecSize(getBytesCodec(), {})", size)
             }
             other => format!("/* unknown: {} */", other),
@@ -953,31 +954,6 @@ fn pascal_to_screaming_snake(s: &str) -> String {
         result.push(c.to_ascii_uppercase());
     }
     result
-}
-
-fn format_disc_array(disc: &[u8]) -> String {
-    let mut s = String::with_capacity(disc.len() * 4 + 2);
-    s.push('[');
-    for (i, b) in disc.iter().enumerate() {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        write!(s, "{}", b).expect("write to String");
-    }
-    s.push(']');
-    s
-}
-
-/// Format discriminator bytes as a comma-separated list (no brackets).
-fn format_disc_list(disc: &[u8]) -> String {
-    let mut s = String::with_capacity(disc.len() * 4);
-    for (i, b) in disc.iter().enumerate() {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        write!(s, "{}", b).expect("write to String");
-    }
-    s
 }
 
 /// Write a `new Uint8Array([...])` seed line directly to the output.

--- a/idl/src/lint/constraints.rs
+++ b/idl/src/lint/constraints.rs
@@ -3,6 +3,40 @@
 //! Classifies account field wrapper types (`Account<T>`, `Signer`, etc.) and
 //! extracts constraint directives from `#[account(...)]` attributes.
 
+/// Recognized account wrapper type identifiers from the source code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WrapperType {
+    Account,
+    InterfaceAccount,
+    TokenAccount,
+    Mint,
+    Signer,
+    Program,
+    Sysvar,
+    SystemAccount,
+    UncheckedAccount,
+    AccountInfo,
+}
+
+impl WrapperType {
+    /// Classify an identifier string into a known wrapper type, if any.
+    pub fn from_ident(ident: &str) -> Option<Self> {
+        match ident {
+            "Account" => Some(Self::Account),
+            "InterfaceAccount" => Some(Self::InterfaceAccount),
+            "TokenAccount" => Some(Self::TokenAccount),
+            "Mint" => Some(Self::Mint),
+            "Signer" => Some(Self::Signer),
+            "Program" => Some(Self::Program),
+            "Sysvar" => Some(Self::Sysvar),
+            "SystemAccount" => Some(Self::SystemAccount),
+            "UncheckedAccount" => Some(Self::UncheckedAccount),
+            "AccountInfo" => Some(Self::AccountInfo),
+            _ => None,
+        }
+    }
+}
+
 /// Classification of an account field's wrapper type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldClass {
@@ -61,17 +95,26 @@ pub fn classify_field_type(ty: &syn::Type) -> (FieldClass, Option<String>) {
     let ident = last_seg.ident.to_string();
     let inner_name = extract_inner_type_name(last_seg);
 
-    match ident.as_str() {
-        "Account" => {
-            let inner = inner_name.clone().unwrap_or_else(|| "Unknown".to_string());
-            (
-                FieldClass::Account {
-                    inner_type: inner.clone(),
-                },
-                Some(inner),
-            )
+    let wrapper = match WrapperType::from_ident(&ident) {
+        Some(w) => w,
+        None => return (FieldClass::Unchecked, None),
+    };
+
+    match wrapper {
+        WrapperType::Account => {
+            // If there's no inner type, classify as Unchecked rather than
+            // injecting a fake "Unknown" name into the IDL.
+            match inner_name {
+                Some(inner) => (
+                    FieldClass::Account {
+                        inner_type: inner.clone(),
+                    },
+                    Some(inner),
+                ),
+                None => (FieldClass::Unchecked, None),
+            }
         }
-        "InterfaceAccount" => {
+        WrapperType::InterfaceAccount => {
             // Distinguish TokenAccount vs Mint by inner type name
             let inner = inner_name.clone().unwrap_or_default();
             if inner == "Mint" {
@@ -81,17 +124,13 @@ pub fn classify_field_type(ty: &syn::Type) -> (FieldClass, Option<String>) {
                 (FieldClass::TokenAccount, inner_name)
             }
         }
-        "TokenAccount" => (FieldClass::TokenAccount, inner_name),
-        "Mint" => (FieldClass::Mint, inner_name),
-        "Signer" => (FieldClass::Signer, None),
-        "Program" => (FieldClass::Program, inner_name),
-        "Sysvar" => (FieldClass::Sysvar, inner_name),
-        "SystemAccount" => (FieldClass::SystemAccount, None),
-        "UncheckedAccount" | "AccountInfo" => (FieldClass::Unchecked, None),
-        _ => {
-            // Unknown wrapper — default to Unchecked
-            (FieldClass::Unchecked, None)
-        }
+        WrapperType::TokenAccount => (FieldClass::TokenAccount, inner_name),
+        WrapperType::Mint => (FieldClass::Mint, inner_name),
+        WrapperType::Signer => (FieldClass::Signer, None),
+        WrapperType::Program => (FieldClass::Program, inner_name),
+        WrapperType::Sysvar => (FieldClass::Sysvar, inner_name),
+        WrapperType::SystemAccount => (FieldClass::SystemAccount, None),
+        WrapperType::UncheckedAccount | WrapperType::AccountInfo => (FieldClass::Unchecked, None),
     }
 }
 

--- a/idl/src/parser/accounts.rs
+++ b/idl/src/parser/accounts.rs
@@ -87,7 +87,10 @@ fn has_writable_directive(attrs: &[syn::Attribute]) -> bool {
         }
         let tokens_str = match attr.meta.require_list() {
             Ok(list) => list.tokens.to_string(),
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping malformed #[account] attribute: {e}");
+                continue;
+            }
         };
         for directive in tokens_str.split(',') {
             let d = directive.trim();
@@ -185,7 +188,10 @@ fn parse_pda_from_attrs(
 
         let tokens = match attr.meta.require_list() {
             Ok(list) => list.tokens.clone(),
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping malformed #[account] attribute: {e}");
+                continue;
+            }
         };
 
         let tokens_str = tokens.to_string();

--- a/idl/src/parser/events.rs
+++ b/idl/src/parser/events.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         parser::helpers,
-        types::{IdlEventDef, IdlField, IdlTypeDef, IdlTypeDefType},
+        types::{IdlEventDef, IdlField, IdlTypeDef, IdlTypeDefType, TypeDefKind},
     },
     syn::{Fields, Item},
 };
@@ -53,7 +53,10 @@ fn get_event_discriminator(attrs: &[syn::Attribute]) -> Option<Vec<u8>> {
 
         let tokens = match attr.meta.require_list() {
             Ok(list) => list.tokens.to_string(),
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping malformed #[event] attribute: {e}");
+                continue;
+            }
         };
 
         if !tokens.contains("discriminator") {
@@ -85,7 +88,7 @@ pub fn to_idl_type_def(raw: &RawEvent) -> IdlTypeDef {
     IdlTypeDef {
         name: raw.name.clone(),
         ty: IdlTypeDefType {
-            kind: "struct".to_string(),
+            kind: TypeDefKind::Struct,
             fields,
         },
     }

--- a/idl/src/parser/mod.rs
+++ b/idl/src/parser/mod.rs
@@ -138,10 +138,17 @@ pub fn build_idl(parsed: &ParsedProgram) -> Result<Idl, Vec<String>> {
         .instructions
         .iter()
         .map(|ix| {
-            let accounts_items = parsed
+            let accounts_struct = parsed
                 .accounts_structs
                 .iter()
-                .find(|s| s.name == ix.accounts_type_name)
+                .find(|s| s.name == ix.accounts_type_name);
+            if accounts_struct.is_none() {
+                errors.push(format!(
+                    "  instruction '{}' references accounts struct '{}' which was not found",
+                    ix.name, ix.accounts_type_name,
+                ));
+            }
+            let accounts_items = accounts_struct
                 .map(|s| accounts::to_idl_accounts(s, &parsed.state_accounts))
                 .unwrap_or_default();
 
@@ -183,7 +190,7 @@ pub fn build_idl(parsed: &ParsedProgram) -> Result<Idl, Vec<String>> {
             let type_def = IdlTypeDef {
                 name: sa.name.clone(),
                 ty: IdlTypeDefType {
-                    kind: "struct".to_string(),
+                    kind: TypeDefKind::Struct,
                     fields,
                 },
             };
@@ -210,7 +217,7 @@ pub fn build_idl(parsed: &ParsedProgram) -> Result<Idl, Vec<String>> {
             let type_def = IdlTypeDef {
                 name: ev.name.clone(),
                 ty: IdlTypeDefType {
-                    kind: "struct".to_string(),
+                    kind: TypeDefKind::Struct,
                     fields,
                 },
             };
@@ -273,7 +280,7 @@ pub fn build_idl(parsed: &ParsedProgram) -> Result<Idl, Vec<String>> {
             type_defs.push(IdlTypeDef {
                 name: type_name,
                 ty: IdlTypeDefType {
-                    kind: "struct".to_string(),
+                    kind: TypeDefKind::Struct,
                     fields: idl_fields,
                 },
             });
@@ -444,9 +451,10 @@ fn extract_plain_structs(file: &syn::File) -> Vec<RawDataStruct> {
 pub fn parse_program_from_source(src: &str) -> ParsedProgram {
     let file = syn::parse_file(src).expect("failed to parse source");
 
-    let program_id = program::extract_program_id(&file).unwrap_or_default();
-    let (program_name, instructions) =
-        program::extract_program_module(&file).unwrap_or_else(|| ("test".to_string(), vec![]));
+    let program_id =
+        program::extract_program_id(&file).expect("test source must contain declare_id!(...)");
+    let (program_name, instructions) = program::extract_program_module(&file)
+        .expect("test source must contain a #[program] module");
     let accounts_structs = accounts::extract_accounts_structs(&file);
     let state_accounts = state::extract_state_accounts(&file);
     let all_events = events::extract_events(&file);

--- a/idl/src/parser/state.rs
+++ b/idl/src/parser/state.rs
@@ -3,7 +3,7 @@
 
 use {
     super::helpers,
-    crate::types::{IdlAccountDef, IdlField, IdlTypeDef, IdlTypeDefType},
+    crate::types::{IdlAccountDef, IdlField, IdlTypeDef, IdlTypeDefType, TypeDefKind},
     syn::{Fields, Item},
 };
 
@@ -65,7 +65,10 @@ fn get_account_discriminator(attrs: &[syn::Attribute]) -> Option<Vec<u8>> {
 
         let tokens = match attr.meta.require_list() {
             Ok(list) => list.tokens.to_string(),
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping malformed #[account] attribute: {e}");
+                continue;
+            }
         };
 
         if !tokens.contains("discriminator") {
@@ -87,12 +90,18 @@ fn parse_seeds_attr(attrs: &[syn::Attribute]) -> Option<RawTypedSeeds> {
 
         let tokens = match attr.meta.require_list() {
             Ok(list) => list.tokens.clone(),
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping malformed #[seeds] attribute: {e}");
+                continue;
+            }
         };
 
         let parsed: SeedsTokens = match syn::parse2(tokens) {
             Ok(p) => p,
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("warning: skipping unparseable #[seeds] attribute: {e}");
+                continue;
+            }
         };
 
         return Some(RawTypedSeeds {
@@ -188,7 +197,7 @@ pub fn to_idl_type_def(raw: &RawStateAccount) -> IdlTypeDef {
     IdlTypeDef {
         name: raw.name.clone(),
         ty: IdlTypeDefType {
-            kind: "struct".to_string(),
+            kind: TypeDefKind::Struct,
             fields,
         },
     }

--- a/idl/src/types.rs
+++ b/idl/src/types.rs
@@ -131,9 +131,16 @@ pub struct IdlTypeDef {
     pub ty: IdlTypeDefType,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TypeDefKind {
+    Struct,
+    Enum,
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct IdlTypeDefType {
-    pub kind: String,
+    pub kind: TypeDefKind,
     pub fields: Vec<IdlField>,
 }
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -19,7 +19,7 @@ quasar-pod = { version = "0.0", path = "../pod" }
 const-crypto = "0.3.0"
 solana-program-error = "3.0.0"
 solana-account-view = "2.0.0"
-solana-address = { version = "2.2.0", features = ["wincode", "decode", "copy"] }
+solana-address = { version = ">=2.2, <2.6", features = ["wincode", "decode", "copy"] }
 solana-instruction-view = { version = "2.0.0", features = ["cpi"] }
 solana-program-log = "1.0.0"
 

--- a/pod/src/lib.rs
+++ b/pod/src/lib.rs
@@ -21,6 +21,7 @@
 
 #![no_std]
 
+pub(crate) mod prefix;
 pub mod string;
 pub mod vec;
 

--- a/pod/src/prefix.rs
+++ b/pod/src/prefix.rs
@@ -1,0 +1,57 @@
+//! Shared length-prefix encoding/decoding for `PodString` and `PodVec`.
+//!
+//! Both types store a `PFX`-byte little-endian length prefix. This module
+//! extracts the common encode/decode logic so each type doesn't duplicate it.
+
+/// Returns the maximum `N` value representable by a `PFX`-byte length prefix.
+///
+/// Returns `0` for invalid `PFX` values, which causes compile-time cap checks
+/// to fire.
+pub(crate) const fn max_n_for_pfx(pfx: usize) -> usize {
+    match pfx {
+        1 => u8::MAX as usize,
+        2 => u16::MAX as usize,
+        4 => u32::MAX as usize,
+        8 => usize::MAX,
+        _ => 0,
+    }
+}
+
+/// Decode a `PFX`-byte little-endian length prefix into a `usize`.
+///
+/// LLVM constant-folds this per monomorphization (e.g., for PFX=1 it
+/// compiles to a single byte load).
+#[inline(always)]
+pub(crate) fn decode_prefix_len<const PFX: usize>(len: &[u8; PFX]) -> usize {
+    let mut buf = [0u8; 8];
+    buf[..PFX].copy_from_slice(len);
+    u64::from_le_bytes(buf) as usize
+}
+
+/// Encode `n` as a `PFX`-byte little-endian prefix into the given buffer.
+#[inline(always)]
+pub(crate) fn encode_prefix_len<const PFX: usize>(len: &mut [u8; PFX], n: usize) {
+    let bytes = (n as u64).to_le_bytes();
+    len.copy_from_slice(&bytes[..PFX]);
+}
+
+/// Compile-time assertion that `PFX` is valid and `N` fits within the prefix.
+///
+/// Used by both `PodString` and `PodVec` in their `_CAP_CHECK` constants.
+macro_rules! cap_check {
+    ($type_name:expr, $N:expr, $PFX:expr) => {{
+        assert!(
+            $PFX == 1 || $PFX == 2 || $PFX == 4 || $PFX == 8,
+            concat!($type_name, ": PFX must be 1, 2, 4, or 8")
+        );
+        assert!(
+            $N <= $crate::prefix::max_n_for_pfx($PFX),
+            concat!(
+                $type_name,
+                ": N exceeds the maximum value representable by the PFX-byte length prefix"
+            )
+        );
+    }};
+}
+
+pub(crate) use cap_check;

--- a/pod/src/string.rs
+++ b/pod/src/string.rs
@@ -42,20 +42,10 @@
 //! loaded on guard creation, flushed back (with one realloc CPI if size
 //! changes) on drop.
 
-use core::mem::MaybeUninit;
-
-/// Returns the maximum `N` value representable by a `PFX`-byte length prefix.
-///
-/// Returns `0` for invalid `PFX` values, which causes `_CAP_CHECK` to fire.
-pub(crate) const fn max_n_for_pfx(pfx: usize) -> usize {
-    match pfx {
-        1 => u8::MAX as usize,
-        2 => u16::MAX as usize,
-        4 => u32::MAX as usize,
-        8 => usize::MAX,
-        _ => 0,
-    }
-}
+use {
+    crate::prefix::{cap_check, decode_prefix_len, encode_prefix_len},
+    core::mem::MaybeUninit,
+};
 
 /// Fixed-capacity inline string stored in account data.
 ///
@@ -79,17 +69,7 @@ pub struct PodString<const N: usize, const PFX: usize = 1> {
 
 // Compile-time: PFX must be in {1,2,4,8} and N must fit in the prefix.
 impl<const N: usize, const PFX: usize> PodString<N, PFX> {
-    const _CAP_CHECK: () = {
-        assert!(
-            PFX == 1 || PFX == 2 || PFX == 4 || PFX == 8,
-            "PodString<N, PFX>: PFX must be 1, 2, 4, or 8"
-        );
-        assert!(
-            N <= max_n_for_pfx(PFX),
-            "PodString<N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
-             prefix"
-        );
-    };
+    const _CAP_CHECK: () = cap_check!("PodString<N, PFX>", N, PFX);
 
     /// Compile-time validity check. Reference this in a `const` context to
     /// verify that `N` and `PFX` are in range at the call site.
@@ -122,16 +102,11 @@ const _: () = assert!(core::mem::align_of::<PodString<0, 8>>() == 1);
 
 impl<const N: usize, const PFX: usize> PodString<N, PFX> {
     /// Decode the on-disk length prefix into a `usize`.
-    ///
-    /// LLVM constant-folds this per monomorphization (e.g., for PFX=1 it
-    /// compiles to a single byte load).
     #[inline(always)]
     fn decode_len(&self) -> usize {
         #[allow(clippy::let_unit_value)]
         let _ = Self::_CAP_CHECK;
-        let mut buf = [0u8; 8];
-        buf[..PFX].copy_from_slice(&self.len);
-        u64::from_le_bytes(buf) as usize
+        decode_prefix_len(&self.len)
     }
 
     /// Encode `n` as a `PFX`-byte little-endian prefix into `self.len`.
@@ -139,8 +114,7 @@ impl<const N: usize, const PFX: usize> PodString<N, PFX> {
     fn encode_len(&mut self, n: usize) {
         #[allow(clippy::let_unit_value)]
         let _ = Self::_CAP_CHECK;
-        let bytes = (n as u64).to_le_bytes();
-        self.len.copy_from_slice(&bytes[..PFX]);
+        encode_prefix_len(&mut self.len, n);
     }
 
     /// Number of active bytes in the string.
@@ -277,9 +251,11 @@ impl<const N: usize, const PFX: usize> PodString<N, PFX> {
             bytes.len() >= PFX,
             "load_from_bytes: slice must have at least PFX bytes"
         );
-        let mut buf = [0u8; 8];
-        buf[..PFX].copy_from_slice(&bytes[..PFX]);
-        let slen = (u64::from_le_bytes(buf) as usize).min(N);
+        // SAFETY: debug_assert above ensures bytes.len() >= PFX. We need a
+        // [u8; PFX] reference for decode_prefix_len; try_into is infallible
+        // given the length check.
+        let pfx_bytes: &[u8; PFX] = bytes[..PFX].try_into().unwrap();
+        let slen = decode_prefix_len(pfx_bytes).min(N);
         debug_assert!(
             bytes.len() >= PFX + slen,
             "load_from_bytes: slice too short for encoded length"

--- a/pod/src/vec.rs
+++ b/pod/src/vec.rs
@@ -44,7 +44,10 @@
 //! stack-local copy — loaded on guard creation, flushed back (with one realloc
 //! CPI if size changes) on drop.
 
-use {super::string::max_n_for_pfx, core::mem::MaybeUninit};
+use {
+    crate::prefix::{cap_check, decode_prefix_len, encode_prefix_len},
+    core::mem::MaybeUninit,
+};
 
 /// Fixed-capacity inline vector stored in account data.
 ///
@@ -85,17 +88,7 @@ impl<T: Copy, const N: usize, const PFX: usize> PodVec<T, N, PFX> {
          native integers."
     );
 
-    const _CAP_CHECK: () = {
-        assert!(
-            PFX == 1 || PFX == 2 || PFX == 4 || PFX == 8,
-            "PodVec<T, N, PFX>: PFX must be 1, 2, 4, or 8"
-        );
-        assert!(
-            N <= max_n_for_pfx(PFX),
-            "PodVec<T, N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
-             prefix"
-        );
-    };
+    const _CAP_CHECK: () = cap_check!("PodVec<T, N, PFX>", N, PFX);
 
     /// Compile-time validity check. Reference this in a `const` context to
     /// verify that `T`, `N`, and `PFX` are valid at the call site.
@@ -110,16 +103,11 @@ impl<T: Copy, const N: usize, const PFX: usize> PodVec<T, N, PFX> {
     };
 
     /// Decode the on-disk length prefix into a `usize`.
-    ///
-    /// LLVM constant-folds this per monomorphization (e.g., for PFX=2 it
-    /// compiles to a 16-bit load).
     #[inline(always)]
     fn decode_len(&self) -> usize {
         #[allow(clippy::let_unit_value)]
         let _ = Self::_CAP_CHECK;
-        let mut buf = [0u8; 8];
-        buf[..PFX].copy_from_slice(&self.len);
-        u64::from_le_bytes(buf) as usize
+        decode_prefix_len(&self.len)
     }
 
     /// Encode `n` as a `PFX`-byte little-endian prefix into `self.len`.
@@ -127,8 +115,7 @@ impl<T: Copy, const N: usize, const PFX: usize> PodVec<T, N, PFX> {
     fn encode_len(&mut self, n: usize) {
         #[allow(clippy::let_unit_value)]
         let _ = Self::_CAP_CHECK;
-        let bytes = (n as u64).to_le_bytes();
-        self.len.copy_from_slice(&bytes[..PFX]);
+        encode_prefix_len(&mut self.len, n);
     }
 
     /// Number of active elements.
@@ -367,9 +354,8 @@ impl<T: Copy, const N: usize, const PFX: usize> PodVec<T, N, PFX> {
             bytes.len() >= PFX,
             "load_from_bytes: slice must have at least PFX bytes"
         );
-        let mut buf = [0u8; 8];
-        buf[..PFX].copy_from_slice(&bytes[..PFX]);
-        let count = (u64::from_le_bytes(buf) as usize).min(N);
+        let pfx_bytes: &[u8; PFX] = bytes[..PFX].try_into().unwrap();
+        let count = decode_prefix_len(pfx_bytes).min(N);
         let data_bytes = count * core::mem::size_of::<T>();
         debug_assert!(
             bytes.len() >= PFX + data_bytes,

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -45,11 +45,13 @@
 
 #![no_std]
 
-/// Implements the full account type contract for a type owned by a single
-/// program.
+/// Defines a `#[repr(transparent)]` SPL account wrapper type and implements
+/// the full account type contract for it.
 ///
-/// Generates five trait implementations:
+/// This is the single source of truth for all SPL account wrapper types
+/// (`Token`, `Mint`, `Token2022`, `Mint2022`). Each invocation generates:
 ///
+/// - The struct itself (with a single `__view: AccountView` field)
 /// - `StaticView` — marks the type as having a fixed layout
 /// - `AsAccountView` — provides access to the underlying `AccountView`
 /// - `AccountCheck` — validates `data_len >= T::LEN`
@@ -65,73 +67,82 @@
 /// 1. `AccountCheck::check` validated `data_len >= $target::LEN`
 /// 2. `$target` is `#[repr(C)]` with alignment 1 (any pointer is valid)
 /// 3. The owner check guarantees the data was written by the expected program
-macro_rules! impl_program_account {
-    ($ty:ty, $id:expr, $target:ty) => {
-        unsafe impl StaticView for $ty {}
+macro_rules! define_spl_account {
+    (
+        $(#[$meta:meta])*
+        $name:ident, $owner_id:expr, $state:ty
+    ) => {
+        $(#[$meta])*
+        #[repr(transparent)]
+        pub struct $name {
+            __view: AccountView,
+        }
 
-        impl AsAccountView for $ty {
+        unsafe impl StaticView for $name {}
+
+        impl AsAccountView for $name {
             #[inline(always)]
             fn to_account_view(&self) -> &AccountView {
                 &self.__view
             }
         }
 
-        impl AccountCheck for $ty {
+        impl AccountCheck for $name {
             #[inline(always)]
             fn check(view: &AccountView) -> Result<(), ProgramError> {
-                if quasar_lang::utils::hint::unlikely(view.data_len() < <$target>::LEN) {
+                if quasar_lang::utils::hint::unlikely(view.data_len() < <$state>::LEN) {
                     return Err(ProgramError::AccountDataTooSmall);
                 }
                 Ok(())
             }
         }
 
-        impl CheckOwner for $ty {
+        impl CheckOwner for $name {
             #[inline(always)]
             fn check_owner(view: &AccountView) -> Result<(), ProgramError> {
-                if quasar_lang::utils::hint::unlikely(!quasar_lang::keys_eq(view.owner(), &$id)) {
+                if quasar_lang::utils::hint::unlikely(!quasar_lang::keys_eq(view.owner(), &$owner_id)) {
                     return Err(ProgramError::IllegalOwner);
                 }
                 Ok(())
             }
         }
 
-        impl core::ops::Deref for $ty {
-            type Target = $target;
+        impl core::ops::Deref for $name {
+            type Target = $state;
 
             #[inline(always)]
             fn deref(&self) -> &Self::Target {
                 // SAFETY: `AccountCheck::check` validated `data_len >= LEN`.
-                // `$target` is `#[repr(C)]` with alignment 1 — any data
+                // `$state` is `#[repr(C)]` with alignment 1 — any data
                 // pointer is valid.
-                unsafe { &*(self.__view.data_ptr() as *const $target) }
+                unsafe { &*(self.__view.data_ptr() as *const $state) }
             }
         }
 
-        impl core::ops::DerefMut for $ty {
+        impl core::ops::DerefMut for $name {
             #[inline(always)]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 // SAFETY: Same as Deref — length validated, alignment 1.
                 // Mutability checked by the writable constraint.
-                unsafe { &mut *(self.__view.data_mut_ptr() as *mut $target) }
+                unsafe { &mut *(self.__view.data_mut_ptr() as *mut $state) }
             }
         }
 
-        impl ZeroCopyDeref for $ty {
-            type Target = $target;
+        impl ZeroCopyDeref for $name {
+            type Target = $state;
 
             #[inline(always)]
             unsafe fn deref_from(view: &AccountView) -> &Self::Target {
                 // SAFETY: Caller ensures `view.data_len() >= LEN`.
-                // `$target` is `#[repr(C)]` with alignment 1.
-                &*(view.data_ptr() as *const $target)
+                // `$state` is `#[repr(C)]` with alignment 1.
+                &*(view.data_ptr() as *const $state)
             }
 
             #[inline(always)]
             unsafe fn deref_from_mut(view: &mut AccountView) -> &mut Self::Target {
                 // SAFETY: Same as `deref_from` — caller ensures length
                 // and writable.
-                &mut *(view.data_mut_ptr() as *mut $target)
+                &mut *(view.data_mut_ptr() as *mut $state)
             }
         }
     };

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -7,32 +7,28 @@ use {
     quasar_lang::{prelude::*, traits::Id},
 };
 
-/// Token account view — validates owner is SPL Token program.
-///
-/// Use as `Account<Token>` for single-program token accounts,
-/// or `InterfaceAccount<Token>` to accept both SPL Token and Token-2022.
-///
-/// Also implements `Id`, so `Program<Token>` serves as the program account
-/// type.
-#[repr(transparent)]
-pub struct Token {
-    __view: AccountView,
-}
-impl_program_account!(Token, SPL_TOKEN_ID, TokenAccountState);
+define_spl_account!(
+    /// Token account view — validates owner is SPL Token program.
+    ///
+    /// Use as `Account<Token>` for single-program token accounts,
+    /// or `InterfaceAccount<Token>` to accept both SPL Token and Token-2022.
+    ///
+    /// Also implements `Id`, so `Program<Token>` serves as the program account
+    /// type.
+    Token, SPL_TOKEN_ID, TokenAccountState
+);
 
 impl Id for Token {
     const ID: Address = Address::new_from_array(SPL_TOKEN_BYTES);
 }
 
-/// Mint account view — validates owner is SPL Token program.
-///
-/// Use as `Account<Mint>` for single-program mints,
-/// or `InterfaceAccount<Mint>` to accept both SPL Token and Token-2022.
-#[repr(transparent)]
-pub struct Mint {
-    __view: AccountView,
-}
-impl_program_account!(Mint, SPL_TOKEN_ID, MintAccountState);
+define_spl_account!(
+    /// Mint account view — validates owner is SPL Token program.
+    ///
+    /// Use as `Account<Mint>` for single-program mints,
+    /// or `InterfaceAccount<Mint>` to accept both SPL Token and Token-2022.
+    Mint, SPL_TOKEN_ID, MintAccountState
+);
 
 /// Valid owner programs for token interface accounts (SPL Token + Token-2022).
 static SPL_TOKEN_OWNERS: [Address; 2] = [SPL_TOKEN_ID, TOKEN_2022_ID];

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -7,25 +7,21 @@ use {
     quasar_lang::{prelude::*, traits::Id},
 };
 
-/// Token account view — validates owner is Token-2022 program.
-///
-/// Also implements `Id`, so `Program<Token2022>` serves as the program account
-/// type.
-#[repr(transparent)]
-pub struct Token2022 {
-    __view: AccountView,
-}
-impl_program_account!(Token2022, TOKEN_2022_ID, TokenAccountState);
+define_spl_account!(
+    /// Token account view — validates owner is Token-2022 program.
+    ///
+    /// Also implements `Id`, so `Program<Token2022>` serves as the program account
+    /// type.
+    Token2022, TOKEN_2022_ID, TokenAccountState
+);
 
 impl Id for Token2022 {
     const ID: Address = Address::new_from_array(TOKEN_2022_BYTES);
 }
 
-/// Mint account view — validates owner is Token-2022 program.
-#[repr(transparent)]
-pub struct Mint2022 {
-    __view: AccountView,
-}
-impl_program_account!(Mint2022, TOKEN_2022_ID, MintAccountState);
+define_spl_account!(
+    /// Mint account view — validates owner is Token-2022 program.
+    Mint2022, TOKEN_2022_ID, MintAccountState
+);
 
 impl TokenCpi for Program<Token2022> {}


### PR DESCRIPTION
## Summary

- **fix(cli):** Add pre-flight check for `cargo-build-sbf` platform-tools version compatibility — older Agave releases panic with an opaque `unwrap()` when asked for a version they don't bundle; now produces a clear error with upgrade instructions
- **refactor(cli):** Add `JsonError`/`Dialoguer` variants to `CliError`, replacing ~40 `.map_err(anyhow::Error::from)?` calls with plain `?`; extract banner animation into a fallible function
- **refactor(idl):** Replace stringly-typed `TypeDefKind` with an enum; deduplicate discriminator formatting across all four codegen backends; introduce `WrapperType` enum for account classification; add parser diagnostics for malformed attributes
- **refactor(pod):** Extract shared length-prefix encode/decode into `prefix` module, removing ~40 lines of duplication between `PodString` and `PodVec`
- **refactor(spl):** Unify `define_spl_account!` macro to generate both the struct and all trait impls from a single invocation
- **chore(lang):** Widen `solana-address` version range to `>=2.2, <2.6` for broader Agave SDK compatibility

Original branch: [`worktree-fix-toolchain-compat`](https://github.com/blueshift-gg/quasar/tree/worktree-fix-toolchain-compat)

## Test plan

- [ ] `cargo clippy --workspace` passes (verified by pre-push hook)
- [ ] `cargo fmt --check` passes (verified by pre-push hook)
- [ ] IDL generation produces identical output for existing test programs
- [ ] `cargo build-sbf` version check triggers correctly with an outdated Agave install