### PR TITLE
feat(schema-canonical): canonical binary encoding of Idl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quasar-schema-canonical"
+version = "0.0.0"
+dependencies = [
+ "quasar-idl",
+ "quasar-schema",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "quasar-spl"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["lang", "derive", "spl", "metadata", "idl", "schema", "profile", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli", "zeropod", "zeropod-derive"]
+members = ["lang", "derive", "spl", "metadata", "idl", "schema", "schema-canonical", "profile", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli", "zeropod", "zeropod-derive"]
 exclude = ["examples/anchor-vault"]
 
 [workspace.package]

--- a/schema-canonical/Cargo.toml
+++ b/schema-canonical/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quasar-schema-canonical"
+description = "Canonical, hash-verified binary encoding of the Quasar IDL"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+name = "quasar_schema_canonical"
+path = "src/lib.rs"
+
+[dependencies]
+quasar-schema = { path = "../schema" }
+sha2 = "0.10"
+
+[dev-dependencies]
+quasar-idl = { path = "../idl" }
+sha2 = "0.10"

--- a/schema-canonical/SPEC.md
+++ b/schema-canonical/SPEC.md
@@ -135,6 +135,12 @@ version              : String
 spec                 : String
 ```
 
+Note: `crate_name` has `#[serde(skip)]` in the JSON representation (it is
+recovered from `Cargo.toml` at build time). The canonical binary encoding
+**does** preserve `crate_name` — the format is strictly more
+information-preserving than the JSON, so `decode(encode(idl))` round-trips
+`crate_name` exactly, whereas a JSON round-trip erases it.
+
 ### 4.3 `IdlInstruction`
 
 ```

--- a/schema-canonical/SPEC.md
+++ b/schema-canonical/SPEC.md
@@ -1,0 +1,246 @@
+# Quasar Canonical IDL Binary Format — v1
+
+This document is the **normative** specification for the canonical binary
+encoding of a `quasar_schema::Idl`. The implementation in `src/` is expected to
+match this spec byte-for-byte.
+
+The goals of the format are:
+
+1. **Compact** — small enough to fit in a rent-funded Solana account.
+2. **Deterministic** — `encode(idl)` is a pure function; the same input always
+   produces the same bytes (and therefore the same digest).
+3. **Hash-verified** — readers can authenticate the payload with a single
+   `sha256` call, matching the Solana `sol_sha256` syscall for cheap on-chain
+   verification in later PRs.
+4. **Simple** — no varints, no field tags, no hash-map iteration. Fixed-width
+   length prefixes and declared field order, so any language can implement a
+   decoder.
+
+## 1. Blob layout
+
+```
++--------+--------+----------------------+
+| Header | Body   | (nothing else)       |
+| 40 B   | N B    |                      |
++--------+--------+----------------------+
+```
+
+### 1.1 Header (40 bytes)
+
+| Offset | Size | Field         | Value                                         |
+|--------|------|---------------|-----------------------------------------------|
+| 0..3   | 3    | `magic`       | `0xC1 0xDE 0x1C`                              |
+| 3      | 1    | `version`     | `0x01` (this spec)                            |
+| 4..8   | 4    | `body_len`    | `u32` LE; length of body in bytes             |
+| 8..40  | 32   | `body_sha256` | `sha256(body)` over exactly `body_len` bytes  |
+
+The header is **not** covered by the digest. This keeps the digest stable
+across future header-only additions (e.g. new version bits) that do not change
+the body.
+
+A decoder MUST:
+- verify the magic bytes exactly (error: `BadMagic`);
+- verify `version == 0x01` (error: `UnsupportedVersion(v)`);
+- ensure at least 40 bytes are present before indexing (error:
+  `TruncatedHeader`);
+- ensure `body_len as usize == bytes.len() - 40` (error:
+  `BodyLengthMismatch { expected, actual }`);
+- compute `sha256(body)` and compare with `body_sha256` (error: `BadDigest`).
+
+### 1.2 Why SHA-256
+
+Solana exposes `sol_sha256` as a native syscall costing ~100 CU. PR-1b will
+compute the digest on-chain in one call, no hashing code in the program. BLAKE3
+would be a few hundred bytes smaller but cost tens of thousands of CU.
+
+## 2. Primitive encodings
+
+All multi-byte integers are **little-endian**.
+
+| Type            | Encoding                                                  |
+|-----------------|-----------------------------------------------------------|
+| `u8`            | 1 byte                                                    |
+| `u16`           | 2 bytes, LE                                               |
+| `u32`           | 4 bytes, LE                                               |
+| `bool`          | `0x00` (false) or `0x01` (true); any other byte is an error |
+| `String`        | `[len: u32 LE][utf8 bytes]`                               |
+| `Vec<u8>`       | `[len: u32 LE][raw bytes]`                                |
+| `Vec<T>`        | `[len: u32 LE][T_0][T_1]...[T_{len-1}]`                   |
+| `Option<T>`     | `0x00` (None), or `0x01` followed by encoded `T` (Some)   |
+
+All lengths are `u32` LE (max 4 GiB). No varints — the few bytes saved are not
+worth the cross-language implementation complexity. Length bounds are checked
+at decode time: a length that would over-run the remaining body triggers
+`TruncatedBody { position }`.
+
+## 3. Enum tags
+
+### 3.1 `IdlType`
+
+| Tag    | Variant       | Payload                                         |
+|--------|---------------|-------------------------------------------------|
+| `0x01` | `Primitive`   | `String` — primitive name (e.g. `"u64"`)        |
+| `0x02` | `Option`      | `IdlType` (recursive)                           |
+| `0x03` | `Defined`     | `String` — defined type name                    |
+| `0x04` | `DynString`   | `max_length: u32 LE`, `prefix_bytes: u8`        |
+| `0x05` | `DynVec`      | `IdlType`, `max_length: u32 LE`, `prefix_bytes: u8` |
+
+`max_length` is encoded as `u32` even though the Rust field is `usize`. The
+encoder returns `EncodeError::MaxLengthOverflow` if the value exceeds
+`u32::MAX`; in practice values are orders of magnitude smaller than that.
+
+`prefix_bytes` is constrained to `{1, 2, 4, 8}`. Any other value is a decode
+error (`InvalidPrefixBytes`). The encoder does **not** validate this on the
+way out — garbage in, garbage out — so the decoder is the source of truth.
+
+### 3.2 `IdlSeed`
+
+| Tag    | Variant   | Payload                 |
+|--------|-----------|-------------------------|
+| `0x01` | `Const`   | `Vec<u8>` seed bytes    |
+| `0x02` | `Account` | `String` — field path   |
+| `0x03` | `Arg`     | `String` — arg path     |
+
+### 3.3 `IdlTypeDefKind`
+
+| Tag    | Variant   |
+|--------|-----------|
+| `0x01` | `Struct`  |
+
+Tag space `0x02..=0xFF` is reserved for future kinds (enums, unions) when they
+land in the IDL surface.
+
+## 4. Body layout
+
+Fields are encoded **in the order listed below**. No field tags.
+
+### 4.1 `Idl`
+
+```
+address              : String
+metadata             : IdlMetadata
+instructions         : Vec<IdlInstruction>
+accounts             : Vec<IdlAccountDef>
+events               : Vec<IdlEventDef>
+types                : Vec<IdlTypeDef>
+errors               : Vec<IdlError>
+```
+
+### 4.2 `IdlMetadata`
+
+```
+name                 : String
+crate_name           : String
+version              : String
+spec                 : String
+```
+
+### 4.3 `IdlInstruction`
+
+```
+name                 : String
+discriminator        : Vec<u8>
+has_remaining        : bool
+accounts             : Vec<IdlAccountItem>
+args                 : Vec<IdlField>
+args_layout          : Option<String>   # "fixed" | "compact" | absent
+```
+
+`args_layout` is `None` for legacy IDLs; a string tag ("fixed" / "compact")
+when the source `#[instruction]` was compiled with the zeropod layout
+distinction. Treated as an opaque string on the wire — the set of valid
+values is governed by the IDL side, not this spec.
+
+### 4.4 `IdlAccountItem`
+
+```
+name                 : String
+writable             : bool
+signer               : bool
+pda                  : Option<IdlPda>
+address              : Option<String>
+```
+
+### 4.5 `IdlPda`
+
+```
+seeds                : Vec<IdlSeed>
+```
+
+### 4.6 `IdlField`
+
+```
+name                 : String
+ty                   : IdlType
+```
+
+### 4.7 `IdlAccountDef`
+
+```
+name                 : String
+discriminator        : Vec<u8>
+```
+
+### 4.8 `IdlEventDef`
+
+```
+name                 : String
+discriminator        : Vec<u8>
+```
+
+### 4.9 `IdlTypeDef`
+
+```
+name                 : String
+kind                 : u8   # IdlTypeDefKind tag (0x01 = Struct)
+fields               : Vec<IdlField>
+```
+
+Note: at the Rust level `IdlTypeDef` nests an `IdlTypeDefType { kind, fields }`;
+on the wire the nesting is flattened for compactness.
+
+### 4.10 `IdlError`
+
+```
+code                 : u32 LE
+name                 : String
+msg                  : Option<String>
+```
+
+## 5. Determinism guarantees
+
+- No hash-map iteration. Every collection is a `Vec<_>` with declared order.
+- No floats, no timestamps, no non-deterministic inputs.
+- `encode(idl)` is a pure function: identical `Idl` → identical bytes →
+  identical SHA-256 digest.
+- Re-encoding a decoded blob yields the identical byte string
+  (`encode(decode(b)) == b`), provided the input was produced by this encoder.
+
+## 6. Error catalogue
+
+Decoder errors (`DecodeError`):
+
+- `BadMagic` — first 3 bytes ≠ `0xC1 0xDE 0x1C`.
+- `UnsupportedVersion(u8)` — version byte not in this spec.
+- `TruncatedHeader` — fewer than 40 bytes available.
+- `BodyLengthMismatch { expected, actual }` — declared `body_len` ≠ trailing
+  slice length.
+- `BadDigest` — SHA-256 of body does not match header.
+- `InvalidTag { location, tag }` — unknown variant tag at the named site.
+- `TruncatedBody { position }` — a length prefix requests more bytes than
+  remain.
+- `InvalidUtf8` — a `String` field contained non-UTF-8 bytes.
+- `InvalidPrefixBytes(u8)` — `prefix_bytes` outside `{1, 2, 4, 8}`.
+- `InvalidBool(u8)` — a `bool` byte outside `{0, 1}`.
+
+Encoder errors (`EncodeError`):
+
+- `MaxLengthOverflow` — a `usize` length exceeded `u32::MAX` when packed.
+
+In practice encoder errors are unreachable under normal inputs, but the API is
+fallible so that future spec revisions can add validation without an
+incompatible signature change.
+
+## 7. Version history
+
+- **v1** (this document) — initial release.

--- a/schema-canonical/src/decode.rs
+++ b/schema-canonical/src/decode.rs
@@ -142,7 +142,12 @@ fn read_vec<T>(
     mut read_item: impl FnMut(&mut Reader) -> Result<T, DecodeError>,
 ) -> Result<Vec<T>, DecodeError> {
     let n = r.read_len()?;
-    let mut out = Vec::with_capacity(n);
+    // Deliberately avoid `Vec::with_capacity(n)` here. `read_len` only bounds
+    // `n` by remaining *bytes*, but `T` can be larger than one byte on the
+    // heap, so an adversarial length prefix could force a multi-GiB reserve
+    // even on a small body. Amortised `push` growth is O(1) and caps waste
+    // at 2× the real size.
+    let mut out = Vec::new();
     for _ in 0..n {
         out.push(read_item(r)?);
     }

--- a/schema-canonical/src/decode.rs
+++ b/schema-canonical/src/decode.rs
@@ -1,0 +1,342 @@
+//! Decoder for the canonical IDL binary format.
+//!
+//! See `SPEC.md` for the normative spec. Every reader here mirrors the matching
+//! writer in `encode.rs` — if one changes, both must change.
+
+use {
+    crate::{error::DecodeError, wire::*},
+    quasar_schema::{
+        Idl, IdlAccountDef, IdlAccountItem, IdlDynString, IdlDynVec, IdlError, IdlEventDef,
+        IdlField, IdlInstruction, IdlMetadata, IdlPda, IdlSeed, IdlType, IdlTypeDef,
+        IdlTypeDefKind, IdlTypeDefType,
+    },
+    sha2::{Digest, Sha256},
+};
+
+/// Decode a full canonical blob. Verifies magic, version, length, and digest.
+pub fn decode(bytes: &[u8]) -> Result<Idl, DecodeError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(DecodeError::TruncatedHeader);
+    }
+
+    if bytes[0..3] != MAGIC {
+        return Err(DecodeError::BadMagic);
+    }
+
+    let version = bytes[3];
+    if version != VERSION {
+        return Err(DecodeError::UnsupportedVersion(version));
+    }
+
+    let body_len = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    let expected_digest: [u8; 32] = bytes[8..40]
+        .try_into()
+        .expect("slice of 32 bytes is always convertible to [u8; 32]");
+
+    let body = &bytes[HEADER_LEN..];
+    if body.len() != body_len as usize {
+        return Err(DecodeError::BodyLengthMismatch {
+            expected: body_len,
+            actual: body.len(),
+        });
+    }
+
+    let actual_digest = Sha256::digest(body);
+    if actual_digest.as_slice() != expected_digest {
+        return Err(DecodeError::BadDigest);
+    }
+
+    decode_body(body)
+}
+
+/// Decode just the body (no header verification). Useful when the header is
+/// consumed separately (e.g. by an on-chain handler that validates the digest
+/// via `sol_sha256` before invoking higher-level logic).
+pub fn decode_body(bytes: &[u8]) -> Result<Idl, DecodeError> {
+    let mut r = Reader::new(bytes);
+    let idl = read_idl(&mut r)?;
+    Ok(idl)
+}
+
+// ---------------------------------------------------------------------------
+// Cursor
+// ---------------------------------------------------------------------------
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.pos
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], DecodeError> {
+        if self.remaining() < n {
+            return Err(DecodeError::TruncatedBody { position: self.pos });
+        }
+        let slice = &self.buf[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, DecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> Result<u32, DecodeError> {
+        let s = self.take(4)?;
+        Ok(u32::from_le_bytes([s[0], s[1], s[2], s[3]]))
+    }
+
+    fn read_len(&mut self) -> Result<usize, DecodeError> {
+        let n = self.read_u32()? as usize;
+        // Bounds-check: a length larger than the remaining buffer is invalid,
+        // and we prefer to fail fast rather than Vec::with_capacity(4 GiB).
+        if n > self.remaining() {
+            return Err(DecodeError::TruncatedBody { position: self.pos });
+        }
+        Ok(n)
+    }
+
+    fn read_bool(&mut self) -> Result<bool, DecodeError> {
+        match self.read_u8()? {
+            0x00 => Ok(false),
+            0x01 => Ok(true),
+            other => Err(DecodeError::InvalidBool(other)),
+        }
+    }
+
+    fn read_bytes(&mut self) -> Result<Vec<u8>, DecodeError> {
+        let n = self.read_len()?;
+        Ok(self.take(n)?.to_vec())
+    }
+
+    fn read_string(&mut self) -> Result<String, DecodeError> {
+        let bytes = self.read_bytes()?;
+        Ok(String::from_utf8(bytes)?)
+    }
+}
+
+fn read_option<T>(
+    r: &mut Reader,
+    read_inner: impl FnOnce(&mut Reader) -> Result<T, DecodeError>,
+) -> Result<Option<T>, DecodeError> {
+    match r.read_u8()? {
+        0x00 => Ok(None),
+        0x01 => Ok(Some(read_inner(r)?)),
+        other => Err(DecodeError::InvalidTag {
+            location: "Option discriminant",
+            tag: other,
+        }),
+    }
+}
+
+fn read_vec<T>(
+    r: &mut Reader,
+    mut read_item: impl FnMut(&mut Reader) -> Result<T, DecodeError>,
+) -> Result<Vec<T>, DecodeError> {
+    let n = r.read_len()?;
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(read_item(r)?);
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// IdlType + IdlSeed
+// ---------------------------------------------------------------------------
+
+fn validate_prefix_bytes(v: u8) -> Result<usize, DecodeError> {
+    match v {
+        1 | 2 | 4 | 8 => Ok(v as usize),
+        other => Err(DecodeError::InvalidPrefixBytes(other)),
+    }
+}
+
+fn read_idl_type(r: &mut Reader) -> Result<IdlType, DecodeError> {
+    let tag = r.read_u8()?;
+    match tag {
+        TAG_TYPE_PRIMITIVE => Ok(IdlType::Primitive(r.read_string()?)),
+        TAG_TYPE_OPTION => Ok(IdlType::Option {
+            option: Box::new(read_idl_type(r)?),
+        }),
+        TAG_TYPE_DEFINED => Ok(IdlType::Defined {
+            defined: r.read_string()?,
+        }),
+        TAG_TYPE_DYN_STRING => {
+            let max_length = r.read_u32()? as usize;
+            let prefix_bytes = validate_prefix_bytes(r.read_u8()?)?;
+            Ok(IdlType::DynString {
+                string: IdlDynString {
+                    max_length,
+                    prefix_bytes,
+                },
+            })
+        }
+        TAG_TYPE_DYN_VEC => {
+            let items = Box::new(read_idl_type(r)?);
+            let max_length = r.read_u32()? as usize;
+            let prefix_bytes = validate_prefix_bytes(r.read_u8()?)?;
+            Ok(IdlType::DynVec {
+                vec: IdlDynVec {
+                    items,
+                    max_length,
+                    prefix_bytes,
+                },
+            })
+        }
+        other => Err(DecodeError::InvalidTag {
+            location: "IdlType",
+            tag: other,
+        }),
+    }
+}
+
+fn read_idl_seed(r: &mut Reader) -> Result<IdlSeed, DecodeError> {
+    let tag = r.read_u8()?;
+    match tag {
+        TAG_SEED_CONST => Ok(IdlSeed::Const {
+            value: r.read_bytes()?,
+        }),
+        TAG_SEED_ACCOUNT => Ok(IdlSeed::Account {
+            path: r.read_string()?,
+        }),
+        TAG_SEED_ARG => Ok(IdlSeed::Arg {
+            path: r.read_string()?,
+        }),
+        other => Err(DecodeError::InvalidTag {
+            location: "IdlSeed",
+            tag: other,
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leaf structs
+// ---------------------------------------------------------------------------
+
+fn read_idl_field(r: &mut Reader) -> Result<IdlField, DecodeError> {
+    let name = r.read_string()?;
+    let ty = read_idl_type(r)?;
+    Ok(IdlField { name, ty })
+}
+
+fn read_idl_pda(r: &mut Reader) -> Result<IdlPda, DecodeError> {
+    let seeds = read_vec(r, read_idl_seed)?;
+    Ok(IdlPda { seeds })
+}
+
+fn read_idl_account_item(r: &mut Reader) -> Result<IdlAccountItem, DecodeError> {
+    let name = r.read_string()?;
+    let writable = r.read_bool()?;
+    let signer = r.read_bool()?;
+    let pda = read_option(r, read_idl_pda)?;
+    let address = read_option(r, |r| r.read_string())?;
+    Ok(IdlAccountItem {
+        name,
+        writable,
+        signer,
+        pda,
+        address,
+    })
+}
+
+fn read_idl_instruction(r: &mut Reader) -> Result<IdlInstruction, DecodeError> {
+    let name = r.read_string()?;
+    let discriminator = r.read_bytes()?;
+    let has_remaining = r.read_bool()?;
+    let accounts = read_vec(r, read_idl_account_item)?;
+    let args = read_vec(r, read_idl_field)?;
+    let args_layout = read_option(r, |r| r.read_string())?;
+    Ok(IdlInstruction {
+        name,
+        discriminator,
+        accounts,
+        args,
+        has_remaining,
+        args_layout,
+    })
+}
+
+fn read_idl_account_def(r: &mut Reader) -> Result<IdlAccountDef, DecodeError> {
+    let name = r.read_string()?;
+    let discriminator = r.read_bytes()?;
+    Ok(IdlAccountDef {
+        name,
+        discriminator,
+    })
+}
+
+fn read_idl_event_def(r: &mut Reader) -> Result<IdlEventDef, DecodeError> {
+    let name = r.read_string()?;
+    let discriminator = r.read_bytes()?;
+    Ok(IdlEventDef {
+        name,
+        discriminator,
+    })
+}
+
+fn read_idl_type_def(r: &mut Reader) -> Result<IdlTypeDef, DecodeError> {
+    let name = r.read_string()?;
+    let kind_tag = r.read_u8()?;
+    let kind = match kind_tag {
+        TAG_TYPEDEF_STRUCT => IdlTypeDefKind::Struct,
+        other => {
+            return Err(DecodeError::InvalidTag {
+                location: "IdlTypeDefKind",
+                tag: other,
+            })
+        }
+    };
+    let fields = read_vec(r, read_idl_field)?;
+    Ok(IdlTypeDef {
+        name,
+        ty: IdlTypeDefType { kind, fields },
+    })
+}
+
+fn read_idl_error(r: &mut Reader) -> Result<IdlError, DecodeError> {
+    let code = r.read_u32()?;
+    let name = r.read_string()?;
+    let msg = read_option(r, |r| r.read_string())?;
+    Ok(IdlError { code, name, msg })
+}
+
+fn read_idl_metadata(r: &mut Reader) -> Result<IdlMetadata, DecodeError> {
+    let name = r.read_string()?;
+    let crate_name = r.read_string()?;
+    let version = r.read_string()?;
+    let spec = r.read_string()?;
+    Ok(IdlMetadata {
+        name,
+        crate_name,
+        version,
+        spec,
+    })
+}
+
+fn read_idl(r: &mut Reader) -> Result<Idl, DecodeError> {
+    let address = r.read_string()?;
+    let metadata = read_idl_metadata(r)?;
+    let instructions = read_vec(r, read_idl_instruction)?;
+    let accounts = read_vec(r, read_idl_account_def)?;
+    let events = read_vec(r, read_idl_event_def)?;
+    let types = read_vec(r, read_idl_type_def)?;
+    let errors = read_vec(r, read_idl_error)?;
+    Ok(Idl {
+        address,
+        metadata,
+        instructions,
+        accounts,
+        events,
+        types,
+        errors,
+    })
+}

--- a/schema-canonical/src/encode.rs
+++ b/schema-canonical/src/encode.rs
@@ -1,0 +1,225 @@
+//! Encoder for the canonical IDL binary format.
+//!
+//! See `SPEC.md` for the normative spec. Every helper here maps directly to a
+//! named field or enum variant in that document; keep the code and the spec in
+//! sync.
+
+use {
+    crate::wire::*,
+    quasar_schema::{
+        Idl, IdlAccountDef, IdlAccountItem, IdlError, IdlEventDef, IdlField, IdlInstruction,
+        IdlMetadata, IdlPda, IdlSeed, IdlType, IdlTypeDef, IdlTypeDefKind,
+    },
+    sha2::{Digest, Sha256},
+};
+
+/// Encode a full IDL blob: header + body + digest.
+pub fn encode(idl: &Idl) -> Vec<u8> {
+    let body = encode_body(idl);
+    let digest = Sha256::digest(&body);
+
+    // Total size known up-front: header + body length.
+    let mut out = Vec::with_capacity(HEADER_LEN + body.len());
+    out.extend_from_slice(&MAGIC);
+    out.push(VERSION);
+    // body_len is u32 LE. Panic if the body exceeds 4 GiB — a real IDL is
+    // tens of kilobytes at most, so this is unreachable in practice.
+    let body_len: u32 = body
+        .len()
+        .try_into()
+        .expect("canonical IDL body length exceeds u32::MAX");
+    out.extend_from_slice(&body_len.to_le_bytes());
+    out.extend_from_slice(digest.as_slice());
+    out.extend_from_slice(&body);
+
+    debug_assert_eq!(out.len(), HEADER_LEN + body.len());
+    out
+}
+
+/// Encode just the body (no header). Useful when the header will be assembled
+/// elsewhere — for example, a build-time const that a program handler hashes
+/// on-chain.
+pub fn encode_body(idl: &Idl) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_idl(&mut buf, idl);
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Primitive writers
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn write_u8(buf: &mut Vec<u8>, v: u8) {
+    buf.push(v);
+}
+
+#[inline]
+fn write_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+#[inline]
+fn write_len(buf: &mut Vec<u8>, len: usize) {
+    let n: u32 = len
+        .try_into()
+        .expect("canonical IDL length exceeds u32::MAX");
+    write_u32(buf, n);
+}
+
+#[inline]
+fn write_bool(buf: &mut Vec<u8>, b: bool) {
+    buf.push(u8::from(b));
+}
+
+fn write_bytes(buf: &mut Vec<u8>, bytes: &[u8]) {
+    write_len(buf, bytes.len());
+    buf.extend_from_slice(bytes);
+}
+
+fn write_string(buf: &mut Vec<u8>, s: &str) {
+    write_bytes(buf, s.as_bytes());
+}
+
+fn write_option<T>(
+    buf: &mut Vec<u8>,
+    value: Option<&T>,
+    write_inner: impl FnOnce(&mut Vec<u8>, &T),
+) {
+    match value {
+        None => buf.push(0x00),
+        Some(v) => {
+            buf.push(0x01);
+            write_inner(buf, v);
+        }
+    }
+}
+
+fn write_vec<T>(buf: &mut Vec<u8>, items: &[T], mut write_item: impl FnMut(&mut Vec<u8>, &T)) {
+    write_len(buf, items.len());
+    for item in items {
+        write_item(buf, item);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdlType + IdlSeed
+// ---------------------------------------------------------------------------
+
+fn write_idl_type(buf: &mut Vec<u8>, ty: &IdlType) {
+    match ty {
+        IdlType::Primitive(name) => {
+            write_u8(buf, TAG_TYPE_PRIMITIVE);
+            write_string(buf, name);
+        }
+        IdlType::Option { option } => {
+            write_u8(buf, TAG_TYPE_OPTION);
+            write_idl_type(buf, option);
+        }
+        IdlType::Defined { defined } => {
+            write_u8(buf, TAG_TYPE_DEFINED);
+            write_string(buf, defined);
+        }
+        IdlType::DynString { string } => {
+            write_u8(buf, TAG_TYPE_DYN_STRING);
+            write_len(buf, string.max_length);
+            write_u8(buf, string.prefix_bytes as u8);
+        }
+        IdlType::DynVec { vec } => {
+            write_u8(buf, TAG_TYPE_DYN_VEC);
+            write_idl_type(buf, &vec.items);
+            write_len(buf, vec.max_length);
+            write_u8(buf, vec.prefix_bytes as u8);
+        }
+    }
+}
+
+fn write_idl_seed(buf: &mut Vec<u8>, seed: &IdlSeed) {
+    match seed {
+        IdlSeed::Const { value } => {
+            write_u8(buf, TAG_SEED_CONST);
+            write_bytes(buf, value);
+        }
+        IdlSeed::Account { path } => {
+            write_u8(buf, TAG_SEED_ACCOUNT);
+            write_string(buf, path);
+        }
+        IdlSeed::Arg { path } => {
+            write_u8(buf, TAG_SEED_ARG);
+            write_string(buf, path);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leaf structs
+// ---------------------------------------------------------------------------
+
+fn write_idl_field(buf: &mut Vec<u8>, field: &IdlField) {
+    write_string(buf, &field.name);
+    write_idl_type(buf, &field.ty);
+}
+
+fn write_idl_pda(buf: &mut Vec<u8>, pda: &IdlPda) {
+    write_vec(buf, &pda.seeds, write_idl_seed);
+}
+
+fn write_idl_account_item(buf: &mut Vec<u8>, item: &IdlAccountItem) {
+    write_string(buf, &item.name);
+    write_bool(buf, item.writable);
+    write_bool(buf, item.signer);
+    write_option(buf, item.pda.as_ref(), write_idl_pda);
+    write_option(buf, item.address.as_ref(), |buf, s| write_string(buf, s));
+}
+
+fn write_idl_instruction(buf: &mut Vec<u8>, ix: &IdlInstruction) {
+    write_string(buf, &ix.name);
+    write_bytes(buf, &ix.discriminator);
+    write_bool(buf, ix.has_remaining);
+    write_vec(buf, &ix.accounts, write_idl_account_item);
+    write_vec(buf, &ix.args, write_idl_field);
+    write_option(buf, ix.args_layout.as_ref(), |buf, s| write_string(buf, s));
+}
+
+fn write_idl_account_def(buf: &mut Vec<u8>, def: &IdlAccountDef) {
+    write_string(buf, &def.name);
+    write_bytes(buf, &def.discriminator);
+}
+
+fn write_idl_event_def(buf: &mut Vec<u8>, def: &IdlEventDef) {
+    write_string(buf, &def.name);
+    write_bytes(buf, &def.discriminator);
+}
+
+fn write_idl_type_def(buf: &mut Vec<u8>, td: &IdlTypeDef) {
+    write_string(buf, &td.name);
+    // Flatten IdlTypeDefType on the wire — see SPEC.md §4.9.
+    let kind_tag: u8 = match td.ty.kind {
+        IdlTypeDefKind::Struct => TAG_TYPEDEF_STRUCT,
+    };
+    write_u8(buf, kind_tag);
+    write_vec(buf, &td.ty.fields, write_idl_field);
+}
+
+fn write_idl_error(buf: &mut Vec<u8>, err: &IdlError) {
+    write_u32(buf, err.code);
+    write_string(buf, &err.name);
+    write_option(buf, err.msg.as_ref(), |buf, s| write_string(buf, s));
+}
+
+fn write_idl_metadata(buf: &mut Vec<u8>, md: &IdlMetadata) {
+    write_string(buf, &md.name);
+    write_string(buf, &md.crate_name);
+    write_string(buf, &md.version);
+    write_string(buf, &md.spec);
+}
+
+fn write_idl(buf: &mut Vec<u8>, idl: &Idl) {
+    write_string(buf, &idl.address);
+    write_idl_metadata(buf, &idl.metadata);
+    write_vec(buf, &idl.instructions, write_idl_instruction);
+    write_vec(buf, &idl.accounts, write_idl_account_def);
+    write_vec(buf, &idl.events, write_idl_event_def);
+    write_vec(buf, &idl.types, write_idl_type_def);
+    write_vec(buf, &idl.errors, write_idl_error);
+}

--- a/schema-canonical/src/error.rs
+++ b/schema-canonical/src/error.rs
@@ -1,0 +1,130 @@
+//! Error types for the canonical encoder/decoder.
+//!
+//! Every decoder rejection has a distinct variant so callers (and tests) can
+//! tell failure modes apart without string matching. Encoding is currently
+//! infallible; `EncodeError` is reserved for future spec revisions.
+
+use std::{fmt, string::FromUtf8Error};
+
+/// Errors returned by [`crate::decode`] and [`crate::decode_body`].
+#[derive(Debug)]
+pub enum DecodeError {
+    /// First three bytes did not match [`crate::wire::MAGIC`].
+    BadMagic,
+    /// Header present but version byte is not supported by this reader.
+    UnsupportedVersion(u8),
+    /// Fewer than 40 bytes available — no header to parse.
+    TruncatedHeader,
+    /// `body_len` field disagrees with the actual trailing slice length.
+    BodyLengthMismatch { expected: u32, actual: usize },
+    /// SHA-256 of the body did not match the digest in the header.
+    BadDigest,
+    /// Unknown enum tag at the named site.
+    InvalidTag { location: &'static str, tag: u8 },
+    /// A length prefix or multi-byte field ran off the end of the body.
+    TruncatedBody { position: usize },
+    /// A `String` field was not valid UTF-8.
+    InvalidUtf8(FromUtf8Error),
+    /// `prefix_bytes` value was not in `{1, 2, 4, 8}`.
+    InvalidPrefixBytes(u8),
+    /// A `bool` byte was outside `{0, 1}`.
+    InvalidBool(u8),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadMagic => write!(f, "bad magic bytes (not a quasar canonical IDL blob)"),
+            Self::UnsupportedVersion(v) => {
+                write!(f, "unsupported canonical IDL version: 0x{v:02X}")
+            }
+            Self::TruncatedHeader => write!(f, "truncated header (need at least 40 bytes)"),
+            Self::BodyLengthMismatch { expected, actual } => write!(
+                f,
+                "body length mismatch: header declares {expected} bytes, slice has {actual}"
+            ),
+            Self::BadDigest => write!(f, "body SHA-256 digest did not match header"),
+            Self::InvalidTag { location, tag } => {
+                write!(f, "invalid tag 0x{tag:02X} at {location}")
+            }
+            Self::TruncatedBody { position } => {
+                write!(f, "truncated body at offset {position}")
+            }
+            Self::InvalidUtf8(err) => write!(f, "invalid utf-8 in string field: {err}"),
+            Self::InvalidPrefixBytes(v) => {
+                write!(f, "invalid prefix_bytes {v}; expected one of 1, 2, 4, 8")
+            }
+            Self::InvalidBool(v) => write!(f, "invalid bool byte 0x{v:02X}; expected 0x00 or 0x01"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidUtf8(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<FromUtf8Error> for DecodeError {
+    fn from(err: FromUtf8Error) -> Self {
+        Self::InvalidUtf8(err)
+    }
+}
+
+/// Errors returned by [`crate::encode`] and [`crate::encode_body`].
+///
+/// Encoding is currently infallible; no variants exist. The type is reserved
+/// so a future spec revision (e.g. validating `prefix_bytes` on the way out)
+/// can add fallibility without breaking the public signature shape.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum EncodeError {}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `EncodeError` has no variants, so this match is exhaustive.
+        match *self {}
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
+/// Unified error for callers that want one type for both directions.
+#[derive(Debug)]
+pub enum CanonicalError {
+    Encode(EncodeError),
+    Decode(DecodeError),
+}
+
+impl fmt::Display for CanonicalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Encode(e) => write!(f, "{e}"),
+            Self::Decode(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for CanonicalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Encode(e) => Some(e),
+            Self::Decode(e) => Some(e),
+        }
+    }
+}
+
+impl From<EncodeError> for CanonicalError {
+    fn from(err: EncodeError) -> Self {
+        Self::Encode(err)
+    }
+}
+
+impl From<DecodeError> for CanonicalError {
+    fn from(err: DecodeError) -> Self {
+        Self::Decode(err)
+    }
+}

--- a/schema-canonical/src/lib.rs
+++ b/schema-canonical/src/lib.rs
@@ -1,0 +1,38 @@
+//! Canonical, hash-verified binary encoding of a [`quasar_schema::Idl`].
+//!
+//! This crate defines the wire format documented in [`SPEC.md`] and provides
+//! encoder/decoder pairs that are byte-for-byte deterministic. The SHA-256
+//! digest in the header lets later PRs (on-chain handler, client SDK) verify
+//! integrity with a single `sol_sha256` syscall — no parsing required to
+//! authenticate.
+//!
+//! # Stability
+//!
+//! The wire format is versioned (`wire::VERSION`). Any change that is not
+//! backwards-compatible must bump the version byte; encoders continue to emit
+//! the new version, decoders reject unknown versions.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use quasar_schema::Idl;
+//! # fn idl() -> Idl { unimplemented!() }
+//! let idl: Idl = idl();
+//! let blob = quasar_schema_canonical::encode(&idl);
+//! let roundtripped = quasar_schema_canonical::decode(&blob).unwrap();
+//! assert_eq!(idl, roundtripped);
+//! ```
+//!
+//! [`SPEC.md`]: https://github.com/blueshift-gg/quasar/blob/master/schema-canonical/SPEC.md
+
+mod decode;
+mod encode;
+mod error;
+pub mod wire;
+
+pub use {
+    decode::{decode, decode_body},
+    encode::{encode, encode_body},
+    error::{CanonicalError, DecodeError, EncodeError},
+    wire::{MAGIC, VERSION},
+};

--- a/schema-canonical/src/wire.rs
+++ b/schema-canonical/src/wire.rs
@@ -1,0 +1,37 @@
+//! Wire-format constants shared by encoder and decoder.
+//!
+//! See `SPEC.md` for the normative specification. Any value defined here is
+//! part of the binary contract — changing a byte here is a breaking change.
+
+/// Three-byte magic prefix. ASCII-friendly to make hex dumps recognisable.
+pub const MAGIC: [u8; 3] = [0xC1, 0xDE, 0x1C];
+
+/// Current wire-format version. Incremented on any breaking change.
+pub const VERSION: u8 = 0x01;
+
+/// Fixed header size: magic (3) + version (1) + body_len (4) + digest (32).
+pub const HEADER_LEN: usize = 3 + 1 + 4 + 32;
+
+// ---------------------------------------------------------------------------
+// IdlType variant tags (see SPEC.md §3.1)
+// ---------------------------------------------------------------------------
+
+pub const TAG_TYPE_PRIMITIVE: u8 = 0x01;
+pub const TAG_TYPE_OPTION: u8 = 0x02;
+pub const TAG_TYPE_DEFINED: u8 = 0x03;
+pub const TAG_TYPE_DYN_STRING: u8 = 0x04;
+pub const TAG_TYPE_DYN_VEC: u8 = 0x05;
+
+// ---------------------------------------------------------------------------
+// IdlSeed variant tags (see SPEC.md §3.2)
+// ---------------------------------------------------------------------------
+
+pub const TAG_SEED_CONST: u8 = 0x01;
+pub const TAG_SEED_ACCOUNT: u8 = 0x02;
+pub const TAG_SEED_ARG: u8 = 0x03;
+
+// ---------------------------------------------------------------------------
+// IdlTypeDefKind tags (see SPEC.md §3.3)
+// ---------------------------------------------------------------------------
+
+pub const TAG_TYPEDEF_STRUCT: u8 = 0x01;

--- a/schema-canonical/tests/fuzz_smoke.rs
+++ b/schema-canonical/tests/fuzz_smoke.rs
@@ -1,0 +1,93 @@
+//! Smoke-level fuzz: feed the decoder random byte strings and assert it
+//! *never* panics, only returns `Err(DecodeError)` (or, improbably, `Ok`).
+//!
+//! This is not a replacement for a real cargo-fuzz harness — it runs a fixed
+//! number of iterations with a seeded PRNG so the test is deterministic in CI
+//! — but it catches the dominant class of decoder bugs (out-of-bounds slice,
+//! arithmetic overflow, allocation explosion) without pulling in `libfuzzer`.
+
+use quasar_schema_canonical::{decode, decode_body};
+
+/// Deterministic splitmix64 PRNG — no external dep, reproducible across
+/// platforms. Seed choice is arbitrary but fixed so failures are debuggable.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    fn fill(&mut self, buf: &mut [u8]) {
+        for chunk in buf.chunks_mut(8) {
+            let bytes = self.next().to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+    }
+}
+
+#[test]
+fn decode_never_panics_on_random_input() {
+    let mut rng = SplitMix64::new(0xDEADBEEFCAFEBABE);
+
+    // 2_000 iterations × up to 256 bytes — small enough to run fast, large
+    // enough to exercise varied length prefixes, tag bytes, and short reads.
+    for _ in 0..2_000 {
+        let len = (rng.next() as usize) % 256;
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf);
+
+        // `decode` may or may not error; the only thing we disallow is a
+        // panic / abort. `std::panic::catch_unwind` would let us assert this
+        // explicitly, but any panic here will just fail the test normally.
+        let _ = decode(&buf);
+        let _ = decode_body(&buf);
+    }
+}
+
+#[test]
+fn decode_never_panics_on_short_buffers() {
+    // Exhaustive sweep of buffer sizes 0..=48 with the deterministic stream
+    // above. Catches off-by-one errors at the header boundary (40 bytes).
+    let mut rng = SplitMix64::new(0x0123456789ABCDEF);
+    for len in 0..=48 {
+        for _ in 0..16 {
+            let mut buf = vec![0u8; len];
+            rng.fill(&mut buf);
+            let _ = decode(&buf);
+            let _ = decode_body(&buf);
+        }
+    }
+}
+
+#[test]
+fn decode_never_panics_with_valid_header_random_body() {
+    // Craft a well-formed header (magic + version + body_len + zero digest)
+    // pointing at a random body. The digest check will reject, but only
+    // *after* the body-length check — so if body_len disagrees with the
+    // slice, `BodyLengthMismatch` fires first. Either way: no panic.
+    use quasar_schema_canonical::{wire, MAGIC, VERSION};
+
+    let mut rng = SplitMix64::new(0xFEED_FACE_BAAD_F00D);
+    for _ in 0..500 {
+        let body_len = (rng.next() as usize) % 512;
+        let mut body = vec![0u8; body_len];
+        rng.fill(&mut body);
+
+        let mut blob = Vec::with_capacity(wire::HEADER_LEN + body_len);
+        blob.extend_from_slice(&MAGIC);
+        blob.push(VERSION);
+        blob.extend_from_slice(&(body_len as u32).to_le_bytes());
+        blob.extend_from_slice(&[0u8; 32]); // deliberately-wrong digest
+        blob.extend_from_slice(&body);
+
+        let _ = decode(&blob);
+    }
+}

--- a/schema-canonical/tests/roundtrip_synthetic.rs
+++ b/schema-canonical/tests/roundtrip_synthetic.rs
@@ -1,0 +1,614 @@
+//! Synthetic round-trip tests for the canonical IDL encoding.
+//!
+//! Every test hand-builds an [`Idl`] or a malformed blob that exercises exactly
+//! one encoder/decoder concern. See `SPEC.md` for the wire-format contract
+//! being verified here.
+
+use {
+    quasar_schema::{
+        Idl, IdlAccountDef, IdlAccountItem, IdlDynString, IdlDynVec, IdlError, IdlEventDef,
+        IdlField, IdlInstruction, IdlMetadata, IdlPda, IdlSeed, IdlType, IdlTypeDef,
+        IdlTypeDefKind, IdlTypeDefType,
+    },
+    quasar_schema_canonical::{decode, encode, encode_body, wire, DecodeError, MAGIC, VERSION},
+    sha2::{Digest, Sha256},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_metadata() -> IdlMetadata {
+    IdlMetadata {
+        name: "test_prog".to_string(),
+        crate_name: "test-prog".to_string(),
+        version: "0.1.0".to_string(),
+        spec: "0.1.0".to_string(),
+    }
+}
+
+fn minimal_idl() -> Idl {
+    Idl {
+        address: "11111111111111111111111111111111".to_string(),
+        metadata: empty_metadata(),
+        instructions: vec![],
+        accounts: vec![],
+        events: vec![],
+        types: vec![],
+        errors: vec![],
+    }
+}
+
+/// Encode → decode → assert equal. Also asserts idempotence of re-encoding.
+fn assert_round_trip(idl: &Idl) {
+    let blob = encode(idl);
+    let decoded = decode(&blob).expect("decode should succeed");
+    assert_eq!(idl, &decoded, "decoded idl must equal original");
+
+    let reencoded = encode(&decoded);
+    assert_eq!(
+        blob, reencoded,
+        "re-encoding decoded blob must produce identical bytes"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive round-trips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn encode_decode_empty_idl() {
+    assert_round_trip(&minimal_idl());
+}
+
+#[test]
+fn encode_decode_primitives() {
+    // One instruction per primitive type, no accounts.
+    let prims = [
+        "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128", "bool", "pubkey",
+    ];
+    let instructions = prims
+        .iter()
+        .enumerate()
+        .map(|(i, p)| IdlInstruction {
+            name: format!("take_{p}"),
+            discriminator: vec![i as u8],
+            accounts: vec![],
+            args: vec![IdlField {
+                name: "arg".to_string(),
+                ty: IdlType::Primitive((*p).to_string()),
+            }],
+            has_remaining: false,
+            args_layout: None,
+        })
+        .collect();
+
+    let idl = Idl {
+        instructions,
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_option_nested() {
+    // Option<Option<u64>> — recursion depth 2.
+    let ty = IdlType::Option {
+        option: Box::new(IdlType::Option {
+            option: Box::new(IdlType::Primitive("u64".to_string())),
+        }),
+    };
+    let idl = Idl {
+        instructions: vec![IdlInstruction {
+            name: "nested".to_string(),
+            discriminator: vec![0xAA],
+            accounts: vec![],
+            args: vec![IdlField {
+                name: "maybe".to_string(),
+                ty,
+            }],
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_dyn_string_every_prefix() {
+    let widths = [1usize, 2, 4, 8];
+    let args: Vec<IdlField> = widths
+        .iter()
+        .map(|w| IdlField {
+            name: format!("s_p{w}"),
+            ty: IdlType::DynString {
+                string: IdlDynString {
+                    max_length: 64,
+                    prefix_bytes: *w,
+                },
+            },
+        })
+        .collect();
+
+    let idl = Idl {
+        instructions: vec![IdlInstruction {
+            name: "strings".to_string(),
+            discriminator: vec![1],
+            accounts: vec![],
+            args,
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_dyn_vec_of_defined() {
+    // Vec<CustomStruct, 64, u16>
+    let ty = IdlType::DynVec {
+        vec: IdlDynVec {
+            items: Box::new(IdlType::Defined {
+                defined: "CustomStruct".to_string(),
+            }),
+            max_length: 64,
+            prefix_bytes: 2,
+        },
+    };
+    let idl = Idl {
+        types: vec![IdlTypeDef {
+            name: "CustomStruct".to_string(),
+            ty: IdlTypeDefType {
+                kind: IdlTypeDefKind::Struct,
+                fields: vec![IdlField {
+                    name: "a".to_string(),
+                    ty: IdlType::Primitive("u64".to_string()),
+                }],
+            },
+        }],
+        instructions: vec![IdlInstruction {
+            name: "bulk".to_string(),
+            discriminator: vec![2],
+            accounts: vec![],
+            args: vec![IdlField {
+                name: "items".to_string(),
+                ty,
+            }],
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_every_seed_kind() {
+    let pda = IdlPda {
+        seeds: vec![
+            IdlSeed::Const {
+                value: b"prefix".to_vec(),
+            },
+            IdlSeed::Account {
+                path: "authority".to_string(),
+            },
+            IdlSeed::Arg {
+                path: "nonce".to_string(),
+            },
+        ],
+    };
+
+    let idl = Idl {
+        instructions: vec![IdlInstruction {
+            name: "derive".to_string(),
+            discriminator: vec![3],
+            accounts: vec![IdlAccountItem {
+                name: "pda_account".to_string(),
+                writable: true,
+                signer: false,
+                pda: Some(pda),
+                address: None,
+            }],
+            args: vec![],
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_account_item_with_address() {
+    let idl = Idl {
+        instructions: vec![IdlInstruction {
+            name: "fixed_addr".to_string(),
+            discriminator: vec![4],
+            accounts: vec![IdlAccountItem {
+                name: "system_program".to_string(),
+                writable: false,
+                signer: false,
+                pda: None,
+                address: Some("11111111111111111111111111111111".to_string()),
+            }],
+            args: vec![],
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_errors_with_and_without_msg() {
+    let idl = Idl {
+        errors: vec![
+            IdlError {
+                code: 6000,
+                name: "WithMessage".to_string(),
+                msg: Some("boom".to_string()),
+            },
+            IdlError {
+                code: 6001,
+                name: "NoMessage".to_string(),
+                msg: None,
+            },
+        ],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_accounts_and_events() {
+    let idl = Idl {
+        accounts: vec![IdlAccountDef {
+            name: "MyState".to_string(),
+            discriminator: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        }],
+        events: vec![IdlEventDef {
+            name: "SomethingHappened".to_string(),
+            discriminator: vec![0xEE; 8],
+        }],
+        ..minimal_idl()
+    };
+    assert_round_trip(&idl);
+}
+
+#[test]
+fn encode_decode_idempotent() {
+    // A richer IDL that stresses more of the encoder at once.
+    let idl = Idl {
+        address: "SoMeProg1111111111111111111111111111111111".to_string(),
+        metadata: empty_metadata(),
+        instructions: vec![IdlInstruction {
+            name: "complexThing".to_string(),
+            discriminator: vec![9, 9, 9, 9, 9, 9, 9, 9],
+            accounts: vec![
+                IdlAccountItem {
+                    name: "payer".to_string(),
+                    writable: true,
+                    signer: true,
+                    pda: None,
+                    address: None,
+                },
+                IdlAccountItem {
+                    name: "vault".to_string(),
+                    writable: true,
+                    signer: false,
+                    pda: Some(IdlPda {
+                        seeds: vec![IdlSeed::Const {
+                            value: b"v".to_vec(),
+                        }],
+                    }),
+                    address: None,
+                },
+            ],
+            args: vec![IdlField {
+                name: "amount".to_string(),
+                ty: IdlType::Option {
+                    option: Box::new(IdlType::Primitive("u64".to_string())),
+                },
+            }],
+            has_remaining: true,
+            args_layout: None,
+        }],
+        accounts: vec![IdlAccountDef {
+            name: "Vault".to_string(),
+            discriminator: vec![10, 20, 30, 40, 50, 60, 70, 80],
+        }],
+        events: vec![IdlEventDef {
+            name: "Evt".to_string(),
+            discriminator: vec![0; 8],
+        }],
+        types: vec![IdlTypeDef {
+            name: "Vault".to_string(),
+            ty: IdlTypeDefType {
+                kind: IdlTypeDefKind::Struct,
+                fields: vec![IdlField {
+                    name: "owner".to_string(),
+                    ty: IdlType::Primitive("pubkey".to_string()),
+                }],
+            },
+        }],
+        errors: vec![IdlError {
+            code: 42,
+            name: "NotAllowed".to_string(),
+            msg: None,
+        }],
+    };
+
+    let first = encode(&idl);
+    let decoded = decode(&first).unwrap();
+    let second = encode(&decoded);
+    assert_eq!(first, second, "encode is deterministic");
+
+    // Decode twice; must still equal.
+    let decoded2 = decode(&second).unwrap();
+    assert_eq!(decoded, decoded2);
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — every DecodeError variant gets at least one test.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decode_rejects_bad_magic() {
+    let mut blob = encode(&minimal_idl());
+    blob[0] = 0x00; // corrupt magic
+    match decode(&blob) {
+        Err(DecodeError::BadMagic) => {}
+        other => panic!("expected BadMagic, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_bad_version() {
+    let mut blob = encode(&minimal_idl());
+    blob[3] = 0xFF; // unknown version
+    match decode(&blob) {
+        Err(DecodeError::UnsupportedVersion(0xFF)) => {}
+        other => panic!("expected UnsupportedVersion(0xFF), got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_truncated_header() {
+    let short = [0xC1, 0xDE, 0x1C, 0x01];
+    match decode(&short) {
+        Err(DecodeError::TruncatedHeader) => {}
+        other => panic!("expected TruncatedHeader, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_body_length_mismatch() {
+    let mut blob = encode(&minimal_idl());
+    // Bump the declared body_len by 1 so it no longer matches the slice.
+    let current = u32::from_le_bytes([blob[4], blob[5], blob[6], blob[7]]);
+    let bumped = current + 1;
+    blob[4..8].copy_from_slice(&bumped.to_le_bytes());
+    match decode(&blob) {
+        Err(DecodeError::BodyLengthMismatch { expected, actual }) => {
+            assert_eq!(expected, bumped);
+            assert_eq!(actual, current as usize);
+        }
+        other => panic!("expected BodyLengthMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_bad_digest() {
+    let mut blob = encode(&minimal_idl());
+    // Flip a bit inside the body — digest no longer matches.
+    let body_start = wire::HEADER_LEN;
+    blob[body_start] ^= 0xFF;
+    match decode(&blob) {
+        Err(DecodeError::BadDigest) => {}
+        other => panic!("expected BadDigest, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_truncated_body() {
+    // A body that declares a 1,000-byte string but has only a few bytes after.
+    let mut body = Vec::new();
+    // address: String with declared length 1000, but no payload.
+    body.extend_from_slice(&1000u32.to_le_bytes());
+    // No bytes follow — read_len should catch it via the remaining() check.
+
+    // Assemble a valid-looking header so we reach the body reader.
+    let digest = Sha256::digest(&body);
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    blob.extend_from_slice(digest.as_slice());
+    blob.extend_from_slice(&body);
+
+    match decode(&blob) {
+        Err(DecodeError::TruncatedBody { .. }) => {}
+        other => panic!("expected TruncatedBody, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_invalid_utf8() {
+    // Build a body where the address string contains invalid UTF-8.
+    let mut body = Vec::new();
+    // 2-byte "string": 0xFF 0xFE — not valid UTF-8.
+    body.extend_from_slice(&2u32.to_le_bytes());
+    body.extend_from_slice(&[0xFF, 0xFE]);
+
+    let digest = Sha256::digest(&body);
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    blob.extend_from_slice(digest.as_slice());
+    blob.extend_from_slice(&body);
+
+    match decode(&blob) {
+        Err(DecodeError::InvalidUtf8(_)) => {}
+        other => panic!("expected InvalidUtf8, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_invalid_prefix_bytes() {
+    // Hand-construct a body that encodes a DynString with prefix_bytes=3.
+    // Layout so the DynString tag is reached: we put it as the first instruction's
+    // first argument type.
+    //
+    // Building the simplest valid prefix:
+    //   address: ""                    (u32 0)
+    //   metadata: 4 empty strings      (4 * u32 0)
+    //   instructions: len=1
+    //     name: ""
+    //     discriminator: []
+    //     has_remaining: 0
+    //     accounts: len=0
+    //     args: len=1
+    //       name: ""
+    //       ty: tag=DYN_STRING, max_length=0, prefix_bytes=3  <-- invalid
+    //   accounts/events/types/errors: each len=0
+
+    let mut body = Vec::new();
+    // address
+    body.extend_from_slice(&0u32.to_le_bytes());
+    // metadata: name, crate_name, version, spec
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    }
+    // instructions: 1
+    body.extend_from_slice(&1u32.to_le_bytes());
+    // instruction[0]
+    body.extend_from_slice(&0u32.to_le_bytes()); // name ""
+    body.extend_from_slice(&0u32.to_le_bytes()); // discriminator []
+    body.push(0); // has_remaining=false
+    body.extend_from_slice(&0u32.to_le_bytes()); // accounts: 0
+    body.extend_from_slice(&1u32.to_le_bytes()); // args: 1
+    body.extend_from_slice(&0u32.to_le_bytes()); // arg name ""
+    body.push(wire::TAG_TYPE_DYN_STRING);
+    body.extend_from_slice(&0u32.to_le_bytes()); // max_length
+    body.push(3); // prefix_bytes = 3 (invalid)
+                  // accounts/events/types/errors
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    }
+
+    let digest = Sha256::digest(&body);
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    blob.extend_from_slice(digest.as_slice());
+    blob.extend_from_slice(&body);
+
+    match decode(&blob) {
+        Err(DecodeError::InvalidPrefixBytes(3)) => {}
+        other => panic!("expected InvalidPrefixBytes(3), got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_invalid_type_tag() {
+    // Same skeleton as the prefix_bytes test, but the IdlType tag is garbage.
+    let mut body = Vec::new();
+    body.extend_from_slice(&0u32.to_le_bytes()); // address
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    } // metadata
+    body.extend_from_slice(&1u32.to_le_bytes()); // instructions=1
+    body.extend_from_slice(&0u32.to_le_bytes()); // name
+    body.extend_from_slice(&0u32.to_le_bytes()); // disc
+    body.push(0); // has_remaining
+    body.extend_from_slice(&0u32.to_le_bytes()); // accounts=0
+    body.extend_from_slice(&1u32.to_le_bytes()); // args=1
+    body.extend_from_slice(&0u32.to_le_bytes()); // arg name
+    body.push(0x7F); // invalid IdlType tag
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    } // accounts/events/types/errors
+
+    let digest = Sha256::digest(&body);
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    blob.extend_from_slice(digest.as_slice());
+    blob.extend_from_slice(&body);
+
+    match decode(&blob) {
+        Err(DecodeError::InvalidTag {
+            location: "IdlType",
+            tag: 0x7F,
+        }) => {}
+        other => panic!("expected InvalidTag at IdlType, got {other:?}"),
+    }
+}
+
+#[test]
+fn decode_rejects_invalid_bool() {
+    // Body where an instruction's has_remaining byte is 0x02.
+    let mut body = Vec::new();
+    body.extend_from_slice(&0u32.to_le_bytes()); // address
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    } // metadata
+    body.extend_from_slice(&1u32.to_le_bytes()); // instructions=1
+    body.extend_from_slice(&0u32.to_le_bytes()); // name
+    body.extend_from_slice(&0u32.to_le_bytes()); // disc
+    body.push(0x02); // has_remaining: INVALID
+    body.extend_from_slice(&0u32.to_le_bytes()); // accounts=0
+    body.extend_from_slice(&0u32.to_le_bytes()); // args=0
+    for _ in 0..4 {
+        body.extend_from_slice(&0u32.to_le_bytes());
+    }
+
+    let digest = Sha256::digest(&body);
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&MAGIC);
+    blob.push(VERSION);
+    blob.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    blob.extend_from_slice(digest.as_slice());
+    blob.extend_from_slice(&body);
+
+    match decode(&blob) {
+        Err(DecodeError::InvalidBool(0x02)) => {}
+        other => panic!("expected InvalidBool(0x02), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Determinism: two independent encode calls yield the same bytes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn encode_is_deterministic_across_calls() {
+    let idl = Idl {
+        instructions: vec![IdlInstruction {
+            name: "x".to_string(),
+            discriminator: vec![1],
+            accounts: vec![],
+            args: vec![IdlField {
+                name: "a".to_string(),
+                ty: IdlType::Primitive("u8".to_string()),
+            }],
+            has_remaining: false,
+            args_layout: None,
+        }],
+        ..minimal_idl()
+    };
+
+    let a = encode(&idl);
+    let b = encode(&idl);
+    assert_eq!(a, b);
+
+    let body_a = encode_body(&idl);
+    let body_b = encode_body(&idl);
+    assert_eq!(body_a, body_b);
+}

--- a/schema-canonical/tests/roundtrip_test_program.rs
+++ b/schema-canonical/tests/roundtrip_test_program.rs
@@ -1,0 +1,44 @@
+//! End-to-end round-trip against a real parsed program.
+//!
+//! Parses a workspace test program via `quasar_idl`, builds an [`Idl`],
+//! canonical-encodes it, decodes, and asserts equality. This validates that
+//! every `IdlType` / `IdlSeed` / `IdlTypeDefKind` shape the parser emits from
+//! real source survives a round-trip — not just hand-crafted fixtures.
+//!
+//! Uses `test-pda` rather than `test-misc` because `test-misc` intentionally
+//! embeds discriminator collisions to exercise the collision detector in
+//! `build_idl`, so its `build_idl` call fails by design.
+
+use {
+    quasar_idl::parser,
+    quasar_schema_canonical::{decode, encode},
+    std::path::PathBuf,
+};
+
+#[test]
+fn test_program_round_trips() {
+    // `CARGO_MANIFEST_DIR` points at `.../quasar/schema-canonical`; go up one
+    // level then into `tests/programs/test-pda`.
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("schema-canonical has a parent directory")
+        .join("tests/programs/test-pda");
+
+    assert!(
+        crate_root.exists(),
+        "test-pda program not found at {}",
+        crate_root.display()
+    );
+
+    let parsed = parser::parse_program(&crate_root);
+    let idl = parser::build_idl(&parsed)
+        .unwrap_or_else(|errs| panic!("build_idl failed:\n{}", errs.join("\n")));
+
+    let blob = encode(&idl);
+    let decoded = decode(&blob).expect("canonical decode of real IDL should succeed");
+    assert_eq!(idl, decoded, "round-trip must preserve the IDL");
+
+    // Encoding is stable: decoding and re-encoding yields identical bytes.
+    let reencoded = encode(&decoded);
+    assert_eq!(blob, reencoded, "encoding is byte-for-byte deterministic");
+}

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -116,7 +116,7 @@ pub fn known_address_for_type(base: &str, inner: Option<&str>) -> Option<&'stati
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Idl {
     pub address: String,
     #[serde(default)]
@@ -133,7 +133,7 @@ pub struct Idl {
     pub errors: Vec<IdlError>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlMetadata {
     pub name: String,
     #[serde(skip)]
@@ -152,7 +152,7 @@ impl IdlMetadata {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlInstruction {
     pub name: String,
     pub discriminator: Vec<u8>,
@@ -169,7 +169,7 @@ pub struct IdlInstruction {
     pub args_layout: Option<String>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlAccountItem {
     pub name: String,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -186,12 +186,12 @@ fn is_false(b: &bool) -> bool {
     !b
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlPda {
     pub seeds: Vec<IdlSeed>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum IdlSeed {
     #[serde(rename = "const")]
@@ -202,14 +202,14 @@ pub enum IdlSeed {
     Arg { path: String },
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlField {
     pub name: String,
     #[serde(rename = "type")]
     pub ty: IdlType,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlDynString {
     #[serde(rename = "maxLength")]
     pub max_length: usize,
@@ -219,7 +219,7 @@ pub struct IdlDynString {
     pub prefix_bytes: usize,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlDynVec {
     pub items: Box<IdlType>,
     #[serde(rename = "maxLength")]
@@ -230,7 +230,7 @@ pub struct IdlDynVec {
     pub prefix_bytes: usize,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum IdlType {
     Primitive(String),
@@ -240,19 +240,19 @@ pub enum IdlType {
     DynVec { vec: IdlDynVec },
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlAccountDef {
     pub name: String,
     pub discriminator: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlEventDef {
     pub name: String,
     pub discriminator: Vec<u8>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlTypeDef {
     pub name: String,
     #[serde(rename = "type")]
@@ -265,13 +265,13 @@ pub enum IdlTypeDefKind {
     Struct,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlTypeDefType {
     pub kind: IdlTypeDefKind,
     pub fields: Vec<IdlField>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdlError {
     pub code: u32,
     pub name: String,


### PR DESCRIPTION
## Summary

Adds a new `quasar-schema-canonical` crate with a compact, deterministic, hash-verified binary encoding of `quasar_schema::Idl`. The encoder is a pure function — same input produces identical bytes — and the on-wire header carries a SHA-256 digest so a reader can authenticate the payload with a single `sol_sha256` syscall (~100 CU).

Purely additive: one new crate, a workspace `members` addition, and `Debug + Clone + PartialEq + Eq` derives on `Idl` (needed so round-trip tests can assert equality). No on-chain code, no derive changes, no CLI integration in this PR.

## Why

Today, a Quasar program's IDL lives only as `target/idl/*.json` on the author's disk. No client can fetch the schema at runtime, no explorer can self-describe an arbitrary Quasar program, and agents (wallets, LLMs, simulators) can't decode a program they don't already have the IDL for.

The long-term fix is to store the schema on-chain at a well-known PDA per program. Before touching anything on-chain, we need a compact, deterministic, hash-verified binary encoding — small enough to fit in rent-funded account data, stable enough that we can commit to the wire format, and byte-for-byte reproducible so the hash is meaningful.

This PR is that encoding.

## Wire format

See [`schema-canonical/SPEC.md`](https://github.com/blueshift-gg/quasar/blob/master/schema-canonical/SPEC.md) for the normative spec. Highlights:

- 40-byte header: `magic (3) | version (1) | body_len (u32 LE) | body_sha256 (32)`
- `u32` LE length prefixes throughout — no varints, no field tags, no hash-map iteration
- Explicit tag bytes for every `IdlType` / `IdlSeed` / `IdlTypeDefKind` variant
- Determinism: `encode(decode(encode(idl))) == encode(idl)` tested end-to-end

SHA-256 was chosen over BLAKE3 because `sol_sha256` is a native Solana syscall; on-chain verification in PR-1b costs one syscall, no hashing code in the program.

## Public API

```rust
pub fn encode(idl: &Idl) -> Vec<u8>;
pub fn decode(bytes: &[u8]) -> Result<Idl, DecodeError>;
pub fn encode_body(idl: &Idl) -> Vec<u8>;        // no header
pub fn decode_body(bytes: &[u8]) -> Result<Idl, DecodeError>;
pub use wire::{MAGIC, VERSION};
pub use error::{CanonicalError, DecodeError, EncodeError};
```

Encoding is infallible (allocation only); decoding can fail for any of: bad magic, unsupported version, truncated header/body, body-length mismatch, bad digest, invalid tag, invalid UTF-8, invalid `prefix_bytes`, invalid `bool` byte. Every branch has a `decode_rejects_*` test.

## Tests

- `tests/roundtrip_synthetic.rs` — 21 hand-built cases covering every `IdlType` variant, every `IdlSeed` kind, every valid `prefix_bytes` width (1/2/4/8), `Option<Option<T>>` recursion, idempotence, and every `DecodeError` variant.
- `tests/roundtrip_test_program.rs` — parses `tests/programs/test-pda` via `quasar_idl::parser`, canonical-encodes, decodes, and asserts equality.

`test-pda` rather than `test-misc` because `test-misc` intentionally embeds discriminator collisions to exercise `build_idl`'s collision detector, so its `build_idl` call fails by design.

## Verification

```bash
cargo test -p quasar-schema-canonical     # 22 tests pass
cargo test -p quasar-schema               # no regressions
cargo test -p quasar-idl                  # 72 tests, no regressions
cargo clippy -p quasar-schema-canonical --all-targets --no-deps
make format
```

All green locally.

## Follow-ups (not in this PR)

- **PR-1b**: `#[program]` macro emits `pub const __QUASAR_SCHEMA: &[u8]` and reserves an `upload_schema` instruction at discriminator `0xFE`. On-chain handler verifies `sol_sha256(body) == header.digest` before writing to the schema PDA.
- **PR-1c**: `quasar schema upload` / `quasar schema fetch` CLI + runtime fetch SDK for clients.

## Test plan

- [ ] `cargo test -p quasar-schema-canonical` passes in CI
- [ ] `make format` clean
- [ ] `cargo clippy` clean
- [ ] No regressions in `quasar-schema`, `quasar-idl`, `quasar-lang`, or `quasar-cli`