### PR TITLE
fix(derive): support scalar constants in typed seeds

### DIFF
--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -1,10 +1,14 @@
 use {
     super::super::{
         resolve::{BumpSyntax, FieldSemantics, FieldShape, PdaConstraint, UserCheckKind},
-        syntax::{render_seed_expr, seeds_to_emit_nodes, SeedEmitNode, SeedRenderContext},
+        syntax::{
+            render_seed_expr, seeds_to_emit_nodes, AccountWrapperKind, SeedEmitNode,
+            SeedRenderContext,
+        },
     },
     crate::helpers::strip_generics,
     quote::{format_ident, quote},
+    std::collections::BTreeMap,
 };
 
 pub(crate) fn emit_parse_body(
@@ -396,6 +400,33 @@ fn emit_seed_bindings_from_nodes(
     ctx: SeedRenderContext,
     name_prefix: &str,
 ) -> SeedBindingParts {
+    let mut rooted_init_bindings = BTreeMap::<String, syn::Ident>::new();
+    let mut root_lets = Vec::new();
+
+    if matches!(ctx, SeedRenderContext::Init) {
+        for node in seeds {
+            let SeedEmitNode::FieldRootedExpr {
+                root_ident,
+                inner_ty: Some(inner_ty),
+                wrapper_kind,
+                ..
+            } = node
+            else {
+                continue;
+            };
+
+            let key = root_ident.to_string();
+            if rooted_init_bindings.contains_key(&key) {
+                continue;
+            }
+
+            let binding_ident = format_ident!("__{}_{}_root_{}", name_prefix, field, root_ident);
+            let typed_cast = emit_root_wrapper_cast(root_ident, inner_ty, wrapper_kind.as_ref());
+            root_lets.push(quote! { let #binding_ident = unsafe { #typed_cast }; });
+            rooted_init_bindings.insert(key, binding_ident);
+        }
+    }
+
     let seed_idents: Vec<syn::Ident> = seeds
         .iter()
         .enumerate()
@@ -406,14 +437,89 @@ fn emit_seed_bindings_from_nodes(
         .iter()
         .zip(seeds.iter())
         .map(|(ident, node)| {
-            let expr = render_seed_expr(node, ctx);
+            let expr = match (ctx, node) {
+                (
+                    SeedRenderContext::Init,
+                    SeedEmitNode::FieldRootedExpr {
+                        expr,
+                        root_ident,
+                        inner_ty: Some(_),
+                        ..
+                    },
+                ) => {
+                    let binding_ident = &rooted_init_bindings[&root_ident.to_string()];
+                    render_expr_with_bound_root(expr, root_ident, binding_ident)
+                }
+                _ => render_seed_expr(node, ctx),
+            };
             quote! { let #ident: &[u8] = #expr; }
         })
         .collect();
 
     SeedBindingParts {
         seed_idents,
-        seed_lets,
+        seed_lets: root_lets.into_iter().chain(seed_lets).collect(),
+    }
+}
+
+fn emit_root_wrapper_cast(
+    root_ident: &syn::Ident,
+    inner_ty: &syn::Type,
+    wrapper_kind: Option<&AccountWrapperKind>,
+) -> proc_macro2::TokenStream {
+    let base_ty = strip_generics(inner_ty);
+    match wrapper_kind {
+        Some(AccountWrapperKind::InterfaceAccount) => {
+            quote! {
+                quasar_lang::accounts::interface_account::InterfaceAccount::<#base_ty>::from_account_view_unchecked(#root_ident)
+            }
+        }
+        _ => {
+            quote! {
+                quasar_lang::accounts::account::Account::<#base_ty>::from_account_view_unchecked(#root_ident)
+            }
+        }
+    }
+}
+
+fn render_expr_with_bound_root(
+    expr: &syn::Expr,
+    root_ident: &syn::Ident,
+    binding_ident: &syn::Ident,
+) -> proc_macro2::TokenStream {
+    match expr {
+        syn::Expr::Path(ep) if ep.path.segments.len() == 1 && ep.qself.is_none() => {
+            let ident = &ep.path.segments[0].ident;
+            if ident == root_ident {
+                quote! { #binding_ident }
+            } else {
+                quote! { #expr }
+            }
+        }
+        syn::Expr::Field(field_expr) => {
+            let base = render_expr_with_bound_root(&field_expr.base, root_ident, binding_ident);
+            let member = &field_expr.member;
+            quote! { (#base).#member }
+        }
+        syn::Expr::Paren(paren_expr) => {
+            let inner = render_expr_with_bound_root(&paren_expr.expr, root_ident, binding_ident);
+            quote! { (#inner) }
+        }
+        syn::Expr::MethodCall(method_call) => {
+            let receiver =
+                render_expr_with_bound_root(&method_call.receiver, root_ident, binding_ident);
+            let method = &method_call.method;
+            let turbofish = &method_call.turbofish;
+            let args: Vec<_> = method_call.args.iter().collect();
+            quote! { (#receiver).#method #turbofish ( #(#args),* ) }
+        }
+        syn::Expr::Reference(reference_expr) => {
+            let inner =
+                render_expr_with_bound_root(&reference_expr.expr, root_ident, binding_ident);
+            let mutability = &reference_expr.mutability;
+            quote! { &#mutability (#inner) }
+        }
+        _ => quote! { #expr },
     }
 }
 

--- a/derive/src/accounts/syntax/mod.rs
+++ b/derive/src/accounts/syntax/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use {
         generate_instruction_arg_extraction, parse_struct_instruction_args, InstructionArg,
     },
     pda::{
-        classify_seed, lower_bump, render_seed_expr, seeds_to_emit_nodes, SeedEmitNode,
-        SeedRenderContext,
+        classify_seed, lower_bump, render_seed_expr, seeds_to_emit_nodes, AccountWrapperKind,
+        SeedEmitNode, SeedRenderContext,
     },
 };

--- a/derive/src/accounts/syntax/pda.rs
+++ b/derive/src/accounts/syntax/pda.rs
@@ -281,6 +281,10 @@ fn render_field_rooted_expr(
             let rewritten = rewrite_init_expr_root(expr, root_ident, wrapper_kind, &base_ty);
             quote! { (#rewritten) as &[u8] }
         }
+        (SeedRenderContext::Method, Some(_)) => {
+            let rewritten = rewrite_method_expr_root(expr, root_ident);
+            quote! { (#rewritten) as &[u8] }
+        }
         _ => render_expr_as_bytes(expr, ctx),
     }
 }
@@ -475,6 +479,41 @@ fn rewrite_init_expr_root(
         syn::Expr::Reference(reference_expr) => {
             let inner =
                 rewrite_init_expr_root(&reference_expr.expr, root_ident, wrapper_kind, base_ty);
+            let mutability = &reference_expr.mutability;
+            quote! { &#mutability (#inner) }
+        }
+        _ => quote! { #expr },
+    }
+}
+
+fn rewrite_method_expr_root(expr: &syn::Expr, root_ident: &syn::Ident) -> proc_macro2::TokenStream {
+    match expr {
+        syn::Expr::Path(ep) if ep.path.segments.len() == 1 && ep.qself.is_none() => {
+            let ident = &ep.path.segments[0].ident;
+            if ident == root_ident {
+                quote! { self.#root_ident }
+            } else {
+                quote! { #expr }
+            }
+        }
+        syn::Expr::Field(field_expr) => {
+            let base = rewrite_method_expr_root(&field_expr.base, root_ident);
+            let member = &field_expr.member;
+            quote! { (#base).#member }
+        }
+        syn::Expr::Paren(paren_expr) => {
+            let inner = rewrite_method_expr_root(&paren_expr.expr, root_ident);
+            quote! { (#inner) }
+        }
+        syn::Expr::MethodCall(method_call) => {
+            let receiver = rewrite_method_expr_root(&method_call.receiver, root_ident);
+            let method = &method_call.method;
+            let turbofish = &method_call.turbofish;
+            let args: Vec<_> = method_call.args.iter().collect();
+            quote! { (#receiver).#method #turbofish ( #(#args),* ) }
+        }
+        syn::Expr::Reference(reference_expr) => {
+            let inner = rewrite_method_expr_root(&reference_expr.expr, root_ident);
             let mutability = &reference_expr.mutability;
             quote! { &#mutability (#inner) }
         }

--- a/derive/src/accounts/syntax/pda.rs
+++ b/derive/src/accounts/syntax/pda.rs
@@ -308,8 +308,16 @@ fn render_literal_seed(bytes: &[u8], cast_slice: bool) -> proc_macro2::TokenStre
 
 fn render_expr_as_bytes(expr: &syn::Expr, ctx: SeedRenderContext) -> proc_macro2::TokenStream {
     match ctx {
-        SeedRenderContext::Method => quote! { (self.#expr) as &[u8] },
-        SeedRenderContext::Parse | SeedRenderContext::Init => quote! { (#expr) as &[u8] },
+        SeedRenderContext::Method => {
+            if matches!(expr, syn::Expr::Path(_)) {
+                quote! { quasar_lang::pda::seed_bytes(&(#expr)) }
+            } else {
+                quote! { quasar_lang::pda::seed_bytes(&(self.#expr)) }
+            }
+        }
+        SeedRenderContext::Parse | SeedRenderContext::Init => {
+            quote! { quasar_lang::pda::seed_bytes(&(#expr)) }
+        }
     }
 }
 

--- a/lang/src/pda.rs
+++ b/lang/src/pda.rs
@@ -351,6 +351,64 @@ pub const fn find_program_address_const(seeds: &[&[u8]], program_id: &Address) -
     (Address::new_from_array(bytes), bump)
 }
 
+/// Seed values that can be borrowed as PDA seed bytes without allocation.
+pub trait SeedBytes {
+    fn as_seed_bytes(&self) -> &[u8];
+}
+
+#[inline(always)]
+pub fn seed_bytes<T: ?Sized + SeedBytes>(value: &T) -> &[u8] {
+    value.as_seed_bytes()
+}
+
+impl<T: ?Sized + SeedBytes> SeedBytes for &T {
+    #[inline(always)]
+    fn as_seed_bytes(&self) -> &[u8] {
+        (*self).as_seed_bytes()
+    }
+}
+
+impl SeedBytes for [u8] {
+    #[inline(always)]
+    fn as_seed_bytes(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<const N: usize> SeedBytes for [u8; N] {
+    #[inline(always)]
+    fn as_seed_bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl SeedBytes for Address {
+    #[inline(always)]
+    fn as_seed_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+macro_rules! impl_scalar_seed_bytes {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl SeedBytes for $ty {
+                #[inline(always)]
+                fn as_seed_bytes(&self) -> &[u8] {
+                    unsafe {
+                        core::slice::from_raw_parts(
+                            self as *const _ as *const u8,
+                            core::mem::size_of::<Self>(),
+                        )
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_scalar_seed_bytes!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, bool);
+
 #[cfg(kani)]
 mod kani_proofs {
     /// `MAX_PDA_SLICES` from the parent module (cfg'd to Solana, so we

--- a/tests/programs/test-pda/src/instructions/init_const_seed.rs
+++ b/tests/programs/test-pda/src/instructions/init_const_seed.rs
@@ -1,0 +1,26 @@
+use {
+    crate::state::{IntakeQueue, IntakeQueueInner, SIDE_A},
+    quasar_lang::prelude::*,
+};
+
+#[derive(Accounts)]
+pub struct InitConstSeed {
+    #[account(mut)]
+    pub payer: Signer,
+    pub authority: Signer,
+    #[account(mut, init, payer = payer, seeds = IntakeQueue::seeds(authority, SIDE_A), bump)]
+    pub intake: Account<IntakeQueue>,
+    pub system_program: Program<System>,
+}
+
+impl InitConstSeed {
+    #[inline(always)]
+    pub fn handler(&mut self, bumps: &InitConstSeedBumps) -> Result<(), ProgramError> {
+        self.intake.set_inner(IntakeQueueInner {
+            authority: *self.authority.address(),
+            side: SIDE_A,
+            bump: bumps.intake,
+        });
+        Ok(())
+    }
+}

--- a/tests/programs/test-pda/src/instructions/mod.rs
+++ b/tests/programs/test-pda/src/instructions/mod.rs
@@ -43,5 +43,8 @@ pub use init_scoped_item::*;
 pub mod init_scoped_item_from_config;
 pub use init_scoped_item_from_config::*;
 
+pub mod init_const_seed;
+pub use init_const_seed::*;
+
 pub mod verify_scoped_item;
 pub use verify_scoped_item::*;

--- a/tests/programs/test-pda/src/lib.rs
+++ b/tests/programs/test-pda/src/lib.rs
@@ -96,4 +96,9 @@ mod quasar_test_pda {
     ) -> Result<(), ProgramError> {
         ctx.accounts.handler(&ctx.bumps)
     }
+
+    #[instruction(discriminator = 16)]
+    pub fn init_const_seed(ctx: Ctx<InitConstSeed>) -> Result<(), ProgramError> {
+        ctx.accounts.handler(&ctx.bumps)
+    }
 }

--- a/tests/programs/test-pda/src/state.rs
+++ b/tests/programs/test-pda/src/state.rs
@@ -1,5 +1,8 @@
 use quasar_lang::prelude::*;
 
+pub const SIDE_A: u8 = 0;
+pub const SIDE_B: u8 = 1;
+
 #[account(discriminator = 1, set_inner)]
 #[seeds(b"config")]
 pub struct ConfigAccount {
@@ -69,5 +72,13 @@ pub struct NamespaceConfig {
 pub struct ScopedItem {
     pub namespace: u32,
     pub data: u64,
+    pub bump: u8,
+}
+
+#[account(discriminator = 11, set_inner)]
+#[seeds(b"intake", authority: Address, side: u8)]
+pub struct IntakeQueue {
+    pub authority: Address,
+    pub side: u8,
     pub bump: u8,
 }


### PR DESCRIPTION
## Summary

This PR supersedes #131 and carries forward 0xIchigo's typed-seed fix onto the post-#155 derive architecture.

The original intent is preserved:

- typed PDA seeds should accept constant scalar values cleanly

The implementation was forward-ported to the new derive layout instead of mechanically replaying the old branch, because `#155` substantially changed the accounts pipeline.

## What Changed

### 1. Scalar constants now work in typed seeds

The rebased branch adds a `SeedBytes`-based conversion path in `quasar-lang::pda` and routes typed-seed rendering through that interface.

This preserves the intended fix from #131:

- bare scalar constants like `const SIDE_A: u8 = ...` can be used in typed seeds

### 2. The over-broad fallback is not carried forward

The original branch also had a catch-all fallback that treated unknown bare identifiers as raw in-memory bytes.

That was too broad and could mis-handle slice-like or pointer-shaped values.

The rebased version keeps the useful part of the fix while narrowing the behavior to a typed conversion boundary.

### 3. PDA coverage was updated on the new base

The branch includes focused PDA test coverage for the constant-seed case on top of current `master`.

## Attribution

Supersedes #131.

Original contribution by @0xIchigo, forward-ported onto the post-#155 derive layout.

The rebased commit preserves original authorship and explicitly notes the adaptation work.

## Validation

Commands run:

- `cargo test -p quasar-derive --lib`
- `cargo test -p quasar-test-pda --no-run`
