### PR TITLE
fix(cli): harden scaffold and command UX

### DIFF
--- a/cli/Readme.md
+++ b/cli/Readme.md
@@ -12,7 +12,7 @@ cargo install --path cli
 
 ### `quasar init [name] [--yes] [--no-git]`
 
-Scaffold a new Quasar project. When a name is provided, uses saved defaults and skips prompts. Without a name, launches an interactive wizard that prompts for:
+Scaffold a new Quasar project. Without `--yes`, this launches an interactive wizard. If a name is provided, it pre-fills the project name prompt. With `--yes`, the command uses saved defaults or explicit flags and requires a project name.
 
 - **Project name** — becomes the crate name and `Quasar.toml` project name
 - **Toolchain** — `solana` (cargo build-sbf) or `upstream` (cargo +nightly build-bpf)
@@ -24,24 +24,32 @@ The wizard generates a complete project directory with `Cargo.toml`, `Quasar.tom
 
 | Flag | Effect |
 |------|--------|
-| `-y, --yes` | Explicitly skip prompts (same as providing a name) |
+| `-y, --yes` | Explicitly skip prompts and use saved defaults |
 | `--no-git` | Skip git repo setup |
+| `--test-language` | Set `none`, `rust`, or `typescript` |
+| `--rust-framework` | Set `quasar-svm` or `mollusk` for Rust tests |
+| `--ts-sdk` | Set `kit` or `web3.js` for TypeScript tests |
+| `--template` | Set `minimal` or `full` |
+| `--toolchain` | Set `solana` or `upstream` |
 
 ```bash
 quasar init                  # Interactive wizard
-quasar init my-program       # Use saved defaults, no prompts
+quasar init my-program       # Interactive, with the name pre-filled
+quasar init my-program -y    # Use saved defaults, no prompts
 quasar init .                # Scaffold into current directory
 ```
 
-### `quasar build [--debug] [--watch] [--features FEATURES]`
+### `quasar build [--debug] [--verbose] [--watch] [--features FEATURES] [--lint]`
 
 Compile the on-chain program. Reads `Quasar.toml` to determine which toolchain to use and automatically generates the IDL before building.
 
 | Flag | Effect |
 |------|--------|
 | `--debug` | Emit debug symbols (required for profiling and source-interleaved dump) |
+| `--verbose` | Stream the underlying build command output directly |
 | `--watch` | Watch `src/` for changes and rebuild automatically |
 | `--features FEATURES` | Cargo features to enable (passed through to the build command) |
+| `--lint` | Run the account relationship linter after IDL generation |
 
 On success, prints the binary size and delta from the previous build:
 
@@ -49,18 +57,20 @@ On success, prints the binary size and delta from the previous build:
   ✔ Build complete in 1.2s (56.6 KB, -1.2 KB)
 ```
 
-### `quasar test [--debug] [--filter PATTERN] [--watch]`
+### `quasar test [--debug] [--show-output] [--filter PATTERN] [--watch] [--no-build] [--features FEATURES]`
 
-Run the test suite. Builds first, then runs either Rust tests (Mollusk/QuasarSVM) or TypeScript tests (Mocha) based on the `Quasar.toml` testing framework.
+Run the test suite. Builds first, then runs either Rust tests or TypeScript tests based on `Quasar.toml`.
 
 | Flag | Effect |
 |------|--------|
 | `--debug` | Build with debug symbols before testing |
+| `--show-output` | Forward `--show-output` to `cargo test` |
 | `-f, --filter PATTERN` | Only run tests matching the pattern |
 | `-w, --watch` | Watch `src/` for changes and re-run tests automatically |
 | `--no-build` | Skip the build step (use existing binary) |
+| `--features FEATURES` | Cargo features to enable for the build step |
 
-TypeScript tests are parsed from Mocha's JSON reporter for structured pass/fail output. Rust tests are parsed from `cargo test` output.
+TypeScript tests run through the configured command, which defaults to `npx vitest run`. Rust tests run through the configured command, which defaults to `cargo test tests::`.
 
 ### `quasar profile [elf] [--expand] [--diff PROGRAM] [--share] [--watch]`
 
@@ -123,7 +133,7 @@ quasar deploy --program-keypair ./my-key.json
 
 ### `quasar clean`
 
-Remove build artifacts from `target/deploy/`, `target/profile/`, `target/idl/`, and `target/client/`.
+Remove build artifacts from `target/deploy/`, `target/profile/`, `target/idl/`, and the configured `clients.path` directory from `Quasar.toml`.
 
 ### `quasar idl <path>`
 
@@ -166,10 +176,18 @@ Every project has a `Quasar.toml` at the root:
 name = "my-program"
 
 [toolchain]
-type = "solana"        # "solana" or "upstream"
+type = "solana"
 
 [testing]
-framework = "mollusk"  # "none", "mollusk", "quasarsvm-rust", "quasarsvm-web3js", or "quasarsvm-kit"
+language = "rust"
+
+[testing.rust]
+framework = "quasar-svm"
+test = { program = "cargo", args = ["test", "tests::"] }
+
+[clients]
+path = "target/client"
+languages = ["rust"]
 ```
 
 ### Global config (`~/.quasar/config.toml`)
@@ -179,9 +197,12 @@ Preferences that apply across all projects:
 ```toml
 [defaults]
 toolchain = "solana"
-framework = "mollusk"
+test_language = "rust"
+rust_framework = "mollusk"
+ts_sdk = "kit"
 template = "minimal"
 git = "commit"      # "commit", "init", or "skip"
+package_manager = "pnpm"
 
 [ui]
 animation = true   # Animated banner on `quasar init`

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -20,20 +20,31 @@ use {
     std::{
         fs,
         path::{Path, PathBuf},
-        process::{Command, Stdio},
+        process::{Command, ExitStatus, Output, Stdio},
         time::Instant,
     },
 };
 
-pub fn run(debug: bool, watch: bool, features: Option<String>, lint: bool) -> CliResult {
-    if watch {
-        run_watch(debug, features);
-    }
-
-    run_once(debug, features.as_deref(), lint)
+enum BuildResult {
+    Captured(Output),
+    Streamed(ExitStatus),
 }
 
-fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
+pub fn run(
+    debug: bool,
+    verbose: bool,
+    watch: bool,
+    features: Option<String>,
+    lint: bool,
+) -> CliResult {
+    if watch {
+        run_watch(debug, verbose, features);
+    }
+
+    run_once(debug, verbose, features.as_deref(), lint)
+}
+
+fn run_once(debug: bool, verbose: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
     let config = QuasarConfig::load()?;
     let clients_path = config.client_path();
     let start = Instant::now();
@@ -46,7 +57,11 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
         crate::lint::run_lint_on_parsed(&parsed, &quasar_idl::lint::LintConfig::default())?;
     }
 
-    let sp = style::spinner("Building...");
+    let sp = if verbose {
+        indicatif::ProgressBar::hidden()
+    } else {
+        style::spinner("Building...")
+    };
 
     if config.is_solana_toolchain() {
         toolchain::check_build_sbf_supports(PLATFORM_TOOLS_VERSION).map_err(|e| {
@@ -73,7 +88,7 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
         if let Some(f) = features {
             cmd.args(["--features", f]);
         }
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()
+        run_build_command(&mut cmd, verbose)
     } else {
         if !toolchain::has_sbpf_linker() {
             sp.finish_and_clear();
@@ -91,13 +106,13 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
         if let Some(f) = features {
             cmd.args(["--features", f]);
         }
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()
+        run_build_command(&mut cmd, verbose)
     };
 
     sp.finish_and_clear();
 
     match output {
-        Ok(o) if o.status.success() => {
+        Ok(BuildResult::Captured(o)) if o.status.success() => {
             let elapsed = start.elapsed();
 
             if !config.is_solana_toolchain() {
@@ -151,7 +166,7 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
             );
             Ok(())
         }
-        Ok(o) => {
+        Ok(BuildResult::Captured(o)) => {
             let elapsed = start.elapsed();
             let stderr = String::from_utf8_lossy(&o.stderr);
             Err(CliError::process_failure(
@@ -159,6 +174,57 @@ fn run_once(debug: bool, features: Option<&str>, lint_flag: bool) -> CliResult {
                 o.status.code().unwrap_or(1),
             ))
         }
+        Ok(BuildResult::Streamed(status)) if status.success() => {
+            let elapsed = start.elapsed();
+
+            if !config.is_solana_toolchain() {
+                let program = config.module_name();
+                let src = PathBuf::from("target")
+                    .join("bpfel-unknown-none")
+                    .join("release")
+                    .join(format!("lib{}.so", program));
+                let dest_dir = PathBuf::from("target").join("deploy");
+                fs::create_dir_all(&dest_dir)?;
+                let dest = dest_dir.join(format!("lib{}.so", program));
+                fs::copy(&src, &dest).map_err(|e| {
+                    eprintln!(
+                        "  {}",
+                        style::fail(&format!("failed to copy {}: {e}", src.display()))
+                    );
+                    e
+                })?;
+            }
+
+            let so_path = utils::find_so(&config, false);
+            let size_info = so_path
+                .and_then(|p| {
+                    let meta = fs::metadata(&p).ok()?;
+                    let new_size = meta.len();
+                    let delta = size_delta(&p, new_size);
+                    save_last_size(&p, new_size);
+                    Some(format!(
+                        " ({}{delta})",
+                        style::dim(&style::human_size(new_size))
+                    ))
+                })
+                .unwrap_or_default();
+
+            println!(
+                "  {}",
+                style::success(&format!(
+                    "Build complete in {}{size_info}",
+                    style::bold(&style::human_duration(elapsed))
+                ))
+            );
+            Ok(())
+        }
+        Ok(BuildResult::Streamed(status)) => Err(CliError::process_failure(
+            format!(
+                "build failed after {}",
+                style::human_duration(start.elapsed())
+            ),
+            status.code().unwrap_or(1),
+        )),
         Err(e) => Err(CliError::message(format!(
             "failed to run build command: {e}"
         ))),
@@ -289,8 +355,21 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
     }
 }
 
-fn run_watch(debug: bool, features: Option<String>) -> ! {
-    watch_loop(|| run_once(debug, features.as_deref(), false))
+fn run_watch(debug: bool, verbose: bool, features: Option<String>) -> ! {
+    watch_loop(|| run_once(debug, verbose, features.as_deref(), false))
+}
+
+fn run_build_command(cmd: &mut Command, verbose: bool) -> std::io::Result<BuildResult> {
+    if verbose {
+        let status = cmd
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+        Ok(BuildResult::Streamed(status))
+    } else {
+        let output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()?;
+        Ok(BuildResult::Captured(output))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/src/clean.rs
+++ b/cli/src/clean.rs
@@ -1,23 +1,35 @@
 use {
     crate::{
+        config::resolve_client_path,
         error::{CliError, CliResult},
         style,
     },
-    std::{fs, path::Path, process::Command},
+    std::{
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    },
 };
 
 pub fn run(all: bool) -> CliResult {
-    let dirs = [
-        "target/deploy",
-        "target/profile",
-        "target/idl",
-        "target/client",
+    let (client_dirs, config_warning) = client_dirs_to_clean(resolve_client_path());
+    let mut dirs = vec![
+        "target/deploy".to_string(),
+        "target/profile".to_string(),
+        "target/idl".to_string(),
     ];
+    for dir in client_dirs {
+        dirs.push(dir.to_string_lossy().into_owned());
+    }
+
+    if let Some(warning) = config_warning {
+        eprintln!("  {}", style::dim(&warning));
+    }
 
     let removed: Vec<&str> = dirs
         .iter()
-        .filter(|d| Path::new(d).exists())
-        .copied()
+        .map(String::as_str)
+        .filter(|dir| Path::new(dir).exists())
         .collect();
 
     if removed.is_empty() && !all {
@@ -52,6 +64,22 @@ pub fn run(all: bool) -> CliResult {
     Ok(())
 }
 
+fn client_dirs_to_clean(clients_dir: Result<PathBuf, CliError>) -> (Vec<PathBuf>, Option<String>) {
+    let legacy_clients_dir = PathBuf::from("target").join("client");
+
+    match clients_dir {
+        Ok(path) if path == legacy_clients_dir => (vec![legacy_clients_dir], None),
+        Ok(path) => (vec![path, legacy_clients_dir], None),
+        Err(err) => (
+            vec![legacy_clients_dir],
+            Some(format!(
+                "note: could not read clients.path from Quasar.toml ({err}); falling back to \
+                 target/client"
+            )),
+        ),
+    }
+}
+
 /// Remove everything in target/deploy/ except keypair files.
 fn clean_deploy_dir() -> Result<(), std::io::Error> {
     let deploy = Path::new("target/deploy");
@@ -71,4 +99,42 @@ fn clean_deploy_dir() -> Result<(), std::io::Error> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_only_legacy_dir_when_config_matches_default() {
+        let (dirs, warning) = client_dirs_to_clean(Ok(PathBuf::from("target").join("client")));
+
+        assert_eq!(dirs, vec![PathBuf::from("target").join("client")]);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn cleans_custom_and_legacy_dirs_when_config_moves_clients() {
+        let (dirs, warning) = client_dirs_to_clean(Ok(PathBuf::from("generated").join("clients")));
+
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("generated").join("clients"),
+                PathBuf::from("target").join("client")
+            ]
+        );
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn falls_back_to_legacy_dir_when_config_is_invalid() {
+        let (dirs, warning) = client_dirs_to_clean(Err(CliError::message("invalid Quasar.toml")));
+
+        assert_eq!(dirs, vec![PathBuf::from("target").join("client")]);
+        assert!(
+            warning.is_some_and(|msg| msg.contains("falling back to target/client")),
+            "warning should explain legacy fallback"
+        );
+    }
 }

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -22,7 +22,7 @@ pub fn run(
 
     // Build unless skipped
     if !skip_build {
-        crate::build::run(false, false, None, false)?;
+        crate::build::run(false, false, false, None, false)?;
     }
 
     // Find the .so binary

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -64,6 +64,7 @@ pub(super) fn scaffold(
     client_languages: &[String],
 ) -> CliResult {
     let root = Path::new(dir);
+    let clients_path = "target/client";
 
     let src = root.join("src");
     fs::create_dir_all(&src).map_err(anyhow::Error::from)?;
@@ -99,7 +100,7 @@ pub(super) fn scaffold(
             },
         },
         clients: QuasarClients {
-            path: "target/client".to_string(),
+            path: clients_path.to_string(),
             languages: client_languages.to_vec(),
         },
     };
@@ -230,6 +231,7 @@ fn generate_cargo_toml(
     test_language: TestLanguage,
     rust_framework: Option<RustFramework>,
 ) -> String {
+    let quasar_lang_dep = quasar_lang_dependency();
     let mut out = format!(
         r#"[package]
 name = "{name}"
@@ -251,7 +253,7 @@ client = []
 debug = []
 
 [dependencies]
-quasar-lang = "0.0"
+quasar-lang = {quasar_lang_dep}
 "#,
     );
 
@@ -259,44 +261,32 @@ quasar-lang = "0.0"
         out.push_str("solana-instruction = { version = \"3.2.0\" }\n");
     }
 
-    // Dev dependencies based on testing framework
-    let client_dep = format!("{name}-client = {{ path = \"target/client/rust/{name}-client\" }}\n");
-
     match (test_language, rust_framework) {
         (TestLanguage::None, _) => {}
         (TestLanguage::Rust, Some(RustFramework::Mollusk)) => {
-            out.push_str(&format!(
+            out.push_str(
                 r#"
 [dev-dependencies]
-{client_dep}mollusk-svm = "0.10.3"
+mollusk-svm = "0.10.3"
 solana-account = {{ version = "3.4.0" }}
 solana-address = {{ version = "2.2.0", features = ["decode"] }}
 solana-instruction = {{ version = "3.2.0", features = ["bincode"] }}
 "#,
-            ));
+            );
         }
         (TestLanguage::Rust, _) => {
-            out.push_str(&format!(
+            out.push_str(
                 r#"
 [dev-dependencies]
-{client_dep}quasar-svm = {{ version = "0.1" }}
+quasar-svm = {{ version = "0.1" }}
 solana-account = {{ version = "3.4.0" }}
 solana-address = {{ version = "2.2.0", features = ["decode"] }}
 solana-instruction = {{ version = "3.2.0", features = ["bincode"] }}
 solana-pubkey = {{ version = "4.1.0" }}
 "#,
-            ));
+            );
         }
-        (TestLanguage::TypeScript, _) => {
-            out.push_str(&format!(
-                r#"
-[dev-dependencies]
-{client_dep}solana-account = {{ version = "3.4.0" }}
-solana-address = {{ version = "2.2.0", features = ["decode"] }}
-solana-instruction = {{ version = "3.2.0", features = ["bincode"] }}
-"#,
-            ));
-        }
+        (TestLanguage::TypeScript, _) => {}
     }
 
     out
@@ -324,12 +314,12 @@ use quasar_lang::prelude::*;
 declare_id!("{program_id}");
 
 #[derive(Accounts)]
-pub struct Initialize<'info> {{
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct Initialize {{
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }}
 
-impl<'info> Initialize<'info> {{
+impl Initialize {{
     #[inline(always)]
     pub fn initialize(&self) -> Result<(), ProgramError> {{
         Ok(())
@@ -376,6 +366,16 @@ mod {module_name} {{
     }
 }
 
+fn quasar_lang_dependency() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+
+    if version == "0.0.0" {
+        r#"{ git = "https://github.com/blueshift-gg/quasar", branch = "master" }"#.to_string()
+    } else {
+        format!(r#""={version}""#)
+    }
+}
+
 fn generate_package_json(name: &str, ts_sdk: TypeScriptSdk) -> String {
     let solana_dep = if matches!(ts_sdk, TypeScriptSdk::Kit) {
         "\"@solana/kit\": \"^6.0.0\""
@@ -409,7 +409,6 @@ fn generate_package_json(name: &str, ts_sdk: TypeScriptSdk) -> String {
 
 fn generate_test_ts(name: &str, ts_sdk: TypeScriptSdk, toolchain: Toolchain) -> String {
     let module_name = name.replace('-', "_");
-    let class_name = crate::utils::snake_to_pascal(&module_name);
     let so_name = match toolchain {
         Toolchain::Upstream => format!("lib{module_name}"),
         Toolchain::Solana => module_name.clone(),
@@ -418,52 +417,63 @@ fn generate_test_ts(name: &str, ts_sdk: TypeScriptSdk, toolchain: Toolchain) -> 
     if matches!(ts_sdk, TypeScriptSdk::Kit) {
         format!(
             r#"import {{ generateKeyPairSigner }} from "@solana/kit";
-import {{ {class_name}Client, PROGRAM_ADDRESS }} from "../target/client/typescript/{module_name}/kit";
+import {{ AccountRole, address }} from "@solana/kit";
 import {{ describe, it, expect }} from "vitest";
 import {{ QuasarSvm, createKeyedSystemAccount }} from "@blueshift-gg/quasar-svm/kit";
 import {{ readFile }} from "node:fs/promises";
 
-const {class_name}Program = new {class_name}Client();
-
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes", async () => {{
+    const idl = JSON.parse(await readFile("target/idl/{module_name}.json", "utf8")) as {{ address: string }};
+    const programAddress = address(idl.address);
     const vm = new QuasarSvm();
-    vm.addProgram(PROGRAM_ADDRESS, await readFile("target/deploy/{so_name}.so"));
+    vm.addProgram(programAddress, await readFile("target/deploy/{so_name}.so"));
 
     const payer = await generateKeyPairSigner();
 
-    const initializeInstruction = {class_name}Program.createInitializeInstruction({{
-      payer: payer.address,
-    }});
+    const initializeInstruction = {{
+      programAddress,
+      accounts: [
+        {{ address: payer.address, role: AccountRole.WRITABLE_SIGNER }},
+        {{ address: address("11111111111111111111111111111111"), role: AccountRole.READONLY }},
+      ],
+      data: Uint8Array.from([0]),
+    }};
 
     const result = vm.processInstruction(initializeInstruction, [
       createKeyedSystemAccount(payer.address),
     ]);
 
     expect(result.status.ok, `initialize failed:\n${{result.logs.join("\n")}}`).toBe(true);
-  }});
+    }});
 }});
-"#
+"#,
+            class_name = crate::utils::snake_to_pascal(&module_name)
         )
     } else {
         format!(
-            r#"import {{ Keypair }} from "@solana/web3.js";
-import {{ {class_name}Client }} from "../target/client/typescript/{module_name}/web3.js";
+            r#"import {{ Buffer }} from "buffer";
+import {{ Address, Keypair, TransactionInstruction }} from "@solana/web3.js";
 import {{ readFile }} from "node:fs/promises";
 import {{ describe, it, expect }} from "vitest";
 import {{ QuasarSvm, createKeyedSystemAccount }} from "@blueshift-gg/quasar-svm/web3.js";
 
-const {class_name}Program = new {class_name}Client();
-
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes", async () => {{
+    const idl = JSON.parse(await readFile("target/idl/{module_name}.json", "utf8")) as {{ address: string }};
+    const programAddress = new Address(idl.address);
     const vm = new QuasarSvm();
-    vm.addProgram({class_name}Client.programId, await readFile("target/deploy/{so_name}.so"));
+    vm.addProgram(programAddress, await readFile("target/deploy/{so_name}.so"));
 
     const {{ publicKey: payer }} = await Keypair.generate();
 
-    const initializeInstruction = {class_name}Program.createInitializeInstruction({{
-      payer,
+    const initializeInstruction = new TransactionInstruction({{
+      programId: programAddress,
+      keys: [
+        {{ pubkey: payer, isSigner: true, isWritable: true }},
+        {{ pubkey: new Address("11111111111111111111111111111111"), isSigner: false, isWritable: false }},
+      ],
+      data: Buffer.from([0]),
     }});
 
     const result = vm.processInstruction(initializeInstruction, [
@@ -471,9 +481,10 @@ describe.concurrent("{class_name} Program", async () => {{
     ]);
 
     expect(result.status.ok, `initialize failed:\n${{result.logs.join("\n")}}`).toBe(true);
-  }});
+    }});
 }});
-"#
+"#,
+            class_name = crate::utils::snake_to_pascal(&module_name)
         )
     }
 }
@@ -488,20 +499,27 @@ fn generate_tests_rs(
     if matches!(toolchain, Toolchain::Upstream) {
         libname = format!("lib{libname}");
     };
-    let client_crate = format!("{module_name}_client");
-
     match (rust_framework, template) {
         (RustFramework::Mollusk, Template::Minimal | Template::Full) => {
             format!(
                 r#"use mollusk_svm::{{program::keyed_account_for_system_program, Mollusk}};
 use solana_account::Account;
 use solana_address::Address;
-use solana_instruction::Instruction;
-
-use {client_crate}::InitializeInstruction;
+use solana_instruction::{{AccountMeta, Instruction}};
 
 fn setup() -> Mollusk {{
     Mollusk::new(&crate::ID, "target/deploy/{libname}")
+}}
+
+fn initialize_instruction(payer: Address, system_program: Address) -> Instruction {{
+    Instruction {{
+        program_id: Address::from(crate::ID.to_bytes()),
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+        data: vec![0],
+    }}
 }}
 
 #[test]
@@ -512,11 +530,7 @@ fn test_initialize() {{
     let payer = Address::new_unique();
     let payer_account = Account::new(10_000_000_000, 0, &system_program);
 
-    let instruction: Instruction = InitializeInstruction {{
-        payer,
-        system_program,
-    }}
-    .into();
+    let instruction = initialize_instruction(payer, system_program);
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -537,15 +551,25 @@ fn test_initialize() {{
         }
         (RustFramework::QuasarSVM, Template::Minimal | Template::Full) => {
             format!(
-                r#"use quasar_svm::{{Account, Instruction, Pubkey, QuasarSvm}};
+                r#"use quasar_svm::{{Account, Pubkey, QuasarSvm}};
 use solana_address::Address;
-
-use {client_crate}::InitializeInstruction;
+use solana_instruction::{{AccountMeta, Instruction}};
 
 fn setup() -> QuasarSvm {{
-    let elf = include_bytes!("../target/deploy/{libname}.so");
+    let elf = std::fs::read("../target/deploy/{libname}.so").unwrap();
     QuasarSvm::new()
-        .with_program(&Pubkey::from(crate::ID), elf)
+        .with_program(&Pubkey::from(crate::ID), &elf)
+}}
+
+fn initialize_instruction(payer: Address, system_program: Address) -> Instruction {{
+    Instruction {{
+        program_id: Address::from(crate::ID.to_bytes()),
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(system_program, false),
+        ],
+        data: vec![0],
+    }}
 }}
 
 #[test]
@@ -554,11 +578,10 @@ fn test_initialize() {{
 
     let payer = Pubkey::new_unique();
 
-    let instruction: Instruction = InitializeInstruction {{
-        payer: Address::from(payer.to_bytes()),
-        system_program: Address::from(quasar_svm::system_program::ID.to_bytes()),
-    }}
-    .into();
+    let instruction = initialize_instruction(
+        Address::from(payer.to_bytes()),
+        Address::from(quasar_svm::system_program::ID.to_bytes()),
+    );
 
     let result = svm.process_instruction(
         &instruction,

--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -44,12 +44,12 @@ pub use initialize::*;
 pub(super) const INSTRUCTION_INITIALIZE: &str = r#"use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Initialize<'info> {
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<System>,
+pub struct Initialize {
+    pub payer: Signer,
+    pub system_program: Program<System>,
 }
 
-impl<'info> Initialize<'info> {
+impl Initialize {
     #[inline(always)]
     pub fn initialize(&self) -> Result<(), ProgramError> {
         Ok(())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -126,6 +126,10 @@ pub struct BuildCommand {
     #[arg(long, action = ArgAction::SetTrue)]
     pub debug: bool,
 
+    /// Stream the underlying build command output directly
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub verbose: bool,
+
     /// Watch src/ for changes and rebuild automatically
     #[arg(long, short, action = ArgAction::SetTrue)]
     pub watch: bool,
@@ -155,6 +159,10 @@ pub struct TestCommand {
     /// Build with debug symbols before testing
     #[arg(long, action = ArgAction::SetTrue)]
     pub debug: bool,
+
+    /// Forward `--show-output` to `cargo test`
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub show_output: bool,
 
     /// Only run tests whose name matches PATTERN
     #[arg(long, short, value_name = "PATTERN")]
@@ -340,10 +348,17 @@ pub fn run(cli: Cli) -> CliResult {
             }
             Ok(())
         }
-        Command::Build(cmd) => build::run(cmd.debug, cmd.watch, cmd.features, cmd.lint),
-        Command::Test(cmd) => {
-            test::run(cmd.debug, cmd.filter, cmd.watch, cmd.no_build, cmd.features)
+        Command::Build(cmd) => {
+            build::run(cmd.debug, cmd.verbose, cmd.watch, cmd.features, cmd.lint)
         }
+        Command::Test(cmd) => test::run(
+            cmd.debug,
+            cmd.show_output,
+            cmd.filter,
+            cmd.watch,
+            cmd.no_build,
+            cmd.features,
+        ),
         Command::Deploy(cmd) => deploy::run(
             cmd.program_keypair,
             cmd.upgrade_authority,
@@ -429,11 +444,11 @@ pub fn print_help() {
         "Add instructions, state, errors",
     );
     print_cmd(
-        "build   [--debug] [-w] [--features]",
+        "build   [--debug] [--verbose] [-w] [--features]",
         "Compile the on-chain program",
     );
     print_cmd(
-        "test    [--debug] [-f] [-w] [--features]",
+        "test    [--debug] [--show-output] [-f] [-w] [--features]",
         "Run the test suite",
     );
     print_cmd(

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -4,24 +4,32 @@ use {
         error::{CliError, CliResult},
         style,
     },
-    std::process::Command,
+    std::{path::Path, process::Command},
 };
 
 pub fn run(
     debug: bool,
+    show_output: bool,
     filter: Option<String>,
     watch: bool,
     no_build: bool,
     features: Option<String>,
 ) -> CliResult {
     if watch {
-        run_watch(debug, filter, no_build, features);
+        run_watch(debug, show_output, filter, no_build, features);
     }
-    run_once(debug, filter.as_deref(), no_build, features.as_deref())
+    run_once(
+        debug,
+        show_output,
+        filter.as_deref(),
+        no_build,
+        features.as_deref(),
+    )
 }
 
 fn run_once(
     debug: bool,
+    show_output: bool,
     filter: Option<&str>,
     no_build: bool,
     features: Option<&str>,
@@ -29,28 +37,46 @@ fn run_once(
     let config = QuasarConfig::load()?;
 
     if !no_build {
-        crate::build::run(debug, false, features.map(String::from), false)?;
+        crate::build::run(debug, false, false, features.map(String::from), false)?;
     }
 
     if config.has_typescript_tests() {
-        run_typescript_tests(&config, filter)
+        run_typescript_tests(&config, filter, show_output)
     } else if config.has_rust_tests() {
-        run_rust_tests(&config, filter)
+        run_rust_tests(&config, filter, show_output)
     } else {
         println!("  {}", style::warn("no test framework configured"));
         Ok(())
     }
 }
 
-fn run_watch(debug: bool, filter: Option<String>, no_build: bool, features: Option<String>) -> ! {
-    crate::build::watch_loop(|| run_once(debug, filter.as_deref(), no_build, features.as_deref()))
+fn run_watch(
+    debug: bool,
+    show_output: bool,
+    filter: Option<String>,
+    no_build: bool,
+    features: Option<String>,
+) -> ! {
+    crate::build::watch_loop(|| {
+        run_once(
+            debug,
+            show_output,
+            filter.as_deref(),
+            no_build,
+            features.as_deref(),
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
 // TypeScript (vitest)
 // ---------------------------------------------------------------------------
 
-fn run_typescript_tests(config: &QuasarConfig, filter: Option<&str>) -> CliResult {
+fn run_typescript_tests(
+    config: &QuasarConfig,
+    filter: Option<&str>,
+    show_output: bool,
+) -> CliResult {
     let ts = config.testing.typescript.as_ref();
     let default_install = CommandSpec::new("npm", ["install"]);
     let default_test = CommandSpec::new("npx", ["vitest", "run"]);
@@ -61,14 +87,14 @@ fn run_typescript_tests(config: &QuasarConfig, filter: Option<&str>) -> CliResul
         run_command(install_cmd)?;
     }
 
-    run_test_cmd(test_cmd, filter)
+    run_test_cmd(test_cmd, filter, show_output)
 }
 
 // ---------------------------------------------------------------------------
 // Rust (cargo test)
 // ---------------------------------------------------------------------------
 
-fn run_rust_tests(config: &QuasarConfig, filter: Option<&str>) -> CliResult {
+fn run_rust_tests(config: &QuasarConfig, filter: Option<&str>, show_output: bool) -> CliResult {
     let default_test = CommandSpec::new("cargo", ["test", "tests::"]);
     let test_cmd = config
         .testing
@@ -77,7 +103,7 @@ fn run_rust_tests(config: &QuasarConfig, filter: Option<&str>) -> CliResult {
         .map(|r| &r.test)
         .unwrap_or(&default_test);
 
-    run_test_cmd(test_cmd, filter)
+    run_test_cmd(test_cmd, filter, show_output)
 }
 
 // ---------------------------------------------------------------------------
@@ -100,18 +126,9 @@ fn run_command(command: &CommandSpec) -> CliResult {
     }
 }
 
-fn run_test_cmd(test_cmd: &CommandSpec, filter: Option<&str>) -> CliResult {
+fn run_test_cmd(test_cmd: &CommandSpec, filter: Option<&str>, show_output: bool) -> CliResult {
     let mut cmd = Command::new(&test_cmd.program);
-    cmd.args(&test_cmd.args);
-
-    if let Some(pattern) = filter {
-        // cargo test uses a positional filter; vitest/jest use -t
-        if test_cmd.program == "cargo" {
-            cmd.arg(pattern);
-        } else {
-            cmd.args(["-t", pattern]);
-        }
-    }
+    cmd.args(test_command_args(test_cmd, filter, show_output));
 
     let status = cmd.status();
 
@@ -125,5 +142,110 @@ fn run_test_cmd(test_cmd: &CommandSpec, filter: Option<&str>) -> CliResult {
             "failed to run {}: {e}",
             test_cmd.display()
         ))),
+    }
+}
+
+fn test_command_args(
+    test_cmd: &CommandSpec,
+    filter: Option<&str>,
+    show_output: bool,
+) -> Vec<String> {
+    let mut args = test_cmd.args.clone();
+
+    if is_cargo_program(&test_cmd.program) {
+        let mut separator = args.iter().position(|arg| arg == "--");
+
+        if let Some(pattern) = filter {
+            match separator {
+                Some(index) => {
+                    args.insert(index, pattern.to_string());
+                    separator = Some(index + 1);
+                }
+                None => args.push(pattern.to_string()),
+            }
+        }
+
+        if show_output {
+            match separator {
+                Some(index) => args.insert(index + 1, "--show-output".to_string()),
+                None => {
+                    args.push("--".to_string());
+                    args.push("--show-output".to_string());
+                }
+            }
+        }
+    } else if let Some(pattern) = filter {
+        args.push("-t".to_string());
+        args.push(pattern.to_string());
+    }
+
+    args
+}
+
+fn is_cargo_program(program: &str) -> bool {
+    Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "cargo" || name == "cargo.exe")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_filter_is_inserted_before_existing_separator() {
+        let cmd = CommandSpec::new("cargo", ["test", "tests::", "--", "--nocapture"]);
+        let args = test_command_args(&cmd, Some("my_test"), false);
+
+        assert_eq!(
+            args,
+            vec!["test", "tests::", "my_test", "--", "--nocapture"]
+        );
+    }
+
+    #[test]
+    fn cargo_show_output_reuses_existing_separator() {
+        let cmd = CommandSpec::new("cargo", ["test", "tests::", "--", "--nocapture"]);
+        let args = test_command_args(&cmd, None, true);
+
+        assert_eq!(
+            args,
+            vec!["test", "tests::", "--", "--show-output", "--nocapture"]
+        );
+    }
+
+    #[test]
+    fn cargo_filter_and_show_output_keep_test_binary_args_ordered() {
+        let cmd = CommandSpec::new("cargo", ["test", "tests::", "--", "--nocapture"]);
+        let args = test_command_args(&cmd, Some("my_test"), true);
+
+        assert_eq!(
+            args,
+            vec![
+                "test",
+                "tests::",
+                "my_test",
+                "--",
+                "--show-output",
+                "--nocapture"
+            ]
+        );
+    }
+
+    #[test]
+    fn non_cargo_filter_uses_t_flag() {
+        let cmd = CommandSpec::new("npx", ["vitest", "run"]);
+        let args = test_command_args(&cmd, Some("my_test"), true);
+
+        assert_eq!(args, vec!["vitest", "run", "-t", "my_test"]);
+    }
+
+    #[test]
+    fn cargo_executable_path_is_treated_like_cargo() {
+        let cmd = CommandSpec::new("/usr/bin/cargo", ["test"]);
+        let args = test_command_args(&cmd, None, true);
+
+        assert_eq!(args, vec!["test", "--", "--show-output"]);
     }
 }


### PR DESCRIPTION
## Summary

This PR hardens the first CLI/scaffold cleanup pass around `quasar init`, `quasar build`, `quasar test`, and `quasar clean`.

The main goal is to fix the immediate UX issues without leaving the generated test scaffolds coupled to `target/client`, which was the last fragile edge around configurable client paths.

## What Changed

### 1. Scaffolded tests no longer depend on generated clients

Fresh Rust and TypeScript test scaffolds now build the stock `initialize` instruction manually instead of importing generated clients from a baked output path.

That removes the last meaningful `target/client` coupling from generated test code and makes the scaffold stable even when `[clients].path` changes.

### 2. CLI flags are wired through correctly

This PR adds and validates the intended command UX:

- `quasar build --verbose`
- `quasar test --show-output`

The test-command builder was also hardened so custom cargo test commands that already include `--` test-binary args still receive filters and `--nocapture` in the right place.

### 3. Cleanup respects configured client output paths

`quasar clean` now resolves the configured `clients.path`, cleans that directory, and still removes the legacy `target/client` directory when a project migrated away from the default.

If `Quasar.toml` exists but is invalid, cleanup now falls back safely instead of refusing to run.

### 4. Scaffold templates and docs were brought back in line

The scaffold templates now use the correct signer shape, avoid compile-time `.so` embedding in fresh Rust tests, and the CLI README reflects the current commands and config surface.

## Validation

Commands run:

- `cargo test -p quasar-cli --lib`
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- `cargo fmt --check`

Additional smoke checks:

- initialized a fresh Rust scaffold and verified `cargo test --no-run`
- initialized a fresh TypeScript scaffold and verified the generated tests no longer import from `target/client`

Closes #121
Closes #125
Closes #133
Closes #151
