### PR TITLE
fix(idl): improve generated client ergonomics

### DIFF
--- a/idl/src/codegen/rust.rs
+++ b/idl/src/codegen/rust.rs
@@ -212,18 +212,18 @@ fn emit_instructions(
     let mut ix_files: Vec<(String, String)> = Vec::new();
 
     // Scan all instruction arg types for imports needed by mod.rs
-    let mut needs_dyn_bytes = false;
+    let mut needs_dyn_string = false;
     let mut needs_dyn_vec = false;
     let mut needs_address = false;
     for ix in &idl.instructions {
         for arg in &ix.args {
-            collect_wrapper_needs(&arg.ty, &mut needs_dyn_bytes, &mut needs_dyn_vec);
+            collect_wrapper_needs(&arg.ty, &mut needs_dyn_string, &mut needs_dyn_vec);
             if field_needs_address(&arg.ty) {
                 needs_address = true;
             }
         }
     }
-    emit_wrapper_imports(&mut mod_rs, needs_dyn_bytes, needs_dyn_vec);
+    emit_wrapper_imports(&mut mod_rs, needs_dyn_string, needs_dyn_vec);
     if needs_address {
         mod_rs.push_str("use solana_address::Address;\n");
     }
@@ -885,7 +885,7 @@ fn emit_pda(pdas: &[PdaInfo]) -> String {
 // Shared helpers
 // ===========================================================================
 
-/// Scan field types and emit wrapper imports (DynBytes, DynVec), Address
+/// Scan field types and emit wrapper imports (DynString, DynVec), Address
 /// import, and defined type imports. Used by instruction, state/event, and type
 /// emitters.
 fn emit_field_imports<'a>(
@@ -894,10 +894,10 @@ fn emit_field_imports<'a>(
     type_map: &HashMap<String, Vec<IdlField>>,
 ) {
     let mut needs_address = false;
-    let mut needs_dyn_bytes = false;
+    let mut needs_dyn_string = false;
     let mut needs_dyn_vec = false;
     for ty in types {
-        collect_wrapper_needs(ty, &mut needs_dyn_bytes, &mut needs_dyn_vec);
+        collect_wrapper_needs(ty, &mut needs_dyn_string, &mut needs_dyn_vec);
         if field_needs_address(ty) {
             needs_address = true;
         }
@@ -906,7 +906,7 @@ fn emit_field_imports<'a>(
     if needs_address {
         out.push_str("use solana_address::Address;\n");
     }
-    emit_wrapper_imports(out, needs_dyn_bytes, needs_dyn_vec);
+    emit_wrapper_imports(out, needs_dyn_string, needs_dyn_vec);
 }
 
 /// Emit struct definition + manual SchemaWrite/SchemaRead impls with
@@ -1063,7 +1063,7 @@ fn rust_field_type(ty: &IdlType) -> String {
             other => other.to_string(),
         },
         IdlType::Option { option } => format!("Option<{}>", rust_field_type(option)),
-        IdlType::DynString { string } => prefix_generic("DynBytes", string.prefix_bytes),
+        IdlType::DynString { string } => prefix_generic("DynString", string.prefix_bytes),
         IdlType::DynVec { vec } => {
             let inner = rust_field_type(&vec.items);
             format!("DynVec<{}, {}>", inner, prefix_rust_type(vec.prefix_bytes))
@@ -1085,13 +1085,15 @@ fn prefix_rust_type(prefix_bytes: usize) -> &'static str {
     }
 }
 
-fn collect_wrapper_needs(ty: &IdlType, needs_dyn_bytes: &mut bool, needs_dyn_vec: &mut bool) {
+fn collect_wrapper_needs(ty: &IdlType, needs_dyn_string: &mut bool, needs_dyn_vec: &mut bool) {
     match ty {
-        IdlType::Option { option } => collect_wrapper_needs(option, needs_dyn_bytes, needs_dyn_vec),
-        IdlType::DynString { .. } => *needs_dyn_bytes = true,
+        IdlType::Option { option } => {
+            collect_wrapper_needs(option, needs_dyn_string, needs_dyn_vec)
+        }
+        IdlType::DynString { .. } => *needs_dyn_string = true,
         IdlType::DynVec { vec } => {
             *needs_dyn_vec = true;
-            collect_wrapper_needs(&vec.items, needs_dyn_bytes, needs_dyn_vec);
+            collect_wrapper_needs(&vec.items, needs_dyn_string, needs_dyn_vec);
         }
         _ => {}
     }
@@ -1106,10 +1108,10 @@ fn field_needs_address(ty: &IdlType) -> bool {
     }
 }
 
-fn emit_wrapper_imports(out: &mut String, needs_dyn_bytes: bool, needs_dyn_vec: bool) {
+fn emit_wrapper_imports(out: &mut String, needs_dyn_string: bool, needs_dyn_vec: bool) {
     let mut wrappers = Vec::new();
-    if needs_dyn_bytes {
-        wrappers.push("DynBytes");
+    if needs_dyn_string {
+        wrappers.push("DynString");
     }
     if needs_dyn_vec {
         wrappers.push("DynVec");

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -1,7 +1,10 @@
 use {
     crate::types::{Idl, IdlSeed, IdlType},
     quasar_schema::{snake_to_pascal, to_screaming_snake as pascal_to_screaming_snake},
-    std::{collections::HashSet, fmt::Write},
+    std::{
+        collections::{HashMap, HashSet},
+        fmt::Write,
+    },
 };
 
 /// Target flavor for TypeScript client generation.
@@ -23,6 +26,8 @@ pub fn generate_ts_client_kit(idl: &Idl) -> String {
 
 fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     let mut out = String::new();
+    let pdas = collect_pdas(idl);
+    let exportable_pda_helpers = pda_helper_lookup(&pdas);
 
     // --- Collect which codecs are actually used ---
     let used = collect_used_codecs(idl);
@@ -468,11 +473,17 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
 
     // --- Instruction builders (target-specific) ---
     match target {
-        TsTarget::Web3js => generate_instruction_builders_web3js(&mut out, idl),
-        TsTarget::Kit => generate_instruction_builders_kit(&mut out, idl),
+        TsTarget::Web3js => {
+            generate_instruction_builders_web3js(&mut out, idl, &exportable_pda_helpers)
+        }
+        TsTarget::Kit => generate_instruction_builders_kit(&mut out, idl, &exportable_pda_helpers),
     }
 
     out.push_str("}\n\n");
+
+    if !pdas.is_empty() {
+        emit_pda_helpers(&mut out, &pdas, target, &idl.metadata.name);
+    }
 
     // === Errors ===
     if !idl.errors.is_empty() {
@@ -506,11 +517,16 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
 // Instruction builders — @solana/web3.js
 // ---------------------------------------------------------------------------
 
-fn generate_instruction_builders_web3js(out: &mut String, idl: &Idl) {
+fn generate_instruction_builders_web3js(
+    out: &mut String,
+    idl: &Idl,
+    exportable_pda_helpers: &HashMap<Vec<IdlSeed>, String>,
+) {
     let class_name = format!("{}Client", snake_to_pascal(&idl.metadata.name));
     for ix in &idl.instructions {
         out.push('\n');
         let pascal = snake_to_pascal(&ix.name);
+        let arg_types = instruction_arg_types(ix);
 
         let mut user_accs = Vec::new();
         let mut has_non_input_accounts = false;
@@ -564,29 +580,25 @@ fn generate_instruction_builders_web3js(out: &mut String, idl: &Idl) {
         // Derive PDA accounts
         for acc in &ix.accounts {
             if let Some(pda) = &acc.pda {
-                write!(
-                    out,
-                    "    accountsMap[\"{}\"] = Address.findProgramAddressSync(\n      [\n",
-                    acc.name
-                )
-                .expect("write to String");
-                for seed in &pda.seeds {
-                    match seed {
-                        IdlSeed::Const { value } => {
-                            write_byte_array(out, value);
-                        }
-                        IdlSeed::Account { path } => {
-                            writeln!(out, "        {}.toBytes(),", account_expr(path))
-                                .expect("write to String");
-                        }
-                        IdlSeed::Arg { path } => {
-                            writeln!(out, "        input.{},  // arg seed", path)
-                                .expect("write to String");
-                        }
-                    }
-                }
-                write!(out, "      ],\n      {class_name}.programId,\n    )[0];\n")
+                if let Some(helper_name) = exportable_pda_helpers.get(&pda.seeds) {
+                    let args = helper_call_args(&pda.seeds, &account_expr);
+                    writeln!(
+                        out,
+                        "    accountsMap[\"{}\"] = {}({});",
+                        acc.name, helper_name, args
+                    )
                     .expect("write to String");
+                } else {
+                    emit_inline_pda_derivation(
+                        out,
+                        &acc.name,
+                        &pda.seeds,
+                        TsTarget::Web3js,
+                        &arg_types,
+                        &account_expr,
+                        Some(&format!("{class_name}.programId")),
+                    );
+                }
             }
         }
 
@@ -650,10 +662,15 @@ fn generate_instruction_builders_web3js(out: &mut String, idl: &Idl) {
 // Instruction builders — @solana/kit
 // ---------------------------------------------------------------------------
 
-fn generate_instruction_builders_kit(out: &mut String, idl: &Idl) {
+fn generate_instruction_builders_kit(
+    out: &mut String,
+    idl: &Idl,
+    exportable_pda_helpers: &HashMap<Vec<IdlSeed>, String>,
+) {
     for ix in &idl.instructions {
         out.push('\n');
         let pascal = snake_to_pascal(&ix.name);
+        let arg_types = instruction_arg_types(ix);
 
         let mut user_accs = Vec::new();
         let mut has_non_input_accounts = false;
@@ -716,33 +733,25 @@ fn generate_instruction_builders_kit(out: &mut String, idl: &Idl) {
         // Derive PDA accounts (async in kit)
         for acc in &ix.accounts {
             if let Some(pda) = &acc.pda {
-                write!(
-                    out,
-                    "    accountsMap[\"{}\"] = (await getProgramDerivedAddress({{\n      \
-                     programAddress: PROGRAM_ADDRESS,\n      seeds: [\n",
-                    acc.name
-                )
-                .expect("write to String");
-                for seed in &pda.seeds {
-                    match seed {
-                        IdlSeed::Const { value } => {
-                            write_byte_array(out, value);
-                        }
-                        IdlSeed::Account { path } => {
-                            writeln!(
-                                out,
-                                "        getAddressCodec().encode({}),",
-                                account_expr(path)
-                            )
-                            .expect("write to String");
-                        }
-                        IdlSeed::Arg { path } => {
-                            writeln!(out, "        input.{},  // arg seed", path)
-                                .expect("write to String");
-                        }
-                    }
+                if let Some(helper_name) = exportable_pda_helpers.get(&pda.seeds) {
+                    let args = helper_call_args(&pda.seeds, &account_expr);
+                    writeln!(
+                        out,
+                        "    accountsMap[\"{}\"] = await {}({});",
+                        acc.name, helper_name, args
+                    )
+                    .expect("write to String");
+                } else {
+                    emit_inline_pda_derivation(
+                        out,
+                        &acc.name,
+                        &pda.seeds,
+                        TsTarget::Kit,
+                        &arg_types,
+                        &account_expr,
+                        None,
+                    );
                 }
-                out.push_str("      ],\n    }))[0];\n");
             }
         }
 
@@ -805,6 +814,343 @@ fn account_role(signer: bool, writable: bool) -> &'static str {
         (true, false) => "AccountRole.READONLY_SIGNER",
         (false, true) => "AccountRole.WRITABLE",
         (false, false) => "AccountRole.READONLY",
+    }
+}
+
+#[derive(Clone)]
+struct PdaParam {
+    name: String,
+    ty: PdaParamType,
+}
+
+#[derive(Clone)]
+enum PdaParamType {
+    Account,
+    Arg(IdlType),
+}
+
+/// A collected PDA with its field name, seeds, and helper signature params.
+struct PdaInfo {
+    helper_name: String,
+    seeds: Vec<IdlSeed>,
+    params: Vec<PdaParam>,
+}
+
+fn collect_pdas(idl: &Idl) -> Vec<PdaInfo> {
+    let mut pdas: Vec<PdaInfo> = Vec::new();
+    let mut seen_seeds: HashSet<Vec<IdlSeed>> = HashSet::new();
+    let mut used_helper_names: HashMap<String, usize> = HashMap::new();
+
+    for ix in &idl.instructions {
+        let arg_types = instruction_arg_types(ix);
+        for account in &ix.accounts {
+            let Some(pda) = &account.pda else {
+                continue;
+            };
+            if pda.seeds.is_empty()
+                || !pda_is_exportable(&pda.seeds, &arg_types)
+                || !seen_seeds.insert(pda.seeds.clone())
+            {
+                continue;
+            }
+
+            let mut params: Vec<PdaParam> = Vec::new();
+            for seed in &pda.seeds {
+                match seed {
+                    IdlSeed::Const { .. } => {}
+                    IdlSeed::Account { path } => {
+                        if !params.iter().any(|param| param.name == *path) {
+                            params.push(PdaParam {
+                                name: path.clone(),
+                                ty: PdaParamType::Account,
+                            });
+                        }
+                    }
+                    IdlSeed::Arg { path } => {
+                        if params.iter().any(|param| param.name == *path) {
+                            continue;
+                        }
+
+                        let arg = arg_types.get(path).unwrap_or_else(|| {
+                            panic!("missing PDA arg seed definition for {path}")
+                        });
+                        params.push(PdaParam {
+                            name: path.clone(),
+                            ty: PdaParamType::Arg((*arg).clone()),
+                        });
+                    }
+                }
+            }
+
+            pdas.push(PdaInfo {
+                helper_name: unique_pda_helper_name(&account.name, &mut used_helper_names),
+                seeds: pda.seeds.clone(),
+                params,
+            });
+        }
+    }
+
+    pdas
+}
+
+fn emit_pda_helpers(out: &mut String, pdas: &[PdaInfo], target: TsTarget, program_name: &str) {
+    out.push_str("/* PDA Helpers */\n");
+
+    for pda in pdas {
+        let arg_types = pda_arg_types(pda);
+        let params = pda
+            .params
+            .iter()
+            .map(|param| match &param.ty {
+                PdaParamType::Account => format!("{}: Address", param.name),
+                PdaParamType::Arg(ty) => format!("{}: {}", param.name, ts_type(ty)),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        match target {
+            TsTarget::Web3js => {
+                writeln!(
+                    out,
+                    "export function {}({}): Address {{",
+                    pda.helper_name, params
+                )
+                .expect("write to String");
+                out.push_str("  return Address.findProgramAddressSync(\n");
+                out.push_str("    [\n");
+                write_ts_pda_seed_lines(out, &pda.seeds, target, &arg_types);
+                writeln!(
+                    out,
+                    "    ],\n    {}Client.programId,\n  )[0];",
+                    snake_to_pascal(program_name)
+                )
+                .expect("write to String");
+            }
+            TsTarget::Kit => {
+                writeln!(
+                    out,
+                    "export async function {}({}): Promise<Address> {{",
+                    pda.helper_name, params
+                )
+                .expect("write to String");
+                out.push_str("  return (await getProgramDerivedAddress({\n");
+                out.push_str("    programAddress: PROGRAM_ADDRESS,\n");
+                out.push_str("    seeds: [\n");
+                write_ts_pda_seed_lines(out, &pda.seeds, target, &arg_types);
+                out.push_str("    ],\n");
+                out.push_str("  }))[0];\n");
+            }
+        }
+        out.push_str("}\n\n");
+    }
+}
+
+fn ts_pda_helper_name(field_name: &str) -> String {
+    format!("find{}Address", snake_to_pascal(field_name))
+}
+
+fn unique_pda_helper_name(
+    field_name: &str,
+    used_helper_names: &mut HashMap<String, usize>,
+) -> String {
+    let base = ts_pda_helper_name(field_name);
+    match used_helper_names.entry(base.clone()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(1);
+            base
+        }
+        std::collections::hash_map::Entry::Occupied(mut entry) => {
+            let suffix = *entry.get() + 1;
+            entry.insert(suffix);
+            format!("{base}{suffix}")
+        }
+    }
+}
+
+fn pda_helper_lookup(pdas: &[PdaInfo]) -> HashMap<Vec<IdlSeed>, String> {
+    pdas.iter()
+        .map(|pda| (pda.seeds.clone(), pda.helper_name.clone()))
+        .collect()
+}
+
+fn helper_call_args(seeds: &[IdlSeed], account_expr: &impl Fn(&str) -> String) -> String {
+    let mut args = Vec::new();
+    let mut seen = HashSet::new();
+
+    for seed in seeds {
+        let (name, expr) = match seed {
+            IdlSeed::Const { .. } => continue,
+            IdlSeed::Account { path } => (path.as_str(), account_expr(path)),
+            IdlSeed::Arg { path } => (path.as_str(), format!("input.{path}")),
+        };
+
+        if seen.insert(name.to_string()) {
+            args.push(expr);
+        }
+    }
+
+    args.join(", ")
+}
+
+fn write_ts_pda_seed_lines(
+    out: &mut String,
+    seeds: &[IdlSeed],
+    target: TsTarget,
+    arg_types: &HashMap<String, IdlType>,
+) {
+    for seed in seeds {
+        match seed {
+            IdlSeed::Const { value } => write_byte_array(out, value),
+            IdlSeed::Account { path } => match target {
+                TsTarget::Web3js => {
+                    writeln!(out, "      {}.toBytes(),", path).expect("write to String");
+                }
+                TsTarget::Kit => {
+                    writeln!(out, "      getAddressCodec().encode({}),", path)
+                        .expect("write to String");
+                }
+            },
+            IdlSeed::Arg { path } => {
+                let expr = arg_types
+                    .get(path)
+                    .map(|ty| ts_pda_arg_seed_expr(path, ty, target))
+                    .unwrap_or_else(|| path.clone());
+                writeln!(out, "      {},", expr).expect("write to String");
+            }
+        }
+    }
+}
+
+fn emit_inline_pda_derivation(
+    out: &mut String,
+    account_name: &str,
+    seeds: &[IdlSeed],
+    target: TsTarget,
+    arg_types: &HashMap<String, IdlType>,
+    account_expr: &impl Fn(&str) -> String,
+    web3_program_expr: Option<&str>,
+) {
+    match target {
+        TsTarget::Web3js => {
+            writeln!(
+                out,
+                "    accountsMap[\"{}\"] = Address.findProgramAddressSync(",
+                account_name
+            )
+            .expect("write to String");
+            out.push_str("      [\n");
+            write_inline_pda_seed_lines(out, seeds, target, arg_types, account_expr);
+            writeln!(
+                out,
+                "      ],\n      {},\n    )[0];",
+                web3_program_expr.expect("web3 PDA derivation requires program id expression")
+            )
+            .expect("write to String");
+        }
+        TsTarget::Kit => {
+            writeln!(
+                out,
+                "    accountsMap[\"{}\"] = (await getProgramDerivedAddress({{",
+                account_name
+            )
+            .expect("write to String");
+            out.push_str("      programAddress: PROGRAM_ADDRESS,\n");
+            out.push_str("      seeds: [\n");
+            write_inline_pda_seed_lines(out, seeds, target, arg_types, account_expr);
+            out.push_str("      ],\n");
+            out.push_str("    }))[0];\n");
+        }
+    }
+}
+
+fn write_inline_pda_seed_lines(
+    out: &mut String,
+    seeds: &[IdlSeed],
+    target: TsTarget,
+    arg_types: &HashMap<String, IdlType>,
+    account_expr: &impl Fn(&str) -> String,
+) {
+    for seed in seeds {
+        match seed {
+            IdlSeed::Const { value } => write_byte_array(out, value),
+            IdlSeed::Account { path } => match target {
+                TsTarget::Web3js => {
+                    writeln!(out, "        {}.toBytes(),", account_expr(path))
+                        .expect("write to String");
+                }
+                TsTarget::Kit => {
+                    writeln!(
+                        out,
+                        "        getAddressCodec().encode({}),",
+                        account_expr(path)
+                    )
+                    .expect("write to String");
+                }
+            },
+            IdlSeed::Arg { path } => {
+                let expr = arg_types
+                    .get(path)
+                    .map(|ty| ts_pda_arg_seed_expr(&format!("input.{path}"), ty, target))
+                    .unwrap_or_else(|| format!("input.{path}"));
+                writeln!(out, "        {},", expr).expect("write to String");
+            }
+        }
+    }
+}
+
+fn instruction_arg_types(ix: &crate::types::IdlInstruction) -> HashMap<String, IdlType> {
+    ix.args
+        .iter()
+        .map(|arg| (arg.name.clone(), arg.ty.clone()))
+        .collect()
+}
+
+fn pda_arg_types(pda: &PdaInfo) -> HashMap<String, IdlType> {
+    pda.params
+        .iter()
+        .filter_map(|param| match &param.ty {
+            PdaParamType::Arg(ty) => Some((param.name.clone(), ty.clone())),
+            PdaParamType::Account => None,
+        })
+        .collect()
+}
+
+fn pda_is_exportable(seeds: &[IdlSeed], arg_types: &HashMap<String, IdlType>) -> bool {
+    seeds.iter().all(|seed| match seed {
+        IdlSeed::Const { .. } => true,
+        IdlSeed::Account { path } => is_identifier(path),
+        IdlSeed::Arg { path } => is_identifier(path) && arg_types.contains_key(path),
+    })
+}
+
+fn is_identifier(path: &str) -> bool {
+    let mut chars = path.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn ts_pda_arg_seed_expr(expr: &str, ty: &IdlType, target: TsTarget) -> String {
+    match ty {
+        IdlType::Primitive(p) => match p.as_str() {
+            "pubkey" => match target {
+                TsTarget::Web3js => format!("{expr}.toBytes()"),
+                TsTarget::Kit => format!("getAddressCodec().encode({expr})"),
+            },
+            "u8" => format!("getU8Codec().encode({expr})"),
+            "u16" => format!("getU16Codec().encode({expr})"),
+            "u32" => format!("getU32Codec().encode({expr})"),
+            "u64" => format!("getU64Codec().encode({expr})"),
+            "u128" => format!("getU128Codec().encode({expr})"),
+            "i8" => format!("getI8Codec().encode({expr})"),
+            "i16" => format!("getI16Codec().encode({expr})"),
+            "i32" => format!("getI32Codec().encode({expr})"),
+            "i64" => format!("getI64Codec().encode({expr})"),
+            "i128" => format!("getI128Codec().encode({expr})"),
+            "bool" => format!("getBooleanCodec().encode({expr})"),
+            other if other.starts_with('[') => expr.to_string(),
+            _ => expr.to_string(),
+        },
+        _ => expr.to_string(),
     }
 }
 

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -823,11 +823,11 @@ fn rust_codegen_account_metas() {
 // Instruction codegen: dynamic types use wrapper types
 //
 // This is the critical wire compatibility test. String<N> maps to
-// DynBytes<u8> (u8 prefix) and Vec<T, N> maps to DynVec<T, u16> (u16 prefix).
+// DynString<u8> (u8 prefix) and Vec<T, N> maps to DynVec<T, u16> (u16 prefix).
 // ---------------------------------------------------------------------------
 
 #[test]
-fn rust_codegen_dynamic_string_uses_dyn_bytes() {
+fn rust_codegen_dynamic_string_uses_dyn_string() {
     let file = parse_file(
         r#"
         #[program]
@@ -846,8 +846,8 @@ fn rust_codegen_dynamic_string_uses_dyn_bytes() {
     let code = all_content(&files);
 
     assert!(
-        code.contains("pub name: DynBytes<u8>,"),
-        "String<N> must map to DynBytes<u8>, got:\n{code}"
+        code.contains("pub name: DynString<u8>,"),
+        "String<N> must map to DynString<u8>, got:\n{code}"
     );
     assert!(
         !code.contains("pub name: Vec<u8>"),
@@ -876,8 +876,8 @@ fn rust_codegen_dynamic_types_import() {
 
     // Only the actually-used wrapper type is imported
     assert!(
-        code.contains("DynBytes"),
-        "DynBytes must be imported: {code}"
+        code.contains("DynString"),
+        "DynString must be imported: {code}"
     );
     assert!(
         !code.contains("DynVec"),
@@ -897,7 +897,7 @@ fn rust_codegen_dynamic_types_import() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn rust_codegen_dyn_bytes_u8_prefix() {
+fn rust_codegen_dyn_string_u8_prefix() {
     let file = parse_file(
         r#"
         #[program]
@@ -916,8 +916,8 @@ fn rust_codegen_dyn_bytes_u8_prefix() {
     let code = all_content(&files);
 
     assert!(
-        code.contains("pub name: DynBytes<u8>,"),
-        "String<N> must map to DynBytes<u8>, got:\n{code}"
+        code.contains("pub name: DynString<u8>,"),
+        "String<N> must map to DynString<u8>, got:\n{code}"
     );
 }
 

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -1554,6 +1554,372 @@ fn ts_codegen_prefix_aware_codecs() {
     );
 }
 
+#[test]
+fn ts_codegen_pda_helpers_are_exported_and_reused() {
+    use quasar_idl::{
+        codegen::typescript::{generate_ts_client, generate_ts_client_kit},
+        parser::build_idl,
+    };
+
+    let mut parsed = test_program();
+    parsed.instructions.push(program::RawInstruction {
+        name: "deposit".to_string(),
+        discriminator: vec![1],
+        accounts_type_name: "Deposit".to_string(),
+        args: vec![],
+        has_remaining: false,
+    });
+    parsed.accounts_structs = vec![RawAccountsStruct {
+        name: "Deposit".to_string(),
+        fields: vec![
+            RawAccountField {
+                name: "vault".to_string(),
+                writable: true,
+                signer: false,
+                pda: Some(RawPda {
+                    seeds: vec![
+                        RawSeed::ByteString(b"vault".to_vec()),
+                        RawSeed::AccountRef("user".to_string()),
+                    ],
+                }),
+                address: None,
+                field_class: FieldClass::Unchecked,
+                inner_type_name: None,
+                constraints: FieldConstraints::default(),
+                seed_type: None,
+            },
+            RawAccountField {
+                name: "user".to_string(),
+                writable: false,
+                signer: true,
+                pda: None,
+                address: None,
+                field_class: FieldClass::Unchecked,
+                inner_type_name: None,
+                constraints: FieldConstraints::default(),
+                seed_type: None,
+            },
+        ],
+    }];
+
+    let idl = build_idl(&parsed).unwrap();
+
+    let web3 = generate_ts_client(&idl);
+    assert!(
+        web3.contains("export function findVaultAddress(user: Address): Address {"),
+        "{web3}"
+    );
+    assert!(
+        web3.contains("return Address.findProgramAddressSync("),
+        "{web3}"
+    );
+    assert!(
+        web3.contains("accountsMap[\"vault\"] = findVaultAddress(input.user);"),
+        "{web3}"
+    );
+
+    let kit = generate_ts_client_kit(&idl);
+    assert!(
+        kit.contains("export async function findVaultAddress(user: Address): Promise<Address> {"),
+        "{kit}"
+    );
+    assert!(kit.contains("getAddressCodec().encode(user)"), "{kit}");
+    assert!(
+        kit.contains("accountsMap[\"vault\"] = await findVaultAddress(input.user);"),
+        "{kit}"
+    );
+}
+
+#[test]
+fn ts_codegen_pda_arg_seeds_are_encoded_by_type() {
+    use quasar_idl::{
+        codegen::typescript::{generate_ts_client, generate_ts_client_kit},
+        parser::build_idl,
+    };
+
+    let mut parsed = test_program();
+    parsed.instructions.push(program::RawInstruction {
+        name: "deposit".to_string(),
+        discriminator: vec![1],
+        accounts_type_name: "Deposit".to_string(),
+        args: vec![
+            ("authority".to_string(), syn::parse_str("Address").unwrap()),
+            ("index".to_string(), syn::parse_str("u64").unwrap()),
+        ],
+        has_remaining: false,
+    });
+    parsed.accounts_structs = vec![RawAccountsStruct {
+        name: "Deposit".to_string(),
+        fields: vec![RawAccountField {
+            name: "vault".to_string(),
+            writable: true,
+            signer: false,
+            pda: Some(RawPda {
+                seeds: vec![
+                    RawSeed::ByteString(b"vault".to_vec()),
+                    RawSeed::ArgRef("authority".to_string()),
+                    RawSeed::ArgRef("index".to_string()),
+                ],
+            }),
+            address: None,
+            field_class: FieldClass::Unchecked,
+            inner_type_name: None,
+            constraints: FieldConstraints::default(),
+            seed_type: None,
+        }],
+    }];
+
+    let idl = build_idl(&parsed).unwrap();
+
+    let web3 = generate_ts_client(&idl);
+    assert!(
+        web3.contains(
+            "export function findVaultAddress(authority: Address, index: bigint): Address {"
+        ),
+        "{web3}"
+    );
+    assert!(web3.contains("authority.toBytes()"), "{web3}");
+    assert!(web3.contains("getU64Codec().encode(index)"), "{web3}");
+    assert!(
+        web3.contains("accountsMap[\"vault\"] = findVaultAddress(input.authority, input.index);"),
+        "{web3}"
+    );
+
+    let kit = generate_ts_client_kit(&idl);
+    assert!(
+        kit.contains(
+            "export async function findVaultAddress(authority: Address, index: bigint): \
+             Promise<Address> {"
+        ),
+        "{kit}"
+    );
+    assert!(kit.contains("getAddressCodec().encode(authority)"), "{kit}");
+    assert!(kit.contains("getU64Codec().encode(index)"), "{kit}");
+    assert!(
+        kit.contains(
+            "accountsMap[\"vault\"] = await findVaultAddress(input.authority, input.index);"
+        ),
+        "{kit}"
+    );
+}
+
+#[test]
+fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
+    use quasar_idl::{codegen::typescript::generate_ts_client_kit, parser::build_idl};
+
+    let mut parsed = test_program();
+    parsed.instructions.extend([
+        program::RawInstruction {
+            name: "deposit".to_string(),
+            discriminator: vec![1],
+            accounts_type_name: "Deposit".to_string(),
+            args: vec![],
+            has_remaining: false,
+        },
+        program::RawInstruction {
+            name: "withdraw".to_string(),
+            discriminator: vec![2],
+            accounts_type_name: "Withdraw".to_string(),
+            args: vec![],
+            has_remaining: false,
+        },
+    ]);
+    parsed.accounts_structs = vec![
+        RawAccountsStruct {
+            name: "Deposit".to_string(),
+            fields: vec![
+                RawAccountField {
+                    name: "vault".to_string(),
+                    writable: true,
+                    signer: false,
+                    pda: Some(RawPda {
+                        seeds: vec![
+                            RawSeed::ByteString(b"vault".to_vec()),
+                            RawSeed::AccountRef("user".to_string()),
+                        ],
+                    }),
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+                RawAccountField {
+                    name: "user".to_string(),
+                    writable: false,
+                    signer: true,
+                    pda: None,
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+            ],
+        },
+        RawAccountsStruct {
+            name: "Withdraw".to_string(),
+            fields: vec![
+                RawAccountField {
+                    name: "escrow".to_string(),
+                    writable: true,
+                    signer: false,
+                    pda: Some(RawPda {
+                        seeds: vec![
+                            RawSeed::ByteString(b"vault".to_vec()),
+                            RawSeed::AccountRef("user".to_string()),
+                        ],
+                    }),
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+                RawAccountField {
+                    name: "user".to_string(),
+                    writable: false,
+                    signer: true,
+                    pda: None,
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+            ],
+        },
+    ];
+
+    let idl = build_idl(&parsed).unwrap();
+    let kit = generate_ts_client_kit(&idl);
+
+    assert_eq!(
+        kit.matches("export async function findVaultAddress")
+            .count(),
+        1,
+        "{kit}"
+    );
+    assert!(
+        kit.contains("accountsMap[\"vault\"] = await findVaultAddress(input.user);"),
+        "{kit}"
+    );
+    assert!(
+        kit.contains("accountsMap[\"escrow\"] = await findVaultAddress(input.user);"),
+        "{kit}"
+    );
+    assert!(!kit.contains("findEscrowAddress"), "{kit}");
+}
+
+#[test]
+fn ts_codegen_helper_name_collisions_are_disambiguated() {
+    use quasar_idl::{codegen::typescript::generate_ts_client_kit, parser::build_idl};
+
+    let mut parsed = test_program();
+    parsed.instructions.extend([
+        program::RawInstruction {
+            name: "deposit".to_string(),
+            discriminator: vec![1],
+            accounts_type_name: "Deposit".to_string(),
+            args: vec![],
+            has_remaining: false,
+        },
+        program::RawInstruction {
+            name: "settle".to_string(),
+            discriminator: vec![2],
+            accounts_type_name: "Settle".to_string(),
+            args: vec![],
+            has_remaining: false,
+        },
+    ]);
+    parsed.accounts_structs = vec![
+        RawAccountsStruct {
+            name: "Deposit".to_string(),
+            fields: vec![
+                RawAccountField {
+                    name: "vault".to_string(),
+                    writable: true,
+                    signer: false,
+                    pda: Some(RawPda {
+                        seeds: vec![
+                            RawSeed::ByteString(b"vault".to_vec()),
+                            RawSeed::AccountRef("user".to_string()),
+                        ],
+                    }),
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+                RawAccountField {
+                    name: "user".to_string(),
+                    writable: false,
+                    signer: true,
+                    pda: None,
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+            ],
+        },
+        RawAccountsStruct {
+            name: "Settle".to_string(),
+            fields: vec![
+                RawAccountField {
+                    name: "vault".to_string(),
+                    writable: true,
+                    signer: false,
+                    pda: Some(RawPda {
+                        seeds: vec![
+                            RawSeed::ByteString(b"vault-secondary".to_vec()),
+                            RawSeed::AccountRef("user".to_string()),
+                        ],
+                    }),
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+                RawAccountField {
+                    name: "user".to_string(),
+                    writable: false,
+                    signer: true,
+                    pda: None,
+                    address: None,
+                    field_class: FieldClass::Unchecked,
+                    inner_type_name: None,
+                    constraints: FieldConstraints::default(),
+                    seed_type: None,
+                },
+            ],
+        },
+    ];
+
+    let idl = build_idl(&parsed).unwrap();
+    let kit = generate_ts_client_kit(&idl);
+
+    assert!(
+        kit.contains("export async function findVaultAddress(user: Address): Promise<Address> {"),
+        "{kit}"
+    );
+    assert!(
+        kit.contains("export async function findVaultAddress2(user: Address): Promise<Address> {"),
+        "{kit}"
+    );
+    assert!(
+        kit.contains("accountsMap[\"vault\"] = await findVaultAddress(input.user);"),
+        "{kit}"
+    );
+    assert!(
+        kit.contains("accountsMap[\"vault\"] = await findVaultAddress2(input.user);"),
+        "{kit}"
+    );
+}
+
 // ===========================================================================
 // IDL JSON serialization
 // ===========================================================================


### PR DESCRIPTION
## Summary

This PR improves generated client ergonomics across both Rust and TypeScript.

It closes the remaining gap from `String<N>` instruction args in the Rust client and adds exported PDA helpers to the generated TypeScript clients, with a follow-up hardening pass so the helper architecture stays correct when PDA definitions get reused or collide.

## What Changed

### 1. Generated Rust clients now use `DynString` for `String<N>` instruction args

Rust client codegen now maps dynamic string instruction arguments to `DynString<...>` instead of `DynBytes<...>`.

That preserves the same wire format while restoring string-native ergonomics at the generated API surface.

### 2. Generated TypeScript clients now export PDA helpers

The TypeScript generators now emit standalone PDA helper functions and reuse them inside instruction builders instead of inlining the same PDA derivation logic everywhere.

This makes the generated clients easier to use for account fetching and manual transaction assembly.

### 3. PDA helper generation was hardened beyond the original feature request

The helper export path now handles a few correctness edges that would otherwise turn into generator drift later:

- typed PDA instruction-arg seeds are encoded by type instead of being treated as pre-serialized bytes
- duplicate PDA seed sets reuse a single exported helper
- helper-name collisions are disambiguated
- non-exportable/complex seed shapes stay on the inline derivation path instead of being forced through an unsafe helper API

## Validation

Commands run:

- `cargo test -p quasar-idl`
- `cargo clippy -p quasar-idl --all-targets -- -D warnings`
- `cargo fmt --check`

Closes #143
Closes #154
