### PR TITLE
feat(cli): configurable clients path

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -35,11 +35,12 @@ pub fn run(debug: bool, watch: bool, features: Option<String>, lint: bool) -> Cl
 
 fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
     let config = QuasarConfig::load()?;
+    let clients_path = config.client_path();
     let start = Instant::now();
 
     let languages = config.client_languages();
     let crate_root = utils::find_program_crate(&config);
-    let parsed = crate::idl::generate(&crate_root, &languages)?;
+    let parsed = crate::idl::generate(&crate_root, &languages, &clients_path)?;
 
     if lint_flag || config.lint_enabled() {
         crate::lint::run_lint_on_parsed(&parsed, &quasar_idl::lint::LintConfig::default())?;
@@ -168,11 +169,12 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
 /// Copies the .so to target/profile/ and returns the path.
 pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
     let config = QuasarConfig::load()?;
+    let clients_path = config.client_path();
     let start = Instant::now();
 
     let languages = config.client_languages();
     let crate_root = utils::find_program_crate(&config);
-    let _parsed = crate::idl::generate(&crate_root, &languages)?;
+    let _parsed = crate::idl::generate(&crate_root, &languages, &clients_path)?;
 
     let sp = style::spinner("Profile build...");
 

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        config::QuasarConfig,
+        config::resolve_client_path,
         error::{CliError, CliResult},
         style, ClientCommand,
     },
@@ -13,7 +13,7 @@ use {
 const ALL_LANGUAGES: &[&str] = &["typescript", "python", "golang"];
 
 pub fn run(command: ClientCommand) -> CliResult {
-    let clients_path = QuasarConfig::load()?.client_path();
+    let clients_path = resolve_client_path()?;
     let idl_path = &command.idl_path;
 
     if !idl_path.exists() {

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -1,10 +1,11 @@
 use {
     crate::{
+        config::QuasarConfig,
         error::{CliError, CliResult},
         style, ClientCommand,
     },
     quasar_idl::codegen,
-    std::path::PathBuf,
+    std::path::{Path, PathBuf},
 };
 
 /// Languages that can be generated from an IDL JSON file.
@@ -12,6 +13,7 @@ use {
 const ALL_LANGUAGES: &[&str] = &["typescript", "python", "golang"];
 
 pub fn run(command: ClientCommand) -> CliResult {
+    let clients_path = QuasarConfig::load()?.client_path();
     let idl_path = &command.idl_path;
 
     if !idl_path.exists() {
@@ -43,7 +45,7 @@ pub fn run(command: ClientCommand) -> CliResult {
             .collect::<Result<Vec<_>, _>>()?
     };
 
-    generate_clients(&idl, &languages)?;
+    generate_clients(&idl, &languages, &clients_path)?;
 
     println!(
         "  {}",
@@ -52,14 +54,17 @@ pub fn run(command: ClientCommand) -> CliResult {
     Ok(())
 }
 
-pub fn generate_clients(idl: &quasar_idl::types::Idl, languages: &[&str]) -> CliResult {
+pub fn generate_clients(
+    idl: &quasar_idl::types::Idl,
+    languages: &[&str],
+    clients_path: &Path,
+) -> CliResult {
     // TypeScript
     if languages.contains(&"typescript") {
         let ts_code = codegen::typescript::generate_ts_client(idl);
         let ts_kit_code = codegen::typescript::generate_ts_client_kit(idl);
 
-        let ts_dir = PathBuf::from("target")
-            .join("client")
+        let ts_dir = PathBuf::from(clients_path)
             .join("typescript")
             .join(&idl.metadata.name);
         std::fs::create_dir_all(&ts_dir)?;
@@ -97,8 +102,7 @@ pub fn generate_clients(idl: &quasar_idl::types::Idl, languages: &[&str]) -> Cli
     // Python
     if languages.contains(&"python") {
         let py_code = codegen::python::generate_python_client(idl);
-        let py_dir = PathBuf::from("target")
-            .join("client")
+        let py_dir = PathBuf::from(clients_path)
             .join("python")
             .join(&idl.metadata.crate_name);
         std::fs::create_dir_all(&py_dir)?;
@@ -113,10 +117,7 @@ pub fn generate_clients(idl: &quasar_idl::types::Idl, languages: &[&str]) -> Cli
     if languages.contains(&"golang") {
         let go_code = codegen::golang::generate_go_client(idl);
         let go_pkg = idl.metadata.crate_name.replace('-', "_");
-        let go_dir = PathBuf::from("target")
-            .join("client")
-            .join("golang")
-            .join(&go_pkg);
+        let go_dir = PathBuf::from(clients_path).join("golang").join(&go_pkg);
         std::fs::create_dir_all(&go_dir)?;
         std::fs::write(go_dir.join("client.go"), &go_code)?;
         std::fs::write(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -139,6 +139,15 @@ impl QuasarConfig {
     }
 }
 
+pub fn resolve_client_path() -> Result<PathBuf, CliError> {
+    let config_path = Path::new("Quasar.toml");
+    if !config_path.exists() {
+        return Ok(PathBuf::from("target").join("client"));
+    }
+
+    QuasarConfig::load_from(config_path).map(|config| config.client_path())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "RawCommandSpec", into = "RawCommandSpec")]
 pub struct CommandSpec {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -61,6 +61,7 @@ pub struct TypeScriptTestingConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct ClientsConfig {
+    pub path: PathBuf,
     pub languages: Vec<String>,
 }
 
@@ -114,6 +115,13 @@ impl QuasarConfig {
 
     pub fn lint_enabled(&self) -> bool {
         self.lint.as_ref().is_some_and(|l| l.enabled)
+    }
+
+    pub fn client_path(&self) -> PathBuf {
+        self.clients
+            .as_ref()
+            .map(|c| c.path.clone())
+            .unwrap_or(PathBuf::from("target").join("client"))
     }
 
     pub fn client_languages(&self) -> Vec<&str> {

--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        config::QuasarConfig,
+        config::resolve_client_path,
         error::{CliError, CliResult},
         IdlCommand,
     },
@@ -61,7 +61,7 @@ fn generate_idl(
 
 /// Called by `quasar idl <path>` — generates IDL JSON + Rust client only.
 pub fn run(command: IdlCommand) -> CliResult {
-    let clients_path = QuasarConfig::load()?.client_path();
+    let clients_path = resolve_client_path()?;
     let crate_path = &command.crate_path;
     if !crate_path.exists() {
         return Err(CliError::message(format!(

--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        config::QuasarConfig,
         error::{CliError, CliResult},
         IdlCommand,
     },
@@ -13,7 +14,10 @@ use {
 
 /// Parse program source, write IDL JSON and Rust client.
 /// Returns the IDL for optional downstream client generation.
-fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error> {
+fn generate_idl(
+    crate_path: &Path,
+    clients_path: &Path,
+) -> Result<(Idl, ParsedProgram), anyhow::Error> {
     let parsed = parser::parse_program(crate_path);
     let idl =
         parser::build_idl(&parsed).map_err(|errors| anyhow::anyhow!("{}", errors.join("\n")))?;
@@ -33,8 +37,7 @@ fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error
     std::fs::write(&idl_path, &json)?;
 
     // Write Rust client
-    let client_dir = PathBuf::from("target")
-        .join("client")
+    let client_dir = clients_path
         .join("rust")
         .join(format!("{}-client", idl.metadata.crate_name));
     std::fs::create_dir_all(&client_dir)?;
@@ -58,6 +61,7 @@ fn generate_idl(crate_path: &Path) -> Result<(Idl, ParsedProgram), anyhow::Error
 
 /// Called by `quasar idl <path>` — generates IDL JSON + Rust client only.
 pub fn run(command: IdlCommand) -> CliResult {
+    let clients_path = QuasarConfig::load()?.client_path();
     let crate_path = &command.crate_path;
     if !crate_path.exists() {
         return Err(CliError::message(format!(
@@ -66,15 +70,19 @@ pub fn run(command: IdlCommand) -> CliResult {
         )));
     }
 
-    generate_idl(crate_path)?;
+    generate_idl(crate_path, &clients_path)?;
     println!("  {}", crate::style::success("IDL generated"));
     Ok(())
 }
 
 /// Called by `quasar build` — generates IDL + Rust client + configured language
 /// clients. Returns the ParsedProgram for downstream lint use.
-pub fn generate(crate_path: &Path, languages: &[&str]) -> Result<ParsedProgram, CliError> {
-    let (idl, parsed) = generate_idl(crate_path)?;
-    crate::client::generate_clients(&idl, languages)?;
+pub fn generate(
+    crate_path: &Path,
+    languages: &[&str],
+    clients_path: &Path,
+) -> Result<ParsedProgram, CliError> {
+    let (idl, parsed) = generate_idl(crate_path, clients_path)?;
+    crate::client::generate_clients(&idl, languages, clients_path)?;
     Ok(parsed)
 }

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -99,6 +99,7 @@ pub(super) fn scaffold(
             },
         },
         clients: QuasarClients {
+            path: "target/client".to_string(),
             languages: client_languages.to_vec(),
         },
     };

--- a/cli/src/init/schema.rs
+++ b/cli/src/init/schema.rs
@@ -44,5 +44,6 @@ pub(super) struct QuasarTypeScriptTesting {
 
 #[derive(Serialize)]
 pub(super) struct QuasarClients {
+    pub(super) path: String,
     pub(super) languages: Vec<String>,
 }


### PR DESCRIPTION
## Summary

This PR supersedes #122 and rebases Dodecahedr0x's configurable client path work onto post-#155 `master`.

The original contribution is preserved as the feature commit, with one follow-up compatibility fix on top.

The feature remains the same:

- `Quasar.toml` can configure the generated client output path
- CLI client/codegen commands respect that configured path inside a Quasar project

The rebased branch adds one important compatibility correction:

- standalone IDL-driven client generation continues to work outside a Quasar project by falling back to `target/client` when `Quasar.toml` is absent

## What Changed

### 1. Preserve configurable client output paths

The original PR's behavior is kept:

- CLI codegen paths now flow through configured client-path resolution
- project-local client generation can target a non-default path from `Quasar.toml`

### 2. Restore standalone IDL generation behavior

The original branch made `quasar client` unconditionally depend on `Quasar.toml`.

That broke a valid workflow: generating clients directly from an IDL file outside a Quasar project.

This rebased branch fixes that by introducing a path resolver that behaves as follows:

- if `Quasar.toml` exists and is valid, use its configured client path
- if `Quasar.toml` is missing, fall back to `target/client`
- if `Quasar.toml` exists but is invalid, still return the config error

So project-aware behavior is preserved without regressing standalone use.

## Attribution

Supersedes #122.

Original contribution:

- `feat: configurable clients path` by @Dodecahedr0x

Rebase/fixup on top of `master`:

- standalone IDL compatibility fix

## Validation

Commands run:

- `cargo test -p quasar-cli`
