### PR TITLE
idl: emit erasable TypeScript enum objects

### DIFF
--- a/cli/tests/generated_clients_smoke.rs
+++ b/cli/tests/generated_clients_smoke.rs
@@ -92,12 +92,13 @@ fn compile_typescript_client(client_dir: &Path) -> Result<(), Box<dyn Error>> {
         client_dir.join("tsconfig.json"),
         r#"{
   "compilerOptions": {
-    "target": "ES2022",
+    "erasableSyntaxOnly": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "strict": true,
+    "noEmit": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "strict": true,
+    "target": "ES2022"
   },
   "include": ["web3.ts", "kit.ts"]
 }

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -338,11 +338,15 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     out.push_str("/* Enums */\n");
 
     if !idl.events.is_empty() {
-        out.push_str("export enum ProgramEvent {\n");
+        out.push_str("export const ProgramEvent = {\n");
         for event in &idl.events {
-            writeln!(out, "  {} = \"{}\",", event.name, event.name).expect("write to String");
+            writeln!(out, "  {}: \"{}\",", event.name, event.name).expect("write to String");
         }
-        out.push_str("}\n\n");
+        out.push_str("} as const;\n\n");
+
+        out.push_str(
+            "export type ProgramEvent =\n  (typeof ProgramEvent)[keyof typeof ProgramEvent];\n\n",
+        );
 
         out.push_str("export type DecodedEvent =\n");
         for (i, event) in idl.events.iter().enumerate() {
@@ -350,12 +354,12 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
             if has_type {
                 write!(
                     out,
-                    "  | {{ type: ProgramEvent.{}; data: {} }}",
+                    "  | {{ type: typeof ProgramEvent.{}; data: {} }}",
                     event.name, event.name
                 )
                 .expect("write to String");
             } else {
-                write!(out, "  | {{ type: ProgramEvent.{} }}", event.name)
+                write!(out, "  | {{ type: typeof ProgramEvent.{} }}", event.name)
                     .expect("write to String");
             }
             if i < idl.events.len() - 1 {
@@ -366,23 +370,28 @@ fn generate_ts(idl: &Idl, target: TsTarget) -> String {
     }
 
     if !idl.instructions.is_empty() {
-        out.push_str("export enum ProgramInstruction {\n");
+        out.push_str("export const ProgramInstruction = {\n");
         for ix in &idl.instructions {
             let pascal = snake_to_pascal(&ix.name);
-            writeln!(out, "  {} = \"{}\",", pascal, pascal).expect("write to String");
+            writeln!(out, "  {}: \"{}\",", pascal, pascal).expect("write to String");
         }
-        out.push_str("}\n\n");
+        out.push_str("} as const;\n\n");
+
+        out.push_str(
+            "export type ProgramInstruction =\n  (typeof ProgramInstruction)[keyof typeof \
+             ProgramInstruction];\n\n",
+        );
 
         out.push_str("export type DecodedInstruction =\n");
         for (i, ix) in idl.instructions.iter().enumerate() {
             let pascal = snake_to_pascal(&ix.name);
             if ix.args.is_empty() {
-                write!(out, "  | {{ type: ProgramInstruction.{} }}", pascal)
+                write!(out, "  | {{ type: typeof ProgramInstruction.{} }}", pascal)
                     .expect("write to String");
             } else {
                 write!(
                     out,
-                    "  | {{ type: ProgramInstruction.{}; args: {}InstructionArgs }}",
+                    "  | {{ type: typeof ProgramInstruction.{}; args: {}InstructionArgs }}",
                     pascal, pascal
                 )
                 .expect("write to String");

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -1567,6 +1567,70 @@ fn ts_codegen_prefix_aware_codecs() {
 }
 
 #[test]
+fn ts_codegen_uses_erasable_enum_objects() {
+    use quasar_idl::{codegen::typescript::generate_ts_client, parser::build_idl};
+
+    let mut parsed = test_program();
+    parsed.instructions.extend([
+        program::RawInstruction {
+            name: "initialize".to_string(),
+            discriminator: vec![0],
+            accounts_type_name: "Initialize".to_string(),
+            args: vec![],
+            has_remaining: false,
+        },
+        program::RawInstruction {
+            name: "deposit".to_string(),
+            discriminator: vec![1],
+            accounts_type_name: "Deposit".to_string(),
+            args: vec![("amount".to_string(), syn::parse_str("u64").unwrap())],
+            has_remaining: false,
+        },
+    ]);
+    parsed.accounts_structs = vec![
+        RawAccountsStruct {
+            name: "Initialize".to_string(),
+            fields: vec![],
+        },
+        RawAccountsStruct {
+            name: "Deposit".to_string(),
+            fields: vec![],
+        },
+    ];
+    parsed.events.push(events::RawEvent {
+        name: "Made".to_string(),
+        discriminator: vec![2],
+        fields: vec![("amount".to_string(), syn::parse_str("u64").unwrap())],
+    });
+
+    let idl = build_idl(&parsed).unwrap();
+    let code = generate_ts_client(&idl);
+
+    assert!(
+        code.contains("export const ProgramInstruction = {"),
+        "{code}"
+    );
+    assert!(code.contains("export type ProgramInstruction ="), "{code}");
+    assert!(
+        code.contains("typeof ProgramInstruction.Initialize"),
+        "{code}"
+    );
+    assert!(
+        code.contains("typeof ProgramInstruction.Deposit; args: DepositInstructionArgs"),
+        "{code}"
+    );
+    assert!(!code.contains("export enum ProgramInstruction"), "{code}");
+    assert!(code.contains("export const ProgramEvent = {"), "{code}");
+    assert!(code.contains("export type ProgramEvent ="), "{code}");
+    assert!(code.contains("typeof ProgramEvent.Made"), "{code}");
+    assert!(
+        code.contains("| { type: typeof ProgramEvent.Made; data: Made }"),
+        "{code}"
+    );
+    assert!(!code.contains("export enum ProgramEvent"), "{code}");
+}
+
+#[test]
 fn ts_codegen_pda_helpers_are_exported_and_reused() {
     use quasar_idl::{
         codegen::typescript::{generate_ts_client, generate_ts_client_kit},


### PR DESCRIPTION
Replace generated TypeScript `ProgramInstruction` and `ProgramEvent` `export enum` declarations with `as const` objects plus union types.

Before, generated clients used TS enums like:

```ts
export enum ProgramInstruction {
  Initialize = "Initialize",
}

export type DecodedInstruction = { type: ProgramInstruction.Initialize };
```

After, generated clients use erasable syntax:

```ts
export const ProgramInstruction = {
  Initialize: "Initialize",
} as const;

export type ProgramInstruction =
  (typeof ProgramInstruction)[keyof typeof ProgramInstruction];

export type DecodedInstruction = {
  type: typeof ProgramInstruction.Initialize;
};
```

This keeps the runtime values stable while making generated clients compatible with [`erasableSyntaxOnly`](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly) ([release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-8.html#the---erasablesyntaxonly-option)). It also removes enum emit from the generated TypeScript and lets the client smoke test enforce that mode.
