### PR TITLE
fix(idl): enable wincode support in generated rust clients

### DIFF
--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -200,7 +200,7 @@ fn emit_one_check_block(
 
     if !sem.has_init() {
         if let Some(pda) = &sem.pda {
-            stmts.push(emit_pda_check(field_ident, pda, all_semantics));
+            stmts.push(emit_pda_check(sem, field_ident, pda, all_semantics));
         }
         if let Some(token_check) = super::init::emit_non_init_check(sem) {
             stmts.push(token_check);
@@ -221,6 +221,7 @@ fn emit_one_check_block(
 }
 
 fn emit_pda_check(
+    sem: &FieldSemantics,
     field: &syn::Ident,
     pda: &PdaConstraint,
     all_semantics: &[FieldSemantics],
@@ -240,7 +241,11 @@ fn emit_pda_check(
             addr_expr: &addr_access,
             seed_array_name: &seed_array_name,
             explicit_bump_name: &explicit_bump_name,
-            bare_mode: PdaBareMode::KnownAddress,
+            bare_mode: if sem.core.shape.supports_existing_pda_fast_path() {
+                PdaBareMode::KnownAddress
+            } else {
+                PdaBareMode::DeriveExpected
+            },
             log_failure: true,
         },
     );
@@ -428,20 +433,35 @@ pub(super) fn emit_pda_bump_assignment(
     } = assignment;
 
     match &pda.bump {
-        Some(BumpSyntax::Explicit(expr)) => {
-            let failure = emit_failure_log(field, log_failure);
-            quote! {
-                let #explicit_bump_name: u8 = #expr;
-                let __bump_ref: &[u8] = &[#explicit_bump_name];
-                let #seed_array_name = [#(#seed_idents,)* __bump_ref];
-                quasar_lang::pda::verify_program_address(&#seed_array_name, __program_id, #addr_expr)
-                    .map_err(|__e| {
-                        #failure
-                        __e
-                    })?;
-                #bump_var = #explicit_bump_name;
+        Some(BumpSyntax::Explicit(expr)) => match bare_mode {
+            PdaBareMode::KnownAddress => {
+                let failure = emit_failure_log(field, log_failure);
+                quote! {
+                    let #explicit_bump_name: u8 = #expr;
+                    let __bump_ref: &[u8] = &[#explicit_bump_name];
+                    let #seed_array_name = [#(#seed_idents,)* __bump_ref];
+                    quasar_lang::pda::verify_program_address(&#seed_array_name, __program_id, #addr_expr)
+                        .map_err(|__e| {
+                            #failure
+                            __e
+                        })?;
+                    #bump_var = #explicit_bump_name;
+                }
             }
-        }
+            PdaBareMode::DeriveExpected => {
+                let invalid_pda_error = emit_invalid_pda_error_expr(field, log_failure);
+                quote! {
+                    let #explicit_bump_name: u8 = #expr;
+                    let #seed_array_name = [#(#seed_idents),*];
+                    let (__expected, __derived_bump) =
+                        quasar_lang::pda::based_try_find_program_address(&#seed_array_name, __program_id)?;
+                    if !quasar_lang::keys_eq(#addr_expr, &__expected) || __derived_bump != #explicit_bump_name {
+                        return Err({ #invalid_pda_error });
+                    }
+                    #bump_var = #explicit_bump_name;
+                }
+            }
+        },
         Some(BumpSyntax::Bare) | None => {
             let invalid_pda_error = emit_invalid_pda_error_expr(field, log_failure);
             match bare_mode {
@@ -458,7 +478,7 @@ pub(super) fn emit_pda_bump_assignment(
                     let (__expected, __derived_bump) =
                         quasar_lang::pda::based_try_find_program_address(&#seed_array_name, __program_id)?;
                     if !quasar_lang::keys_eq(#addr_expr, &__expected) {
-                        return Err(#invalid_pda_error);
+                        return Err({ #invalid_pda_error });
                     }
                     #bump_var = __derived_bump;
                 },

--- a/derive/src/accounts/resolve/model.rs
+++ b/derive/src/accounts/resolve/model.rs
@@ -44,6 +44,16 @@ impl FieldShape {
     pub fn is_token_or_mint(&self) -> bool {
         self.inner_name_matches(&["Token", "Token2022", "Mint", "Mint2022"])
     }
+
+    /// Whether an existing account of this shape can use the PDA bump fast
+    /// path once wrapper validation has already run.
+    pub fn supports_existing_pda_fast_path(&self) -> bool {
+        match self {
+            Self::Account { .. } => true,
+            Self::InterfaceAccount { .. } => self.is_token_or_mint(),
+            _ => false,
+        }
+    }
 }
 
 pub(crate) struct FieldCore {

--- a/examples/escrow/client/Cargo.toml
+++ b/examples/escrow/client/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-wincode = { version = "0.4", features = ["derive"] }
-solana-address = { version = "2.2", features = ["curve25519"] }
+wincode = { version = "=0.4.9", features = ["derive"] }
+solana-address = { version = "=2.2.0", features = ["curve25519", "wincode"] }
 solana-instruction = "3"

--- a/examples/multisig/client/Cargo.toml
+++ b/examples/multisig/client/Cargo.toml
@@ -8,6 +8,6 @@ workspace = true
 
 [dependencies]
 quasar-lang = { path = "../../../lang" }
-wincode = { version = "0.4", features = ["derive"] }
-solana-address = { version = "2.2", features = ["curve25519"] }
+wincode = { version = "=0.4.9", features = ["derive"] }
+solana-address = { version = "=2.2.0", features = ["curve25519", "wincode"] }
 solana-instruction = "3"

--- a/examples/upstream-vault/client/Cargo.toml
+++ b/examples/upstream-vault/client/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-wincode = { version = "0.4", features = ["derive"] }
-solana-address = "2.2"
+wincode = { version = "=0.4.9", features = ["derive"] }
+solana-address = { version = "=2.2.0", features = ["wincode"] }
 solana-instruction = "3"

--- a/examples/vault/client/Cargo.toml
+++ b/examples/vault/client/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-wincode = { version = "0.4", features = ["derive"] }
-solana-address = { version = "2.2", features = ["curve25519"] }
+wincode = { version = "=0.4.9", features = ["derive"] }
+solana-address = { version = "=2.2.0", features = ["curve25519", "wincode"] }
 solana-instruction = "3"

--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -20,9 +20,9 @@ use {
 /// target wincode 0.4).
 pub fn generate_cargo_toml(name: &str, version: &str, has_pdas: bool) -> String {
     let solana_address = if has_pdas {
-        r#"solana-address = { version = "=2.2.0", features = ["curve25519"] }"#
+        r#"solana-address = { version = "=2.2.0", features = ["curve25519", "wincode"] }"#
     } else {
-        r#"solana-address = "=2.2.0""#
+        r#"solana-address = { version = "=2.2.0", features = ["wincode"] }"#
     };
     format!(
         r#"[package]

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -1849,7 +1849,7 @@ fn rust_codegen_pda_dedup() {
 fn rust_codegen_cargo_toml_with_pdas() {
     let toml = generate_cargo_toml("my-program", "0.1.0", true);
     assert!(
-        toml.contains(r#"features = ["curve25519"]"#),
+        toml.contains(r#"features = ["curve25519", "wincode"]"#),
         "PDA programs need curve25519 feature: {toml}"
     );
 }
@@ -1860,6 +1860,10 @@ fn rust_codegen_cargo_toml_without_pdas() {
     assert!(
         !toml.contains("curve25519"),
         "non-PDA programs must not pull in curve25519: {toml}"
+    );
+    assert!(
+        toml.contains(r#"features = ["wincode"]"#),
+        "generated clients must enable wincode support for Address: {toml}"
     );
 }
 

--- a/lang/tests/compile_fail/pod_string_invalid_pfx.stderr
+++ b/lang/tests/compile_fail/pod_string_invalid_pfx.stderr
@@ -1,11 +1,15 @@
 error[E0080]: evaluation panicked: PodString<N, PFX>: PFX must be 1, 2, 4, or 8
- --> $WORKSPACE/pod/src/string.rs
+ --> $RUST/core/src/panic.rs
+  |
+  = note: evaluation of `quasar_lang::pod::PodString::<10, 3>::_CAP_CHECK` failed here
+  |
+ ::: $WORKSPACE/pod/src/string.rs
   |
   | /         assert!(
   | |             PFX == 1 || PFX == 2 || PFX == 4 || PFX == 8,
   | |             "PodString<N, PFX>: PFX must be 1, 2, 4, or 8"
   | |         );
-  | |_________^ evaluation of `quasar_lang::pod::PodString::<10, 3>::_CAP_CHECK` failed here
+  | |_________- in this macro invocation
 
 note: erroneous constant encountered
  --> $WORKSPACE/pod/src/string.rs

--- a/lang/tests/compile_fail/pod_string_n_exceeds_pfx.stderr
+++ b/lang/tests/compile_fail/pod_string_n_exceeds_pfx.stderr
@@ -1,12 +1,16 @@
 error[E0080]: evaluation panicked: PodString<N, PFX>: N exceeds the maximum value representable by the PFX-byte length prefix
- --> $WORKSPACE/pod/src/string.rs
+ --> $RUST/core/src/panic.rs
+  |
+  = note: evaluation of `quasar_lang::pod::PodString::<256>::_CAP_CHECK` failed here
+  |
+ ::: $WORKSPACE/pod/src/string.rs
   |
   | /         assert!(
   | |             N <= max_n_for_pfx(PFX),
   | |             "PodString<N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
   | |              prefix"
   | |         );
-  | |_________^ evaluation of `quasar_lang::pod::PodString::<256>::_CAP_CHECK` failed here
+  | |_________- in this macro invocation
 
 note: erroneous constant encountered
  --> $WORKSPACE/pod/src/string.rs

--- a/lang/tests/compile_fail/pod_vec_n_exceeds_pfx.stderr
+++ b/lang/tests/compile_fail/pod_vec_n_exceeds_pfx.stderr
@@ -1,12 +1,16 @@
 error[E0080]: evaluation panicked: PodVec<T, N, PFX>: N exceeds the maximum value representable by the PFX-byte length prefix
- --> $WORKSPACE/pod/src/vec.rs
+ --> $RUST/core/src/panic.rs
+  |
+  = note: evaluation of `quasar_lang::pod::PodVec::<u8, 300, 1>::_CAP_CHECK` failed here
+  |
+ ::: $WORKSPACE/pod/src/vec.rs
   |
   | /         assert!(
   | |             N <= max_n_for_pfx(PFX),
   | |             "PodVec<T, N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
   | |              prefix"
   | |         );
-  | |_________^ evaluation of `quasar_lang::pod::PodVec::<u8, 300, 1>::_CAP_CHECK` failed here
+  | |_________- in this macro invocation
 
 note: erroneous constant encountered
  --> $WORKSPACE/pod/src/vec.rs


### PR DESCRIPTION
## Summary
- enable the `wincode` feature on generated Rust client `solana-address` dependencies
- update checked-in example client manifests to match the generator output
- tighten the Rust codegen tests around generated client Cargo.toml contents

## Why
`make check-features` is currently broken on `master`.

Generated Rust clients decode accounts and events with `wincode::deserialize`, which requires `solana_address::Address` to implement `SchemaRead`/`SchemaWrite`. The generated client manifests were pinning `solana-address` without its `wincode` feature, so standalone client crates like `examples/escrow/client` failed under the `Check Features` job.

## Validation
- `cargo test -p quasar-idl`
- `make check-features`
