### PR TITLE
fix(idl): support anchor-compatible pubkey and option types

### DIFF
--- a/derive/src/declare_program.rs
+++ b/derive/src/declare_program.rs
@@ -80,6 +80,7 @@ fn field_byte_size(
 ) -> Result<usize, String> {
     match ty {
         IdlType::Primitive(p) => primitive_size(p),
+        IdlType::Option { option } => Ok(1 + field_byte_size(option, type_map, sizes, resolving)?),
         IdlType::Defined { defined } => resolve_size(defined, type_map, sizes, resolving),
         IdlType::DynString { .. } => {
             Err("dynamic string not supported in CPI — only fixed-size types allowed".into())
@@ -97,7 +98,7 @@ fn primitive_size(name: &str) -> Result<usize, String> {
         "u32" | "i32" => Ok(4),
         "u64" | "i64" => Ok(8),
         "u128" | "i128" => Ok(16),
-        "publicKey" => Ok(32),
+        "pubkey" => Ok(32),
         other => Err(format!("unsupported primitive type '{other}'")),
     }
 }
@@ -128,7 +129,7 @@ fn map_idl_type(ty: &IdlType, type_sizes: &HashMap<String, usize>) -> Result<Typ
                 "i64" => quote! { i64 },
                 "u128" => quote! { u128 },
                 "i128" => quote! { i128 },
-                "publicKey" => {
+                "pubkey" => {
                     return Ok(TypeInfo {
                         param_type: quote! { &quasar_lang::prelude::Address },
                         field_type: quote! { quasar_lang::prelude::Address },
@@ -150,6 +151,9 @@ fn map_idl_type(ty: &IdlType, type_sizes: &HashMap<String, usize>) -> Result<Typ
                 param_type: quote! { #ident },
                 field_type: quote! { #ident },
             })
+        }
+        IdlType::Option { .. } => {
+            Err("option not supported in CPI — only fixed-size types allowed".into())
         }
         IdlType::DynString { .. } => {
             Err("dynamic string not supported in CPI — only fixed-size types allowed".into())
@@ -217,7 +221,7 @@ fn emit_field_write(
     match ty {
         IdlType::Primitive(p) => {
             let size = primitive_size(p)?;
-            if p == "publicKey" {
+            if p == "pubkey" {
                 stmts.push(quote! {
                     core::ptr::copy_nonoverlapping(
                         #access.as_ref().as_ptr(),
@@ -252,7 +256,7 @@ fn emit_field_write(
                 emit_field_write(stmts, offset, &sub_access, &sub_field.ty, idl_types)?;
             }
         }
-        IdlType::DynString { .. } | IdlType::DynVec { .. } => {
+        IdlType::Option { .. } | IdlType::DynString { .. } | IdlType::DynVec { .. } => {
             return Err("dynamic types not supported in CPI".into());
         }
     }
@@ -331,6 +335,7 @@ fn collect_type_refs(ty: &IdlType, idl_types: &[IdlTypeDef], out: &mut HashSet<S
             }
         }
         IdlType::Defined { .. } => {}
+        IdlType::Option { option } => collect_type_refs(option, idl_types, out),
         IdlType::DynVec { vec } => collect_type_refs(&vec.items, idl_types, out),
         IdlType::Primitive(_) | IdlType::DynString { .. } => {}
     }

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -20,15 +20,14 @@ pub fn generate_go_client(idl: &Idl) -> String {
     let has_args = idl.instructions.iter().any(|ix| !ix.args.is_empty());
     let has_types_with_fields = idl.types.iter().any(|t| !t.ty.fields.is_empty());
     let needs_binary = has_args || has_events || has_types_with_fields;
-    let has_floats = idl.instructions.iter().any(|ix| {
-        ix.args
+    let has_floats = idl
+        .instructions
+        .iter()
+        .any(|ix| ix.args.iter().any(|a| type_has_float(&a.ty)))
+        || idl
+            .types
             .iter()
-            .any(|a| matches!(&a.ty, IdlType::Primitive(p) if p == "f32" || p == "f64"))
-    }) || idl.types.iter().any(|t| {
-        t.ty.fields
-            .iter()
-            .any(|f| matches!(&f.ty, IdlType::Primitive(p) if p == "f32" || p == "f64"))
-    });
+            .any(|t| t.ty.fields.iter().any(|f| type_has_float(&f.ty)));
 
     out.push_str("import (\n");
     if needs_binary {
@@ -320,7 +319,7 @@ fn go_type(ty: &IdlType) -> String {
             "i128" => "[16]byte".to_string(),
             "f32" => "float32".to_string(),
             "f64" => "float64".to_string(),
-            "publicKey" => "solana.PublicKey".to_string(),
+            "pubkey" => "solana.PublicKey".to_string(),
             "string" => "string".to_string(),
             other if other.starts_with('[') => {
                 let size = super::parse_fixed_array_size(other).unwrap_or(1);
@@ -328,6 +327,7 @@ fn go_type(ty: &IdlType) -> String {
             }
             _ => "[]byte".to_string(),
         },
+        IdlType::Option { option } => format!("*{}", go_type(option)),
         IdlType::DynString { .. } => "string".to_string(),
         IdlType::DynVec { .. } => "[]byte".to_string(),
         IdlType::Defined { defined } => defined.clone(),
@@ -404,7 +404,7 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
                  math.Float64bits(input.{n})); data = append(data, buf[:]...) }}\n",
                 n = name,
             ),
-            "publicKey" => format!("\tdata = append(data, input.{}[:]...)\n", name,),
+            "pubkey" => format!("\tdata = append(data, input.{}[:]...)\n", name,),
             "string" => format!(
                 "\t{{ b := []byte(input.{n}); var buf [4]byte; \
                  binary.LittleEndian.PutUint32(buf[:], uint32(len(b))); data = append(data, \
@@ -441,6 +441,15 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
                 n = name,
             ),
         },
+        IdlType::Option { option } => {
+            let inner = serialize_field_expr(&format!("(*input.{})", name), option, types);
+            format!(
+                "\tif input.{n} == nil {{\n\t\tdata = append(data, 0)\n\t}} else {{\n\t\tdata = \
+                 append(data, 1)\n{inner}\t}}\n",
+                n = name,
+                inner = inner,
+            )
+        }
         IdlType::Defined { defined } => {
             if let Some(td) = types.iter().find(|t| t.name == *defined) {
                 let mut result = String::new();
@@ -549,7 +558,7 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
             ),
             "f32" => go_float_decode(&t, name, "Float32frombits", "Uint32", 4),
             "f64" => go_float_decode(&t, name, "Float64frombits", "Uint64", 8),
-            "publicKey" => format!(
+            "pubkey" => format!(
                 "{t}var {n} solana.PublicKey\n{t}copy({n}[:], data[offset:offset+32])\n{t}offset \
                  += 32\n",
                 t = t,
@@ -597,6 +606,17 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 n = name,
             ),
         },
+        IdlType::Option { option } => {
+            let inner = decode_field_expr(&format!("{}_val", name), option, depth, types);
+            format!(
+                "{t}var {n} *{ty}\n{t}if data[offset] != 0 {{\n{t}\toffset += 1\n{inner}{t}\t{n} \
+                 = &{n}_val\n{t}}} else {{\n{t}\toffset += 1\n{t}}}\n",
+                t = t,
+                n = name,
+                ty = go_type(option),
+                inner = inner,
+            )
+        }
         IdlType::Defined { defined } => {
             if let Some(td) = types.iter().find(|t| t.name == *defined) {
                 let mut result = String::new();
@@ -659,5 +679,14 @@ fn decode_field_expr(name: &str, ty: &IdlType, depth: usize, types: &[IdlTypeDef
                 n = name,
             ),
         },
+    }
+}
+
+fn type_has_float(ty: &IdlType) -> bool {
+    match ty {
+        IdlType::Primitive(p) => p == "f32" || p == "f64",
+        IdlType::Option { option } => type_has_float(option),
+        IdlType::DynVec { vec } => type_has_float(&vec.items),
+        _ => false,
     }
 }

--- a/idl/src/codegen/python.rs
+++ b/idl/src/codegen/python.rs
@@ -26,17 +26,24 @@ pub fn generate_python_client(idl: &Idl) -> String {
 
     let has_events = !idl.events.is_empty();
     let has_args = idl.instructions.iter().any(|ix| !ix.args.is_empty());
-    let has_dynamic = idl.instructions.iter().any(|ix| {
-        ix.args
+    let has_optional = idl
+        .instructions
+        .iter()
+        .any(|ix| ix.args.iter().any(|a| type_has_option(&a.ty)))
+        || idl
+            .types
             .iter()
-            .any(|a| matches!(a.ty, IdlType::DynString { .. } | IdlType::DynVec { .. }))
-    }) || idl.types.iter().any(|t| {
-        t.ty.fields
+            .any(|t| t.ty.fields.iter().any(|f| type_has_option(&f.ty)));
+    let has_dynamic = idl
+        .instructions
+        .iter()
+        .any(|ix| ix.args.iter().any(|a| type_has_dynamic(&a.ty)))
+        || idl
+            .types
             .iter()
-            .any(|f| matches!(f.ty, IdlType::DynString { .. } | IdlType::DynVec { .. }))
-    });
+            .any(|t| t.ty.fields.iter().any(|f| type_has_dynamic(&f.ty)));
 
-    if has_events || has_args || has_dynamic {
+    if has_events || has_args || has_dynamic || has_optional {
         out.push_str("from typing import Optional\n");
     }
 
@@ -348,11 +355,12 @@ fn python_type(ty: &IdlType) -> String {
                 "int".to_string()
             }
             "f32" | "f64" => "float".to_string(),
-            "publicKey" => "Pubkey".to_string(),
+            "pubkey" => "Pubkey".to_string(),
             "string" => "str".to_string(),
             _ if p.starts_with('[') => "bytes".to_string(),
             _ => "bytes".to_string(),
         },
+        IdlType::Option { option } => format!("Optional[{}]", python_type(option)),
         IdlType::DynString { .. } => "str".to_string(),
         IdlType::DynVec { .. } => "list".to_string(),
         IdlType::Defined { defined } => defined.clone(),
@@ -385,12 +393,21 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
             ),
             "f32" => format!("    data += struct.pack(\"<f\", input.{})\n", name),
             "f64" => format!("    data += struct.pack(\"<d\", input.{})\n", name),
-            "publicKey" => format!("    data += bytes(input.{})\n", name),
+            "pubkey" => format!("    data += bytes(input.{})\n", name),
             _ if p.starts_with('[') => {
                 format!("    data += input.{}\n", name)
             }
             _ => format!("    data += input.{}  # unsupported\n", name),
         },
+        IdlType::Option { option } => {
+            let inner = serialize_field_expr(&format!("{}_val", name), option, types);
+            format!(
+                "    if input.{n} is None:\n        data += b'\\x00'\n    else:\n        data += \
+                 b'\\x01'\n        {n}_val = input.{n}\n{inner}",
+                n = name,
+                inner = inner.replace("    data", "        data"),
+            )
+        }
         IdlType::DynString { string } => {
             let (fmt, _sz) = prefix_fmt(string.prefix_bytes);
             format!(
@@ -403,7 +420,7 @@ fn serialize_field_expr(name: &str, ty: &IdlType, types: &[IdlTypeDef]) -> Strin
         IdlType::DynVec { vec } => {
             let (fmt, _sz) = prefix_fmt(vec.prefix_bytes);
             let item_ser = match &*vec.items {
-                IdlType::Primitive(p) if p == "publicKey" => "bytes(item)".to_string(),
+                IdlType::Primitive(p) if p == "pubkey" => "bytes(item)".to_string(),
                 IdlType::Primitive(p) => {
                     let f = struct_format(p);
                     format!("struct.pack(\"<{}\", item)", f)
@@ -455,7 +472,7 @@ fn decode_field_expr(name: &str, ty: &IdlType, indent: usize, types: &[IdlTypeDe
                 pad = pad,
                 n = name,
             ),
-            "publicKey" => format!(
+            "pubkey" => format!(
                 "{pad}{n} = Pubkey.from_bytes(data[offset:offset + 32])\n{pad}offset += 32\n",
                 pad = pad,
                 n = name,
@@ -509,7 +526,7 @@ fn decode_field_expr(name: &str, ty: &IdlType, indent: usize, types: &[IdlTypeDe
         IdlType::DynVec { vec } => {
             let (fmt, sz) = prefix_fmt(vec.prefix_bytes);
             let item_decode = match &*vec.items {
-                IdlType::Primitive(p) if p == "publicKey" => {
+                IdlType::Primitive(p) if p == "pubkey" => {
                     "Pubkey.from_bytes(data[offset:offset + 32]); offset += 32".to_string()
                 }
                 IdlType::Primitive(p) => {
@@ -531,6 +548,16 @@ fn decode_field_expr(name: &str, ty: &IdlType, indent: usize, types: &[IdlTypeDe
                 fmt = fmt,
                 sz = sz,
                 decode = item_decode,
+            )
+        }
+        IdlType::Option { option } => {
+            let inner = decode_field_expr(&format!("{}_inner", name), option, indent + 4, types);
+            format!(
+                "{pad}if data[offset] == 0:\n{pad}    {n} = None\n{pad}    offset += \
+                 1\n{pad}else:\n{pad}    offset += 1\n{inner}{pad}    {n} = {n}_inner\n",
+                pad = pad,
+                n = name,
+                inner = inner,
             )
         }
         IdlType::Defined { defined } => {
@@ -605,8 +632,24 @@ fn primitive_size(p: &str) -> usize {
         "u32" | "i32" | "f32" => 4,
         "u64" | "i64" | "f64" => 8,
         "u128" | "i128" => 16,
-        "publicKey" => 32,
+        "pubkey" => 32,
         _ => 0,
+    }
+}
+
+fn type_has_dynamic(ty: &IdlType) -> bool {
+    match ty {
+        IdlType::Option { option } => type_has_dynamic(option),
+        IdlType::DynString { .. } | IdlType::DynVec { .. } => true,
+        _ => false,
+    }
+}
+
+fn type_has_option(ty: &IdlType) -> bool {
+    match ty {
+        IdlType::Option { .. } => true,
+        IdlType::DynVec { vec } => type_has_option(&vec.items),
+        _ => false,
     }
 }
 

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -1059,9 +1059,10 @@ fn account_meta_expr(account: &IdlAccountItem) -> String {
 fn rust_field_type(ty: &IdlType) -> String {
     match ty {
         IdlType::Primitive(p) => match p.as_str() {
-            "publicKey" => "Address".to_string(),
+            "pubkey" => "Address".to_string(),
             other => other.to_string(),
         },
+        IdlType::Option { option } => format!("Option<{}>", rust_field_type(option)),
         IdlType::DynString { string } => prefix_generic("DynBytes", string.prefix_bytes),
         IdlType::DynVec { vec } => {
             let inner = rust_field_type(&vec.items);
@@ -1086,6 +1087,7 @@ fn prefix_rust_type(prefix_bytes: usize) -> &'static str {
 
 fn collect_wrapper_needs(ty: &IdlType, needs_dyn_bytes: &mut bool, needs_dyn_vec: &mut bool) {
     match ty {
+        IdlType::Option { option } => collect_wrapper_needs(option, needs_dyn_bytes, needs_dyn_vec),
         IdlType::DynString { .. } => *needs_dyn_bytes = true,
         IdlType::DynVec { vec } => {
             *needs_dyn_vec = true;
@@ -1097,7 +1099,8 @@ fn collect_wrapper_needs(ty: &IdlType, needs_dyn_bytes: &mut bool, needs_dyn_vec
 
 fn field_needs_address(ty: &IdlType) -> bool {
     match ty {
-        IdlType::Primitive(p) => p == "publicKey",
+        IdlType::Primitive(p) => p == "pubkey",
+        IdlType::Option { option } => field_needs_address(option),
         IdlType::DynVec { vec } => field_needs_address(&vec.items),
         _ => false,
     }
@@ -1129,6 +1132,7 @@ fn emit_type_use_imports(
                 out.push_str(&import);
             }
         }
+        IdlType::Option { option } => emit_type_use_imports(out, option, type_map),
         IdlType::DynVec { vec } => emit_type_use_imports(out, &vec.items, type_map),
         _ => {}
     }

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -29,7 +29,7 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     let has_dyn_string = used.contains("dynString");
     let has_dyn_vec = used.contains("dynVec");
     let has_instructions = !idl.instructions.is_empty();
-    let has_public_key = used.contains("publicKey");
+    let has_public_key = used.contains("pubkey");
 
     // Check if any instruction uses PDAs or PDA account seeds
     let has_pdas = idl
@@ -102,7 +102,6 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     if used.contains("bool") {
         codec_imports.push("getBooleanCodec");
     }
-
     // PublicKey codec imports: web3.js uses custom helper, kit uses getAddressCodec
     // from @solana/kit
     if target == TsTarget::Web3js && has_public_key {
@@ -816,10 +815,11 @@ fn ts_type(ty: &IdlType) -> String {
             "u8" | "u16" | "u32" | "i8" | "i16" | "i32" => "number".to_string(),
             "u64" | "u128" | "i64" | "i128" => "bigint".to_string(),
             "bool" => "boolean".to_string(),
-            "publicKey" => "Address".to_string(),
+            "pubkey" => "Address".to_string(),
             other if other.starts_with('[') => "Uint8Array".to_string(),
             other => other.to_string(),
         },
+        IdlType::Option { option } => format!("{} | null", ts_type(option)),
         IdlType::Defined { defined } => defined.clone(),
         IdlType::DynString { .. } => "string".to_string(),
         IdlType::DynVec { vec } => format!("Array<{}>", ts_type(&vec.items)),
@@ -840,7 +840,7 @@ fn ts_codec(ty: &IdlType, target: TsTarget) -> String {
             "i64" => "getI64Codec()".to_string(),
             "i128" => "getI128Codec()".to_string(),
             "bool" => "getBooleanCodec()".to_string(),
-            "publicKey" => match target {
+            "pubkey" => match target {
                 TsTarget::Web3js => "getPublicKeyCodec()".to_string(),
                 TsTarget::Kit => "getAddressCodec()".to_string(),
             },
@@ -850,6 +850,7 @@ fn ts_codec(ty: &IdlType, target: TsTarget) -> String {
             }
             other => format!("/* unknown: {} */", other),
         },
+        IdlType::Option { option } => format!("getOptionCodec({})", ts_codec(option, target)),
         IdlType::Defined { defined } => format!("{}Codec", defined),
         IdlType::DynString { string } => {
             format!(
@@ -894,6 +895,7 @@ fn collect_used_codecs(idl: &Idl) -> HashSet<String> {
         IdlType::Primitive(p) => {
             used.insert(p.clone());
         }
+        IdlType::Option { .. } => {}
         IdlType::Defined { .. } => {}
         IdlType::DynString { string } => {
             used.insert("dynString".to_string());

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -102,6 +102,9 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     if used.contains("bool") {
         codec_imports.push("getBooleanCodec");
     }
+    if used.contains("option") {
+        codec_imports.push("getOptionCodec");
+    }
     // PublicKey codec imports: web3.js uses custom helper, kit uses getAddressCodec
     // from @solana/kit
     if target == TsTarget::Web3js && has_public_key {
@@ -895,7 +898,9 @@ fn collect_used_codecs(idl: &Idl) -> HashSet<String> {
         IdlType::Primitive(p) => {
             used.insert(p.clone());
         }
-        IdlType::Option { .. } => {}
+        IdlType::Option { .. } => {
+            used.insert("option".to_string());
+        }
         IdlType::Defined { .. } => {}
         IdlType::DynString { string } => {
             used.insert("dynString".to_string());
@@ -923,8 +928,10 @@ fn collect_used_codecs(idl: &Idl) -> HashSet<String> {
 
 fn visit_type(ty: &IdlType, visit: &mut impl FnMut(&IdlType)) {
     visit(ty);
-    if let IdlType::DynVec { vec } = ty {
-        visit_type(&vec.items, visit);
+    match ty {
+        IdlType::Option { option } => visit_type(option, visit),
+        IdlType::DynVec { vec } => visit_type(&vec.items, visit),
+        _ => {}
     }
 }
 

--- a/idl/src/parser/helpers.rs
+++ b/idl/src/parser/helpers.rs
@@ -7,7 +7,7 @@ pub use quasar_schema::to_camel_case;
 /// Map a Rust type name string to an IDL type.
 pub fn map_type(rust_type: &str) -> IdlType {
     match rust_type {
-        "Address" | "Pubkey" => IdlType::Primitive("publicKey".to_string()),
+        "Address" | "Pubkey" => IdlType::Primitive("pubkey".to_string()),
         "u8" | "u16" | "u32" | "u64" | "u128" | "i8" | "i16" | "i32" | "i64" | "i128" => {
             IdlType::Primitive(rust_type.to_string())
         }
@@ -56,7 +56,13 @@ pub fn map_type_from_syn(ty: &syn::Type) -> IdlType {
                 let ident = seg.ident.to_string();
                 let mut iter = args.args.iter();
 
-                if ident == "String" || ident == "PodString" {
+                if ident == "Option" {
+                    if let Some(syn::GenericArgument::Type(inner_ty)) = iter.next() {
+                        return IdlType::Option {
+                            option: Box::new(map_type_from_syn(inner_ty)),
+                        };
+                    }
+                } else if ident == "String" || ident == "PodString" {
                     // String<N[, PFX]> / String<'a, N[, PFX]>
                     // Skip an optional leading lifetime parameter.
                     let first = iter.next();

--- a/idl/src/parser/mod.rs
+++ b/idl/src/parser/mod.rs
@@ -417,6 +417,7 @@ fn collect_defined_refs(ty: &IdlType, out: &mut BTreeSet<String>) {
         IdlType::Defined { defined } => {
             out.insert(defined.clone());
         }
+        IdlType::Option { option } => collect_defined_refs(option, out),
         IdlType::DynVec { vec } => collect_defined_refs(&vec.items, out),
         _ => {}
     }

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -263,7 +263,7 @@ fn parse_discriminator_empty_array() {
 fn map_type_primitives() {
     assert!(matches!(
         helpers::map_type("Address"),
-        IdlType::Primitive(s) if s == "publicKey"
+        IdlType::Primitive(s) if s == "pubkey"
     ));
     assert!(matches!(
         helpers::map_type("u64"),
@@ -313,6 +313,16 @@ fn map_type_from_syn_vec_with_lifetime() {
         ),
         "Vec<'a, T, N> must be DynVec with u16 prefix"
     );
+}
+
+#[test]
+fn map_type_from_syn_option() {
+    let ty: syn::Type = syn::parse_str("Option<Address>").expect("parse type");
+    assert!(matches!(
+        helpers::map_type_from_syn(&ty),
+        IdlType::Option { option }
+            if matches!(*option, IdlType::Primitive(ref s) if s == "pubkey")
+    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -217,6 +217,7 @@ pub struct IdlDynVec {
 #[serde(untagged)]
 pub enum IdlType {
     Primitive(String),
+    Option { option: Box<IdlType> },
     Defined { defined: String },
     DynString { string: IdlDynString },
     DynVec { vec: IdlDynVec },


### PR DESCRIPTION
## Summary

This PR supersedes #132 and rebases Jimii's Anchor-compatibility IDL work onto the post-#155 IDL/schema architecture.

The main semantic goal is unchanged:

- use Anchor-compatible `pubkey` naming in the IDL
- support Anchor-style `option` types in the IDL schema and generators

Because `#155` moved Quasar's shared IDL contract into `quasar-schema`, this was forward-ported rather than mechanically replayed.

## What Changed

### 1. `pubkey` replaces `publicKey` in the IDL surface

Address/Pubkey types now lower to `pubkey` in the shared IDL model and codegen paths.

This brings Quasar's IDL closer to the Anchor ecosystem and improves downstream compatibility.

### 2. Anchor-style option types are supported

The shared `IdlType` model now includes:

- `Option { option: Box<IdlType> }`

Parsing, schema traversal, CPI declaration support checks, and the language generators were updated accordingly.

### 3. TypeScript option-codec recursion was fixed

While rebasing, one missing case showed up in the original branch:

- TypeScript codec/import collection did not fully recurse through nested `Option` types

This replacement branch keeps Jimii's port as the main contributor-authored change and adds a separate follow-up fix for the TS codec recursion/import issue.

## Attribution

Supersedes #132.

Original contribution by @jim4067, forward-ported onto the post-#155 IDL/schema layout.

This replacement branch preserves that as the first contributor-authored commit, followed by one small TypeScript-specific fixup commit.

## Validation

Commands run:

- `cargo test -p quasar-idl`
- `cargo test -p quasar-cli`
