### PR TITLE
feat(derive): QuasarSerialize for `#[repr(u8)]` unit enums

### DIFF
--- a/derive/src/serialize.rs
+++ b/derive/src/serialize.rs
@@ -9,6 +9,15 @@
 //! 1. An `InstructionArgDecode<'a>` impl with a fixed-header batch + sequential
 //!    variable-length reads. Reference fields require `#[max(N)]`.
 //! 2. No ZC companion or `InstructionArg` impl (not `Copy`).
+//!
+//! **Unit enums** (`#[repr(u8)]` with all-unit variants):
+//! 1. An `InstructionArg` impl with `Zc = u8`. `validate_zc` rejects tag bytes
+//!    that don't correspond to a declared variant; `from_zc` matches the tag
+//!    back to the variant (using `unreachable_unchecked` on the default arm,
+//!    since `validate_zc` gates it).
+//! 2. Off-chain `SchemaWrite` / `SchemaRead` impls that pass the single
+//!    discriminant byte through, rejecting unknown tags with
+//!    `wincode::error::ReadError::InvalidTagEncoding`.
 
 use {
     proc_macro::TokenStream,
@@ -35,10 +44,11 @@ pub(crate) fn derive_quasar_serialize(input: TokenStream) -> TokenStream {
                 .into();
             }
         },
-        _ => {
+        Data::Enum(_) => return derive_unit_enum(input),
+        Data::Union(_) => {
             return syn::Error::new_spanned(
                 &input.ident,
-                "QuasarSerialize can only be derived for structs",
+                "QuasarSerialize cannot be derived for unions",
             )
             .to_compile_error()
             .into();
@@ -501,4 +511,198 @@ fn derive_borrowed(input: DeriveInput, fields: Vec<Field>) -> TokenStream {
     };
 
     expanded.into()
+}
+
+// ---------------------------------------------------------------------------
+// Unit-enum path (`#[repr(u8)]` with all-unit variants)
+// ---------------------------------------------------------------------------
+
+fn derive_unit_enum(input: DeriveInput) -> TokenStream {
+    let name = &input.ident;
+
+    // Unit enums cannot take generic parameters — the `Zc = u8` mapping
+    // relies on a stable, parameter-free discriminant layout.
+    if !input.generics.params.is_empty() {
+        return syn::Error::new_spanned(
+            &input.generics,
+            "QuasarSerialize: enums with generic parameters are not supported",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // Require `#[repr(u8)]`. The implementation emits `*self as u8`, which
+    // only produces a well-defined discriminant when the enum's layout is
+    // fixed to a 1-byte primitive.
+    if !has_repr_u8(&input.attrs) {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "QuasarSerialize: enums must be declared `#[repr(u8)]`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let data_enum = match &input.data {
+        Data::Enum(e) => e,
+        // Unreachable: caller checked `Data::Enum` before dispatching here.
+        _ => unreachable!("derive_unit_enum only called on Data::Enum"),
+    };
+
+    if data_enum.variants.is_empty() {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "QuasarSerialize: enums must have at least one variant",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // Collect variant idents, enforcing unit-only. Variants with fields
+    // cannot be represented by a single discriminant byte.
+    let mut variant_idents: Vec<&Ident> = Vec::with_capacity(data_enum.variants.len());
+    for v in &data_enum.variants {
+        match &v.fields {
+            Fields::Unit => variant_idents.push(&v.ident),
+            _ => {
+                return syn::Error::new_spanned(
+                    &v.ident,
+                    "QuasarSerialize: only unit variants are supported on `#[repr(u8)]` enums",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
+
+    // `from_zc` arms pair each variant with `*self as u8`. Building the
+    // match as `x if x == Self::Variant as u8 => Self::Variant` keeps the
+    // match driven by the declared discriminants — explicit (`Buy = 7`) or
+    // implicit (0, 1, 2, …) — without the macro having to read them.
+    let from_zc_arms: Vec<TokenStream2> = variant_idents
+        .iter()
+        .map(|v| {
+            quote! { __tag if __tag == Self::#v as u8 => Self::#v, }
+        })
+        .collect();
+    let validate_arms: Vec<TokenStream2> = variant_idents
+        .iter()
+        .map(|v| {
+            quote! { __tag if __tag == Self::#v as u8 => Ok(()), }
+        })
+        .collect();
+    let schema_read_arms: Vec<TokenStream2> = variant_idents
+        .iter()
+        .map(|v| {
+            quote! { __tag if __tag == Self::#v as u8 => Self::#v, }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl quasar_lang::instruction_arg::InstructionArg for #name {
+            type Zc = u8;
+
+            #[inline(always)]
+            fn from_zc(zc: &u8) -> Self {
+                match *zc {
+                    #(#from_zc_arms)*
+                    // SAFETY: `validate_zc` is called by `#[instruction]`
+                    // codegen before `from_zc` on every untrusted decode
+                    // path, and it rejects every tag that does not map to
+                    // a declared variant.
+                    _ => unsafe { core::hint::unreachable_unchecked() },
+                }
+            }
+
+            #[inline(always)]
+            fn to_zc(&self) -> u8 {
+                *self as u8
+            }
+
+            #[inline(always)]
+            fn validate_zc(zc: &u8) -> Result<(), quasar_lang::prelude::ProgramError> {
+                match *zc {
+                    #(#validate_arms)*
+                    _ => Err(quasar_lang::prelude::ProgramError::InvalidInstructionData),
+                }
+            }
+        }
+
+        // Off-chain wincode codec — write the single discriminant byte and
+        // read it back, rejecting unknown tags with the canonical
+        // `InvalidTagEncoding` error.
+        //
+        // Paths are routed through the `quasar_lang::client::wincode`
+        // re-export so downstream crates that derive `QuasarSerialize`
+        // on an enum only need `quasar-lang` as a dependency.
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+        unsafe impl<__C: quasar_lang::client::wincode::config::ConfigCore>
+            quasar_lang::client::wincode::SchemaWrite<__C> for #name
+        {
+            type Src = Self;
+
+            fn size_of(
+                _src: &Self,
+            ) -> quasar_lang::client::wincode::error::WriteResult<usize> {
+                Ok(1)
+            }
+
+            fn write(
+                mut __writer: impl quasar_lang::client::wincode::io::Writer,
+                src: &Self,
+            ) -> quasar_lang::client::wincode::error::WriteResult<()> {
+                __writer.write(&[*src as u8])?;
+                Ok(())
+            }
+        }
+
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+        unsafe impl<'__de, __C: quasar_lang::client::wincode::config::ConfigCore>
+            quasar_lang::client::wincode::SchemaRead<'__de, __C> for #name
+        {
+            type Dst = Self;
+
+            fn read(
+                mut __reader: impl quasar_lang::client::wincode::io::Reader<'__de>,
+                __dst: &mut core::mem::MaybeUninit<Self>,
+            ) -> quasar_lang::client::wincode::error::ReadResult<()> {
+                let __bytes = __reader.take_scoped(1)?;
+                let __variant = match __bytes[0] {
+                    #(#schema_read_arms)*
+                    __tag => {
+                        return Err(
+                            quasar_lang::client::wincode::error::invalid_tag_encoding(
+                                __tag as usize,
+                            ),
+                        );
+                    }
+                };
+                __dst.write(__variant);
+                Ok(())
+            }
+        }
+    };
+
+    expanded.into()
+}
+
+/// Return `true` if the attributes contain a `#[repr(u8)]` (possibly among
+/// other repr hints, e.g. `#[repr(C, u8)]`).
+fn has_repr_u8(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("u8") {
+                found = true;
+            }
+            Ok(())
+        });
+        if found {
+            return true;
+        }
+    }
+    false
 }

--- a/lang/tests/compile_fail/enum_empty.rs
+++ b/lang/tests/compile_fail/enum_empty.rs
@@ -1,0 +1,12 @@
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// An enum with zero variants has no inhabited value for `validate_zc`
+// to ever accept, so the derive must reject it up-front rather than
+// emitting code that is impossible to exercise.
+#[repr(u8)]
+#[derive(QuasarSerialize)]
+pub enum Empty {}
+
+fn main() {}

--- a/lang/tests/compile_fail/enum_empty.stderr
+++ b/lang/tests/compile_fail/enum_empty.stderr
@@ -1,0 +1,14 @@
+error: QuasarSerialize: enums must have at least one variant
+  --> tests/compile_fail/enum_empty.rs:10:10
+   |
+10 | pub enum Empty {}
+   |          ^^^^^
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> tests/compile_fail/enum_empty.rs:8:8
+   |
+ 8 | #[repr(u8)]
+   |        ^^
+ 9 | #[derive(QuasarSerialize)]
+10 | pub enum Empty {}
+   | -------------- zero-variant enum

--- a/lang/tests/compile_fail/enum_with_fields.rs
+++ b/lang/tests/compile_fail/enum_with_fields.rs
@@ -1,0 +1,15 @@
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// Enum with non-unit variants cannot be encoded as a single discriminant
+// byte, so the derive must reject it rather than silently dropping the
+// payload.
+#[repr(u8)]
+#[derive(QuasarSerialize)]
+pub enum Command {
+    Ping,
+    Transfer { amount: u64 },
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/enum_with_fields.stderr
+++ b/lang/tests/compile_fail/enum_with_fields.stderr
@@ -1,0 +1,5 @@
+error: QuasarSerialize: only unit variants are supported on `#[repr(u8)]` enums
+  --> tests/compile_fail/enum_with_fields.rs:12:5
+   |
+12 |     Transfer { amount: u64 },
+   |     ^^^^^^^^

--- a/lang/tests/compile_fail/enum_with_generic.rs
+++ b/lang/tests/compile_fail/enum_with_generic.rs
@@ -1,0 +1,14 @@
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// The derive pins `Zc = u8` for the whole type, so a generic enum has
+// no single discriminant layout to serialize and must be rejected.
+#[repr(u8)]
+#[derive(QuasarSerialize)]
+pub enum Wrapper<T> {
+    None,
+    _Phantom(core::marker::PhantomData<T>),
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/enum_with_generic.stderr
+++ b/lang/tests/compile_fail/enum_with_generic.stderr
@@ -1,0 +1,5 @@
+error: QuasarSerialize: enums with generic parameters are not supported
+ --> tests/compile_fail/enum_with_generic.rs:9:17
+  |
+9 | pub enum Wrapper<T> {
+  |                 ^^^

--- a/lang/tests/compile_fail/enum_without_repr_u8.rs
+++ b/lang/tests/compile_fail/enum_without_repr_u8.rs
@@ -1,0 +1,13 @@
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// Enum without `#[repr(u8)]` — must be rejected because `*self as u8`
+// is only well-defined when the enum is fixed to a 1-byte primitive.
+#[derive(QuasarSerialize)]
+pub enum Side {
+    Bid,
+    Ask,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/enum_without_repr_u8.stderr
+++ b/lang/tests/compile_fail/enum_without_repr_u8.stderr
@@ -1,0 +1,5 @@
+error: QuasarSerialize: enums must be declared `#[repr(u8)]`
+ --> tests/compile_fail/enum_without_repr_u8.rs:8:10
+  |
+8 | pub enum Side {
+  |          ^^^^

--- a/lang/tests/compile_pass/instruction_enum_arg.rs
+++ b/lang/tests/compile_pass/instruction_enum_arg.rs
@@ -1,0 +1,44 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+/// Explicit, non-contiguous discriminants — the common "wire format"
+/// shape where two sides of an exchange need stable on-chain tags.
+#[repr(u8)]
+#[derive(Copy, Clone, QuasarSerialize)]
+pub enum Side {
+    Bid = 7,
+    Ask = 42,
+}
+
+/// Implicit discriminants (the `0, 1, 2, ...` shape) — exercises the
+/// `*self as u8` path without the user writing explicit tags.
+#[repr(u8)]
+#[derive(Copy, Clone, QuasarSerialize)]
+pub enum Priority {
+    Low,
+    Normal,
+    High,
+}
+
+#[derive(Accounts)]
+pub struct PlaceOrder {
+    pub authority: Signer,
+}
+
+#[program]
+mod test_program {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn place_order(
+        _ctx: Ctx<PlaceOrder>,
+        _side: Side,
+        _priority: Priority,
+    ) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/instruction_arg.rs
+++ b/lang/tests/instruction_arg.rs
@@ -328,3 +328,144 @@ fn podvec_zc_is_self() {
         1
     );
 }
+
+// ---------------------------------------------------------------------------
+// `#[repr(u8)]` unit enum as InstructionArg
+//
+// Two shapes are covered:
+// * `Side` uses explicit, non-contiguous discriminants (`Bid=7`, `Ask=42`),
+//   which exercises the `*self as u8` / tag-equality generation without relying
+//   on an implicit 0, 1 layout.
+// * `Priority` uses the implicit `0, 1, 2, ...` layout, which is the most
+//   common form users will write.
+// ---------------------------------------------------------------------------
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, quasar_lang::prelude::QuasarSerialize)]
+enum Side {
+    Bid = 7,
+    Ask = 42,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, quasar_lang::prelude::QuasarSerialize)]
+enum Priority {
+    Low,
+    Normal,
+    High,
+}
+
+#[test]
+fn unit_enum_zc_is_u8() {
+    assert_eq!(core::mem::size_of::<<Side as InstructionArg>::Zc>(), 1);
+    assert_eq!(core::mem::align_of::<<Side as InstructionArg>::Zc>(), 1);
+    assert_eq!(core::mem::size_of::<<Priority as InstructionArg>::Zc>(), 1);
+}
+
+#[test]
+fn unit_enum_explicit_disc_round_trip() {
+    for &v in &[Side::Bid, Side::Ask] {
+        let zc = v.to_zc();
+        assert_eq!(zc, v as u8);
+        assert_eq!(Side::from_zc(&zc), v);
+    }
+}
+
+#[test]
+fn unit_enum_implicit_disc_round_trip() {
+    let cases = [
+        (Priority::Low, 0u8),
+        (Priority::Normal, 1),
+        (Priority::High, 2),
+    ];
+    for &(v, raw) in &cases {
+        let zc = v.to_zc();
+        assert_eq!(zc, raw, "to_zc must match implicit discriminant");
+        assert_eq!(Priority::from_zc(&zc), v);
+    }
+}
+
+#[test]
+fn unit_enum_validate_accepts_declared_tags() {
+    assert!(Side::validate_zc(&7).is_ok());
+    assert!(Side::validate_zc(&42).is_ok());
+    for tag in [0u8, 1, 2, 3] {
+        assert!(Priority::validate_zc(&tag).is_ok() == (tag <= 2));
+    }
+}
+
+#[test]
+fn unit_enum_validate_rejects_undeclared_tags() {
+    // Side only declares 7 and 42; every other byte must be rejected, and
+    // the error must be InvalidInstructionData so that on-chain decoding
+    // fails deterministically before `from_zc` runs.
+    for tag in 0u8..=255u8 {
+        let declared = matches!(tag, 7 | 42);
+        let res = Side::validate_zc(&tag);
+        assert_eq!(
+            res.is_ok(),
+            declared,
+            "tag={tag} declared={declared} res={res:?}"
+        );
+        if !declared {
+            assert!(matches!(
+                res,
+                Err(quasar_lang::prelude::ProgramError::InvalidInstructionData)
+            ));
+        }
+    }
+}
+
+#[test]
+fn unit_enum_wincode_wire_is_single_byte() {
+    use quasar_lang::client::wincode;
+
+    let bid = wincode::serialize(&Side::Bid).unwrap();
+    assert_eq!(bid, [7u8]);
+
+    let ask = wincode::serialize(&Side::Ask).unwrap();
+    assert_eq!(ask, [42u8]);
+
+    let high = wincode::serialize(&Priority::High).unwrap();
+    assert_eq!(high, [2u8]);
+}
+
+#[test]
+fn unit_enum_wincode_round_trip() {
+    use quasar_lang::client::wincode;
+
+    for &v in &[Side::Bid, Side::Ask] {
+        let wire = wincode::serialize(&v).unwrap();
+        let back: Side = wincode::deserialize(&wire).unwrap();
+        assert_eq!(back, v);
+    }
+    for &v in &[Priority::Low, Priority::Normal, Priority::High] {
+        let wire = wincode::serialize(&v).unwrap();
+        let back: Priority = wincode::deserialize(&wire).unwrap();
+        assert_eq!(back, v);
+    }
+}
+
+#[test]
+fn unit_enum_wincode_rejects_unknown_tag() {
+    use quasar_lang::client::wincode;
+
+    // Side accepts only 7 and 42 — every other byte must surface as
+    // `InvalidTagEncoding`, matching the error wincode uses for its own
+    // derived enums and untagged unions.
+    for tag in [0u8, 1, 6, 8, 41, 43, 0xFF] {
+        let err = wincode::deserialize::<Side>(&[tag]).unwrap_err();
+        assert!(
+            matches!(err, wincode::error::ReadError::InvalidTagEncoding(t) if t == tag as usize),
+            "tag={tag} err={err:?}"
+        );
+    }
+}
+
+#[test]
+fn unit_enum_wincode_rejects_truncated_input() {
+    use quasar_lang::client::wincode;
+
+    // An empty buffer cannot contain even the 1-byte tag.
+    assert!(wincode::deserialize::<Side>(&[]).is_err());
+}

--- a/tests/programs/test-misc/src/instructions/enum_check.rs
+++ b/tests/programs/test-misc/src/instructions/enum_check.rs
@@ -1,0 +1,25 @@
+use {
+    crate::state::{Priority, Side},
+    quasar_lang::prelude::*,
+};
+
+#[derive(Accounts)]
+pub struct EnumCheck {
+    pub signer: Signer,
+}
+
+impl EnumCheck {
+    #[inline(always)]
+    pub fn handler(&self, side: Side, priority: Priority) -> Result<(), ProgramError> {
+        // Sentinel values: the happy-path test submits exactly Ask + High.
+        // Any other combination (including mutated explicit-discriminant
+        // bytes that still happen to map to another declared variant)
+        // must fail `require!`, surfacing as `InvalidInstructionData`.
+        require!(side == Side::Ask, ProgramError::InvalidInstructionData);
+        require!(
+            priority == Priority::High,
+            ProgramError::InvalidInstructionData
+        );
+        Ok(())
+    }
+}

--- a/tests/programs/test-misc/src/instructions/mod.rs
+++ b/tests/programs/test-misc/src/instructions/mod.rs
@@ -135,3 +135,6 @@ pub use interface_migration_check::*;
 
 pub mod dynamic_stack_cache;
 pub use dynamic_stack_cache::*;
+
+pub mod enum_check;
+pub use enum_check::*;

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -304,4 +304,13 @@ mod quasar_test_misc {
     ) -> Result<(), ProgramError> {
         ctx.accounts.handler(new_name)
     }
+
+    #[instruction(discriminator = 58)]
+    pub fn enum_arg_check(
+        ctx: Ctx<EnumCheck>,
+        side: state::Side,
+        priority: state::Priority,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler(side, priority)
+    }
 }

--- a/tests/programs/test-misc/src/state.rs
+++ b/tests/programs/test-misc/src/state.rs
@@ -33,6 +33,26 @@ impl InstructionArg for ReturnPayload {
     }
 }
 
+/// Unit enum with explicit, non-contiguous discriminants. Exercises the
+/// `QuasarSerialize` enum derive on a layout where a raw byte not equal
+/// to 7 or 42 must be rejected by `validate_zc`.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, QuasarSerialize)]
+pub enum Side {
+    Bid = 7,
+    Ask = 42,
+}
+
+/// Unit enum with implicit discriminants — exercises the common
+/// `0, 1, 2, ...` layout on the same derive path.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, QuasarSerialize)]
+pub enum Priority {
+    Low,
+    Normal,
+    High,
+}
+
 pub const RETURN_U64_VALUE: u64 = 777;
 pub const RETURN_PAYLOAD_VALUE: ReturnPayload = ReturnPayload {
     amount: 55,

--- a/tests/suite/src/enum_args.rs
+++ b/tests/suite/src/enum_args.rs
@@ -1,0 +1,156 @@
+//! Integration coverage for `#[derive(QuasarSerialize)]` on
+//! `#[repr(u8)]` unit enums. The `enum_arg_check` instruction
+//! (discriminator 58) takes two enum arguments and requires them to be
+//! exactly `Side::Ask` and `Priority::High`.
+//!
+//! Tests are split into two categories:
+//! * Happy-path round-trips through the generated CPI struct, covering both
+//!   explicit (`Side`) and implicit (`Priority`) discriminants.
+//! * Adversarial raw-byte instructions that bypass the CPI struct, to prove
+//!   `validate_zc` rejects bytes outside the declared tag set and truncated
+//!   payloads.
+
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_misc::{
+        cpi::*,
+        state::{Priority, Side},
+    },
+};
+
+const ENUM_CHECK_DISC: u8 = 58;
+
+// ---------------------------------------------------------------------------
+// Happy-path via generated CPI structs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn enum_arg_accepts_expected_variants() {
+    let mut svm = svm_misc();
+    let signer = Pubkey::new_unique();
+    let ix: Instruction = EnumArgCheckInstruction {
+        signer,
+        side: Side::Ask,
+        priority: Priority::High,
+    }
+    .into();
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(
+        result.is_ok(),
+        "Ask + High should satisfy require!: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
+fn enum_arg_rejects_wrong_side() {
+    // Bid is a declared variant (tag = 7) so `validate_zc` passes, but
+    // the handler's `require!` still rejects it — this proves that a
+    // valid tag byte does not imply a valid business-logic argument.
+    let mut svm = svm_misc();
+    let signer = Pubkey::new_unique();
+    let ix: Instruction = EnumArgCheckInstruction {
+        signer,
+        side: Side::Bid,
+        priority: Priority::High,
+    }
+    .into();
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(result.is_err(), "Bid should be rejected by require!");
+}
+
+#[test]
+fn enum_arg_rejects_wrong_priority() {
+    let mut svm = svm_misc();
+    let signer = Pubkey::new_unique();
+    let ix: Instruction = EnumArgCheckInstruction {
+        signer,
+        side: Side::Ask,
+        priority: Priority::Normal,
+    }
+    .into();
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(result.is_err(), "Normal priority should be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial raw-byte instructions
+//
+// Wire format: [disc(58), side_tag: u8, priority_tag: u8]. Side accepts
+// only {7, 42}; Priority accepts only {0, 1, 2}. Any other combination
+// must fail before the handler runs (rejected by `validate_zc`).
+// ---------------------------------------------------------------------------
+
+fn raw_enum_ix(side_tag: u8, priority_tag: u8) -> solana_instruction::Instruction {
+    solana_instruction::Instruction {
+        program_id: quasar_test_misc::ID,
+        accounts: vec![solana_instruction::AccountMeta::new_readonly(
+            Pubkey::new_unique(),
+            true,
+        )],
+        data: vec![ENUM_CHECK_DISC, side_tag, priority_tag],
+    }
+}
+
+#[test]
+fn enum_arg_rejects_undeclared_side_tag() {
+    // Tag 0 is not a declared Side variant — validate_zc must reject.
+    let mut svm = svm_misc();
+    let ix = raw_enum_ix(0, 2);
+    let signer = ix.accounts[0].pubkey;
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(
+        result.is_err(),
+        "side_tag=0 is not a declared variant (only 7 and 42 are)"
+    );
+}
+
+#[test]
+fn enum_arg_rejects_undeclared_side_tag_boundary() {
+    // 6 and 8 flank the `Bid = 7` discriminant; 41 and 43 flank
+    // `Ask = 42`. All four must be rejected, proving `validate_zc` is
+    // checking equality rather than a range.
+    let mut svm = svm_misc();
+    for side_tag in [6u8, 8, 41, 43, 0xFF] {
+        let ix = raw_enum_ix(side_tag, 2);
+        let signer = ix.accounts[0].pubkey;
+        let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+        assert!(
+            result.is_err(),
+            "side_tag={side_tag} must be rejected by validate_zc"
+        );
+    }
+}
+
+#[test]
+fn enum_arg_rejects_undeclared_priority_tag() {
+    // Priority is {Low=0, Normal=1, High=2}; any higher byte must fail.
+    let mut svm = svm_misc();
+    for priority_tag in [3u8, 4, 0x7F, 0xFF] {
+        let ix = raw_enum_ix(42, priority_tag);
+        let signer = ix.accounts[0].pubkey;
+        let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+        assert!(
+            result.is_err(),
+            "priority_tag={priority_tag} must be rejected by validate_zc"
+        );
+    }
+}
+
+#[test]
+fn enum_arg_rejects_truncated_data() {
+    // Only the discriminator + side tag — priority byte missing.
+    let mut svm = svm_misc();
+    let signer = Pubkey::new_unique();
+    let ix = solana_instruction::Instruction {
+        program_id: quasar_test_misc::ID,
+        accounts: vec![solana_instruction::AccountMeta::new_readonly(signer, true)],
+        data: vec![ENUM_CHECK_DISC, 42u8], // Ask, then truncated
+    };
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(
+        result.is_err(),
+        "truncated instruction data (missing priority tag) must fail"
+    );
+}

--- a/tests/suite/src/lib.rs
+++ b/tests/suite/src/lib.rs
@@ -88,6 +88,10 @@ mod test_validate_token;
 #[cfg(test)]
 mod optional_args;
 
+// #[repr(u8)] unit enum instruction args
+#[cfg(test)]
+mod enum_args;
+
 // InterfaceAccount custom Owners
 #[cfg(test)]
 mod test_interface_migration;


### PR DESCRIPTION
Closes #156.

## Summary

Extends `#[derive(QuasarSerialize)]` to accept unit-only enums declared with `#[repr(u8)]`, so enums can be used as instruction arguments alongside structs.

On the happy path the derive emits:

- `impl InstructionArg for Enum` with `Zc = u8`.
  - `to_zc` returns `*self as u8`.
  - `validate_zc` rejects every byte that does not equal one of the declared discriminants, returning `ProgramError::InvalidInstructionData`.
  - `from_zc` matches on the tag using `x if x == Self::Variant as u8 => Self::Variant`. This keeps the match driven by the declared discriminants — explicit (`Buy = 7`) or implicit (`0, 1, 2, ...`) — without the macro having to read them. The catch-all hits `unreachable_unchecked`, which is safe because `#[instruction]` codegen calls `validate_zc` on every untrusted decode path before ever calling `from_zc`.
- Off-chain `wincode::SchemaWrite` / `SchemaRead` that write the single discriminant byte and reject unknown tags with `wincode::error::invalid_tag_encoding`, matching wincode's own convention for derived enums. The impls route through `quasar_lang::client::wincode`, so downstream crates only need `quasar-lang` as a dependency.

## Guardrails

Each of these is covered by a `trybuild` compile-fail snapshot:

- **Missing `#[repr(u8)]`** — `*self as u8` is only well-defined when the layout is pinned to a 1-byte primitive.
- **Non-unit variants** — a single discriminant byte cannot carry a payload.
- **Zero variants** — `validate_zc` would have no inhabited value to accept.
- **Generic parameters** — `Zc = u8` is pinned for the whole type and incompatible with per-instantiation layout.

The existing struct and borrowed-struct paths are unchanged. A `Data::Union(_)` input now returns a clear diagnostic instead of hitting the generic "named fields" error.

## Test coverage

- `lang/tests/instruction_arg.rs` — 9 unit tests: Zc alignment/size, explicit + implicit discriminant round-trip, full 256-byte `validate_zc` sweep, wincode wire-format oracle, wincode round-trip, `InvalidTagEncoding` on unknown tag, truncated-input rejection.
- `lang/tests/compile_pass/instruction_enum_arg.rs` — `#[program]` + `#[instruction]` integration with two enum args.
- `lang/tests/compile_fail/enum_*.rs` — four snapshots for the guardrails.
- `tests/programs/test-misc` — new `enum_arg_check` instruction (discriminator `58`) plus `Side` / `Priority` enums covering explicit and implicit discriminant shapes.
- `tests/suite/src/enum_args.rs` — 7 integration tests: happy path via CPI struct, logic-level rejection of declared-but-wrong variants, `validate_zc`-level rejection of undeclared tag bytes (including discriminant boundaries 6/8/41/43 and `0xFF`), undeclared priority tags (`3`, `4`, `0x7F`, `0xFF`), and truncated instruction data.

## Verification

```bash
cargo +nightly fmt --all -- --check
cargo +nightly clippy -p quasar-derive -p quasar-lang -p quasar-test-misc \
    --all-features --all-targets -- -D warnings
cargo test -p quasar-derive -p quasar-lang
cargo build-sbf --tools-version v1.52 \
    --manifest-path tests/programs/test-misc/Cargo.toml --features debug,alloc
cargo test -p quasar-test-suite enum_args     # 7/7 pass
cargo test -p quasar-test-suite -- \
    optional_args dynamic cpi_return           # 90/90 pass, no regressions
```

## Notes for reviewers

- The wincode impls are gated behind `#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]` and reference `quasar_lang::client::wincode::*` rather than a bare `wincode::*` path. The existing struct derive emits bare `wincode::*`, which silently requires downstream crates to carry `wincode` in their own `Cargo.toml`; the enum path avoids that hidden coupling. Happy to route the struct path through the same re-export in a follow-up if that's preferred.
- The ZC type for an enum is `u8` rather than a generated wrapper. That keeps the on-chain layout trivially alignment-1 and lets the `from_zc` / `validate_zc` match expressions match against `Self::Variant as u8` without the macro ever parsing the discriminant literal.
- IDL enum codegen is intentionally out of scope here — this PR only wires up the instruction-arg side. Happy to follow up once there's consensus on the IDL representation.
