### PR TITLE
Fix: Go/Python clients accidental overwrite

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -59,6 +59,8 @@ pub fn generate_clients(
     languages: &[&str],
     clients_path: &Path,
 ) -> CliResult {
+    let client_name = idl.metadata.client_name();
+
     // TypeScript
     if languages.contains(&"typescript") {
         let ts_code = codegen::typescript::generate_ts_client(idl);
@@ -66,7 +68,7 @@ pub fn generate_clients(
 
         let ts_dir = PathBuf::from(clients_path)
             .join("typescript")
-            .join(&idl.metadata.name);
+            .join(client_name);
         std::fs::create_dir_all(&ts_dir)?;
         std::fs::write(ts_dir.join("web3.ts"), &ts_code)?;
         std::fs::write(ts_dir.join("kit.ts"), &ts_kit_code)?;
@@ -80,7 +82,7 @@ pub fn generate_clients(
         };
         let ts_package_json = format!(
             r#"{{
-  "name": "{crate_name}-client",
+  "name": "{client_name}-client",
   "version": "{version}",
   "private": true,
   "exports": {{
@@ -93,7 +95,7 @@ pub fn generate_clients(
   }}
 }}
 "#,
-            crate_name = idl.metadata.name,
+            client_name = client_name,
             version = idl.metadata.version,
         );
         std::fs::write(ts_dir.join("package.json"), &ts_package_json)?;
@@ -104,7 +106,7 @@ pub fn generate_clients(
         let py_code = codegen::python::generate_python_client(idl);
         let py_dir = PathBuf::from(clients_path)
             .join("python")
-            .join(&idl.metadata.name);
+            .join(client_name);
         std::fs::create_dir_all(&py_dir)?;
         std::fs::write(py_dir.join("client.py"), &py_code)?;
         std::fs::write(
@@ -116,7 +118,7 @@ pub fn generate_clients(
     // Go
     if languages.contains(&"golang") {
         let go_code = codegen::golang::generate_go_client(idl);
-        let go_pkg = idl.metadata.name.replace('-', "_");
+        let go_pkg = client_name.replace('-', "_");
         let go_dir = PathBuf::from(clients_path).join("golang").join(&go_pkg);
         std::fs::create_dir_all(&go_dir)?;
         std::fs::write(go_dir.join("client.go"), &go_code)?;

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -93,7 +93,7 @@ pub fn generate_clients(
   }}
 }}
 "#,
-            crate_name = idl.metadata.crate_name,
+            crate_name = idl.metadata.name,
             version = idl.metadata.version,
         );
         std::fs::write(ts_dir.join("package.json"), &ts_package_json)?;
@@ -104,7 +104,7 @@ pub fn generate_clients(
         let py_code = codegen::python::generate_python_client(idl);
         let py_dir = PathBuf::from(clients_path)
             .join("python")
-            .join(&idl.metadata.crate_name);
+            .join(&idl.metadata.name);
         std::fs::create_dir_all(&py_dir)?;
         std::fs::write(py_dir.join("client.py"), &py_code)?;
         std::fs::write(
@@ -116,7 +116,7 @@ pub fn generate_clients(
     // Go
     if languages.contains(&"golang") {
         let go_code = codegen::golang::generate_go_client(idl);
-        let go_pkg = idl.metadata.crate_name.replace('-', "_");
+        let go_pkg = idl.metadata.name.replace('-', "_");
         let go_dir = PathBuf::from(clients_path).join("golang").join(&go_pkg);
         std::fs::create_dir_all(&go_dir)?;
         std::fs::write(go_dir.join("client.go"), &go_code)?;

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -9,12 +9,7 @@ use {
 /// Uses `gagliardetto/solana-go` for Solana types (PublicKey, Instruction,
 /// AccountMeta).
 pub fn generate_go_client(idl: &Idl) -> String {
-    let raw = if idl.metadata.crate_name.is_empty() {
-        &idl.metadata.name
-    } else {
-        &idl.metadata.crate_name
-    };
-    let pkg_name = raw.replace('-', "_");
+    let pkg_name = idl.metadata.client_name().replace('-', "_");
     let mut out = String::new();
 
     // Package + imports

--- a/idl/src/codegen/golang.rs
+++ b/idl/src/codegen/golang.rs
@@ -9,7 +9,12 @@ use {
 /// Uses `gagliardetto/solana-go` for Solana types (PublicKey, Instruction,
 /// AccountMeta).
 pub fn generate_go_client(idl: &Idl) -> String {
-    let pkg_name = idl.metadata.crate_name.replace('-', "_");
+    let raw = if idl.metadata.crate_name.is_empty() {
+        &idl.metadata.name
+    } else {
+        &idl.metadata.crate_name
+    };
+    let pkg_name = raw.replace('-', "_");
     let mut out = String::new();
 
     // Package + imports

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -142,6 +142,16 @@ pub struct IdlMetadata {
     pub spec: String,
 }
 
+impl IdlMetadata {
+    pub fn client_name(&self) -> &str {
+        if self.crate_name.is_empty() {
+            &self.name
+        } else {
+            &self.crate_name
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct IdlInstruction {
     pub name: String,


### PR DESCRIPTION
Resolves #167 

- Changed the Python/Go output dir paths from `idl.metadata.crate_name` to `idl.metadata.name`
- Added a fallback in `generate_go_client` so `metadata.name` is used when `crate_name` is empty

Another side issue observed was that `package.json` names would fallthru to "-client" due to an absence of the name (similar issue to the above). This was fixed by changing the TS `package.json` name template from `crate_name` to `name`
