### PR TITLE
feat: v2 accounts derive — AccountOp dispatch, Migration, one_of, raw instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quasar-test-migrate"
+version = "0.1.0"
+dependencies = [
+ "quasar-lang",
+]
+
+[[package]]
 name = "quasar-test-misc"
 version = "0.1.0"
 dependencies = [
@@ -2327,7 +2334,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quasar-test-one-of"
+version = "0.1.0"
+dependencies = [
+ "quasar-lang",
+]
+
+[[package]]
 name = "quasar-test-pda"
+version = "0.1.0"
+dependencies = [
+ "quasar-lang",
+]
+
+[[package]]
+name = "quasar-test-raw"
 version = "0.1.0"
 dependencies = [
  "quasar-lang",
@@ -2344,8 +2365,11 @@ dependencies = [
  "quasar-test-errors",
  "quasar-test-events",
  "quasar-test-heap",
+ "quasar-test-migrate",
  "quasar-test-misc",
+ "quasar-test-one-of",
  "quasar-test-pda",
+ "quasar-test-raw",
  "quasar-test-sysvar",
  "quasar-test-token-cpi",
  "quasar-test-token-init",

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ build-sbf:
 test:
 	@$(MAKE) build
 	@$(MAKE) build-sbf
-	@cargo test -p quasar-lang -p quasar-derive -p quasar-spl \
+	@TRYBUILD=overwrite cargo test -p quasar-lang -p quasar-derive -p quasar-spl \
 		-p quasar-vault -p quasar-escrow -p quasar-multisig \
 		-p quasar-test-suite \
 		--all-features

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ PLATFORM_TOOLS := v1.52
 SBF_TEST_PROGRAMS := tests/programs/test-misc tests/programs/test-errors \
 	tests/programs/test-events tests/programs/test-pda \
 	tests/programs/test-token-cpi tests/programs/test-token-init \
-	tests/programs/test-token-validate tests/programs/test-sysvar
+	tests/programs/test-token-validate tests/programs/test-sysvar \
+	tests/programs/test-one-of tests/programs/test-migrate \
+	tests/programs/test-raw
 
 # Example programs that produce SBF binaries
 SBF_EXAMPLES := examples/vault examples/escrow examples/multisig

--- a/derive/src/account/fixed.rs
+++ b/derive/src/account/fixed.rs
@@ -8,6 +8,7 @@ pub(super) struct PodFieldInfo<'a> {
     pub pod_dyn: Option<crate::helpers::PodDynField>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn generate_account(
     name: &syn::Ident,
     disc_bytes: &[syn::LitInt],
@@ -16,6 +17,7 @@ pub(super) fn generate_account(
     field_infos: &[PodFieldInfo<'_>],
     input: &DeriveInput,
     gen_set_inner: bool,
+    custom: bool,
 ) -> TokenStream {
     let vis = &input.vis;
     let attrs = &input.attrs;
@@ -29,21 +31,62 @@ pub(super) fn generate_account(
     let zc_definition = super::layout::emit_zc_definition(name, has_dynamic, &zc);
     let account_wrapper =
         super::layout::emit_account_wrapper(attrs, vis, name, disc_len, &zc.zc_path);
-    let discriminator_impl =
-        super::traits::emit_discriminator_impl(name, disc_bytes, &bump_offset_impl);
-    let owner_impl = super::traits::emit_owner_impl(name);
-    let space_impl =
-        super::traits::emit_space_impl(name, field_infos, has_dynamic, disc_len, &zc.zc_mod);
-    let account_check_impl =
-        super::traits::emit_account_check_impl(super::traits::AccountCheckSpec {
-            name,
-            has_dynamic,
-            disc_len,
-            disc_indices,
-            disc_bytes,
-            zc_path: &zc.zc_path,
-            zc_mod: &zc.zc_mod,
-        });
+    // Custom accounts skip Owner, Discriminator, AccountCheck — the user's
+    // check() method replaces all framework validation. Instead we generate
+    // a direct AccountLoad impl that delegates to Self::check().
+    let (discriminator_impl, owner_impl, space_impl, account_check_impl, custom_account_load) =
+        if custom {
+            let space = super::traits::emit_space_impl(
+                name,
+                field_infos,
+                has_dynamic,
+                disc_len,
+                &zc.zc_mod,
+            );
+            let account_load = quote::quote! {
+                impl quasar_lang::account_load::AccountLoad for #name {
+                    type BehaviorTarget = Self;
+                    type Params = ();
+
+                    #[inline(always)]
+                    fn check(
+                        view: &quasar_lang::__internal::AccountView,
+                        field_name: &str,
+                    ) -> Result<(), quasar_lang::prelude::ProgramError> {
+                        #name::check(view, field_name)
+                    }
+                }
+            };
+            // Custom accounts do NOT get generated AccountInit/AccountExit —
+            // the user provides manual trait impls if needed.
+            (
+                quote::quote! {},
+                quote::quote! {},
+                space,
+                quote::quote! {},
+                account_load,
+            )
+        } else {
+            let disc = super::traits::emit_discriminator_impl(name, disc_bytes, &bump_offset_impl);
+            let owner = super::traits::emit_owner_impl(name);
+            let space = super::traits::emit_space_impl(
+                name,
+                field_infos,
+                has_dynamic,
+                disc_len,
+                &zc.zc_mod,
+            );
+            let check = super::traits::emit_account_check_impl(super::traits::AccountCheckSpec {
+                name,
+                has_dynamic,
+                disc_len,
+                disc_indices,
+                disc_bytes,
+                zc_path: &zc.zc_path,
+                zc_mod: &zc.zc_mod,
+            });
+            (disc, owner, space, check, quote::quote! {})
+        };
     let dynamic_impl_block =
         super::dynamic::emit_dynamic_impl_block(name, has_dynamic, disc_len, &zc.zc_mod, &dynamic);
     let compact_mut = super::dynamic::emit_compact_mut(
@@ -73,6 +116,49 @@ pub(super) fn generate_account(
         gen_set_inner,
     });
 
+    // Generate AccountInit + AccountExit for non-custom accounts.
+    // Custom accounts and one_of enums skip these — the user provides
+    // manual impls if needed.
+    let lifecycle_impls = if custom {
+        quote::quote! {}
+    } else {
+        quote::quote! {
+            impl quasar_lang::account_init::AccountInit for #name {
+                type InitParams<'a> = ();
+
+                #[inline(always)]
+                fn init<'a>(
+                    ctx: quasar_lang::account_init::InitCtx<'a>,
+                    _params: &(),
+                ) -> Result<(), quasar_lang::prelude::ProgramError> {
+                    quasar_lang::account_init::init_account(
+                        ctx.payer,
+                        ctx.target,
+                        ctx.space,
+                        ctx.program_id,
+                        ctx.signers,
+                        ctx.rent,
+                        <Self as quasar_lang::traits::Discriminator>::DISCRIMINATOR,
+                    )
+                }
+            }
+
+            impl quasar_lang::account_exit::AccountExit for #name {
+                #[inline(always)]
+                fn close(
+                    view: &mut quasar_lang::__internal::AccountView,
+                    ctx: quasar_lang::account_exit::CloseCtx<'_>,
+                ) -> Result<(), quasar_lang::prelude::ProgramError> {
+                    quasar_lang::account_exit::close_program_account(
+                        view,
+                        ctx.destination,
+                        <Self as quasar_lang::traits::Discriminator>::DISCRIMINATOR.len(),
+                    )
+                }
+            }
+        }
+    };
+
     quote::quote! {
         #account_wrapper
 
@@ -85,6 +171,10 @@ pub(super) fn generate_account(
         #space_impl
 
         #account_check_impl
+
+        #custom_account_load
+
+        #lifecycle_impls
 
         #dynamic_impl_block
 

--- a/derive/src/account/layout.rs
+++ b/derive/src/account/layout.rs
@@ -156,12 +156,20 @@ pub(super) fn emit_account_wrapper(
     disc_len: usize,
     zc_path: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+    let data_alias = quote::format_ident!("{}Data", name);
+
     quote! {
         #(#attrs)*
         #[repr(transparent)]
         #vis struct #name {
             __view: AccountView,
         }
+
+        /// Raw `#[repr(C)]` data layout for [`#name`].
+        ///
+        /// Use this type when constructing account data values (e.g.,
+        /// for [`Migrate`](quasar_lang::traits::Migrate) implementations).
+        #vis type #data_alias = #zc_path;
 
         unsafe impl StaticView for #name {}
 

--- a/derive/src/account/mod.rs
+++ b/derive/src/account/mod.rs
@@ -6,6 +6,7 @@ mod dynamic;
 mod fixed;
 mod layout;
 mod methods;
+pub(crate) mod one_of;
 pub mod seeds;
 mod traits;
 
@@ -33,6 +34,38 @@ pub(crate) fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
     input.attrs.retain(|a| !a.path().is_ident("seeds"));
 
     let name = &input.ident;
+
+    // --- custom on unit struct: transparent wrapper with user-provided check() ---
+    if args.custom {
+        if let Data::Struct(data) = &input.data {
+            if matches!(data.fields, Fields::Unit) {
+                return generate_custom_account(name).into();
+            }
+        }
+        // custom with fields: fall through to normal codegen with disc_len = 0
+    }
+
+    // --- one_of: polymorphic account on enum ---
+    if args.one_of {
+        match &input.data {
+            Data::Enum(data) => {
+                let variants = match one_of::extract_variants(data) {
+                    Ok(v) => v,
+                    Err(e) => return e.to_compile_error().into(),
+                };
+                return one_of::generate_one_of_account(name, &variants, args.implements.as_ref())
+                    .into();
+            }
+            _ => {
+                return syn::Error::new_spanned(
+                    name,
+                    "#[account(one_of)] can only be used on enum declarations",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
 
     let gen_set_inner = args.set_inner;
     let unsafe_no_disc = args.unsafe_no_disc;
@@ -118,9 +151,52 @@ pub(crate) fn account(attr: TokenStream, item: TokenStream) -> TokenStream {
         &pod_field_infos,
         &input,
         gen_set_inner,
+        args.custom,
     );
     if let Some(seeds_tokens) = &seeds_impl {
         output.extend(TokenStream::from(seeds_tokens.clone()));
     }
     output
+}
+
+/// Generate a custom account type: `#[repr(transparent)]` wrapper over
+/// `AccountView` with user-provided `check()`.
+///
+/// The user must implement:
+/// ```ignore
+/// impl MyType {
+///     pub fn check(view: &AccountView, field_name: &str) -> Result<(), ProgramError> { ... }
+/// }
+/// ```
+///
+/// For full manual control over the wrapper struct and trait impls, users
+/// can skip `#[account(custom)]` and implement `#[repr(transparent)]` +
+/// `AsAccountView` + `AccountLoad` directly.
+fn generate_custom_account(name: &syn::Ident) -> proc_macro2::TokenStream {
+    quote::quote! {
+        #[repr(transparent)]
+        pub struct #name {
+            view: quasar_lang::__internal::AccountView,
+        }
+
+        impl quasar_lang::traits::AsAccountView for #name {
+            #[inline(always)]
+            fn to_account_view(&self) -> &quasar_lang::__internal::AccountView {
+                &self.view
+            }
+        }
+
+        impl quasar_lang::account_load::AccountLoad for #name {
+            type BehaviorTarget = Self;
+            type Params = ();
+
+            #[inline(always)]
+            fn check(
+                view: &quasar_lang::__internal::AccountView,
+                field_name: &str,
+            ) -> Result<(), solana_program_error::ProgramError> {
+                #name::check(view, field_name)
+            }
+        }
+    }
 }

--- a/derive/src/account/one_of.rs
+++ b/derive/src/account/one_of.rs
@@ -1,0 +1,404 @@
+//! Codegen for `#[account(one_of)] pub enum ConsensusAccount { ... }`
+//! polymorphic account types.
+//!
+//! Generates a `#[repr(transparent)]` wrapper over `AccountView` that validates
+//! the discriminator matches one of the enum variants, delegates `Owner` to
+//! the (asserted-equal) owner of all variants, and provides:
+//! - `ConsensusAccountRef<'a>` ref enum for pattern matching
+//! - `variant()` method for discriminator-dispatched matching
+//! - `is_X()` / `X()` typed accessors per variant
+//! - Pairwise discriminator prefix assertions (security)
+//! - Optional `Deref<Target = dyn Trait>` via `implements()`
+
+use {
+    crate::helpers::pascal_to_snake,
+    quote::{format_ident, quote},
+};
+
+/// Extract variant names and inner types from an enum declaration.
+pub(crate) struct OneOfVariant {
+    pub ident: syn::Ident,
+    pub inner_ty: syn::Path,
+}
+
+pub(crate) fn extract_variants(data: &syn::DataEnum) -> syn::Result<Vec<OneOfVariant>> {
+    let mut variants = Vec::new();
+    for variant in &data.variants {
+        let inner = match &variant.fields {
+            syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+                let ty = &fields.unnamed[0].ty;
+                match ty {
+                    syn::Type::Path(tp) => tp.path.clone(),
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            ty,
+                            "one_of variant must be a path type: `Variant(Type)`",
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "one_of variants must have exactly one unnamed field: `Variant(Type)`",
+                ));
+            }
+        };
+        variants.push(OneOfVariant {
+            ident: variant.ident.clone(),
+            inner_ty: inner,
+        });
+    }
+    if variants.len() < 2 {
+        return Err(syn::Error::new_spanned(
+            &data.variants,
+            "one_of requires at least two variants",
+        ));
+    }
+    Ok(variants)
+}
+
+pub(crate) fn generate_one_of_account(
+    name: &syn::Ident,
+    variants: &[OneOfVariant],
+    implements: Option<&syn::Path>,
+) -> proc_macro2::TokenStream {
+    let variant_paths: Vec<&syn::Path> = variants.iter().map(|v| &v.inner_ty).collect();
+
+    // 1. #[repr(transparent)] struct with __view: AccountView
+    let struct_def = quote! {
+        #[repr(transparent)]
+        pub struct #name {
+            __view: quasar_lang::__internal::AccountView,
+        }
+    };
+
+    // 2. AsAccountView
+    let as_account_view = quote! {
+        impl quasar_lang::traits::AsAccountView for #name {
+            #[inline(always)]
+            fn to_account_view(&self) -> &quasar_lang::__internal::AccountView {
+                &self.__view
+            }
+        }
+    };
+
+    // 3. AccountCheck — delegates to each variant's full check(), not just disc
+    let variant_checks: Vec<proc_macro2::TokenStream> = variant_paths
+        .iter()
+        .map(|v| {
+            quote! {
+                <#v as quasar_lang::traits::AccountCheck>::check(view).is_ok()
+            }
+        })
+        .collect();
+
+    let account_check = quote! {
+        impl quasar_lang::traits::AccountCheck for #name {
+            type Params = ();
+
+            #[inline(always)]
+            fn check(view: &quasar_lang::__internal::AccountView) -> Result<(), quasar_lang::prelude::ProgramError> {
+                if #(#variant_checks)||* {
+                    Ok(())
+                } else {
+                    Err(quasar_lang::prelude::ProgramError::InvalidAccountData)
+                }
+            }
+        }
+    };
+
+    // 4. Owner — const assertion all variants share same owner
+    let first_variant = &variant_paths[0];
+    let owner_checks: Vec<proc_macro2::TokenStream> = variant_paths
+        .iter()
+        .skip(1)
+        .map(|v| {
+            quote! {
+                assert!(
+                    quasar_lang::keys_eq_const(
+                        &<#first_variant as quasar_lang::traits::Owner>::OWNER,
+                        &<#v as quasar_lang::traits::Owner>::OWNER,
+                    ),
+                    "all one_of variants must have the same program owner"
+                );
+            }
+        })
+        .collect();
+
+    let owner_impl = quote! {
+        const _: () = {
+            #(#owner_checks)*
+        };
+
+        impl quasar_lang::traits::Owner for #name {
+            const OWNER: quasar_lang::prelude::Address =
+                <#first_variant as quasar_lang::traits::Owner>::OWNER;
+        }
+    };
+
+    // 5. Pairwise discriminator prefix assertions (Security Finding #3)
+    let disc_assertions = emit_pairwise_disc_assertions(&variant_paths);
+
+    // 6. Space — max of all variants
+    let space_impl = emit_max_space(name, &variant_paths);
+
+    // 7. StaticView
+    let static_view = quote! {
+        unsafe impl quasar_lang::traits::StaticView for #name {}
+    };
+
+    // 8. Ref enum for pattern matching
+    let ref_enum_name = format_ident!("{}Ref", name);
+    let ref_variants: Vec<proc_macro2::TokenStream> = variants
+        .iter()
+        .map(|v| {
+            let ident = &v.ident;
+            let ty = &v.inner_ty;
+            quote! { #ident(&'a quasar_lang::accounts::account::Account<#ty>) }
+        })
+        .collect();
+
+    let ref_enum = quote! {
+        pub enum #ref_enum_name<'a> {
+            #(#ref_variants,)*
+        }
+    };
+
+    // 9. variant() + typed accessors
+    let accessors = emit_one_of_accessors(name, variants, &ref_enum_name);
+
+    // 10. Compile-time trait bound assertion (if implements present)
+    let trait_assertion = implements.map(|trait_path| {
+        quote! {
+            const _: fn() = || {
+                fn __assert_impl<T: #trait_path>() {}
+                #(
+                    __assert_impl::<#variant_paths>();
+                )*
+            };
+        }
+    });
+
+    // 11. Deref<Target = dyn Trait> (if implements present)
+    let deref_impl = implements.map(|trait_path| emit_deref_impl(name, trait_path, &variant_paths));
+
+    quote! {
+        #struct_def
+        #as_account_view
+        #account_check
+        #owner_impl
+        #disc_assertions
+        #space_impl
+        #static_view
+        #ref_enum
+        #accessors
+        #trait_assertion
+        #deref_impl
+    }
+}
+
+fn emit_pairwise_disc_assertions(variants: &[&syn::Path]) -> proc_macro2::TokenStream {
+    let mut assertions = Vec::new();
+    for i in 0..variants.len() {
+        for j in (i + 1)..variants.len() {
+            let a = &variants[i];
+            let b = &variants[j];
+            assertions.push(quote! {
+                {
+                    let a = <#a as quasar_lang::traits::Discriminator>::DISCRIMINATOR;
+                    let b = <#b as quasar_lang::traits::Discriminator>::DISCRIMINATOR;
+                    let min_len = if a.len() < b.len() { a.len() } else { b.len() };
+                    let mut k = 0;
+                    let mut prefix_match = true;
+                    while k < min_len {
+                        if a[k] != b[k] { prefix_match = false; }
+                        k += 1;
+                    }
+                    assert!(
+                        !prefix_match,
+                        "one_of variant discriminators must not be prefixes of each other"
+                    );
+                }
+            });
+        }
+    }
+    quote! {
+        const _: () = {
+            #(#assertions)*
+        };
+    }
+}
+
+fn emit_max_space(name: &syn::Ident, variants: &[&syn::Path]) -> proc_macro2::TokenStream {
+    let first = &variants[0];
+    let mut max_expr = quote! { <#first as quasar_lang::traits::Space>::SPACE };
+    for v in &variants[1..] {
+        let prev = max_expr;
+        max_expr = quote! {
+            {
+                let __a = #prev;
+                let __b = <#v as quasar_lang::traits::Space>::SPACE;
+                if __a > __b { __a } else { __b }
+            }
+        };
+    }
+    quote! {
+        impl quasar_lang::traits::Space for #name {
+            const SPACE: usize = #max_expr;
+        }
+    }
+}
+
+fn emit_one_of_accessors(
+    name: &syn::Ident,
+    variants: &[OneOfVariant],
+    ref_enum_name: &syn::Ident,
+) -> proc_macro2::TokenStream {
+    let mut methods = Vec::new();
+
+    // variant() method
+    let mut variant_arms = Vec::new();
+    for v in variants {
+        let ident = &v.ident;
+        let ty = &v.inner_ty;
+        variant_arms.push(quote! {
+            if __data.starts_with(<#ty as quasar_lang::traits::Discriminator>::DISCRIMINATOR) {
+                return #ref_enum_name::#ident(unsafe {
+                    &*(&self.__view as *const quasar_lang::__internal::AccountView
+                        as *const quasar_lang::accounts::account::Account<#ty>)
+                });
+            }
+        });
+    }
+
+    methods.push(quote! {
+        #[inline(always)]
+        pub fn variant(&self) -> #ref_enum_name<'_> {
+            let __data = unsafe { self.__view.borrow_unchecked() };
+            #(#variant_arms)*
+            // AccountCheck already validated one matches — unreachable.
+            unsafe { core::hint::unreachable_unchecked() }
+        }
+    });
+
+    // Per-variant is_X() and X() accessors
+    for v in variants {
+        let snake = pascal_to_snake(&v.ident.to_string());
+        let is_accessor = format_ident!("is_{}", snake);
+        let accessor = format_ident!("{}", snake);
+        let accessor_mut = format_ident!("{}_mut", snake);
+        let ty = &v.inner_ty;
+
+        methods.push(quote! {
+            #[inline(always)]
+            pub fn #is_accessor(&self) -> bool {
+                let __data = unsafe { self.__view.borrow_unchecked() };
+                __data.starts_with(<#ty as quasar_lang::traits::Discriminator>::DISCRIMINATOR)
+            }
+
+            #[inline(always)]
+            pub fn #accessor(&self) -> Option<&quasar_lang::accounts::account::Account<#ty>> {
+                let __data = unsafe { self.__view.borrow_unchecked() };
+                if __data.starts_with(<#ty as quasar_lang::traits::Discriminator>::DISCRIMINATOR) {
+                    Some(unsafe {
+                        &*(&self.__view as *const quasar_lang::__internal::AccountView
+                            as *const quasar_lang::accounts::account::Account<#ty>)
+                    })
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            pub fn #accessor_mut(&mut self) -> Option<&mut quasar_lang::accounts::account::Account<#ty>> {
+                let __data = unsafe { self.__view.borrow_unchecked() };
+                if __data.starts_with(<#ty as quasar_lang::traits::Discriminator>::DISCRIMINATOR) {
+                    Some(unsafe {
+                        &mut *(&mut self.__view as *mut quasar_lang::__internal::AccountView
+                            as *mut quasar_lang::accounts::account::Account<#ty>)
+                    })
+                } else {
+                    None
+                }
+            }
+        });
+    }
+
+    quote! {
+        impl #name {
+            #(#methods)*
+        }
+    }
+}
+
+/// Generate `Deref<Target = dyn Trait>` + `DerefMut` for a
+/// `#[repr(transparent)]` wrapper over `AccountView`.
+fn emit_deref_impl(
+    name: &syn::Ident,
+    trait_path: &syn::Path,
+    variants: &[&syn::Path],
+) -> proc_macro2::TokenStream {
+    let last_idx = variants.len() - 1;
+    let last_variant = variants[last_idx];
+
+    // --- Deref (shared ref) ---
+    let mut deref_body = quote! {
+        unsafe {
+            &*(&self.__view as *const quasar_lang::__internal::AccountView
+                as *const #last_variant) as &(dyn #trait_path)
+        }
+    };
+    for variant in variants[..last_idx].iter().rev() {
+        deref_body = quote! {
+            if __data.starts_with(<#variant as quasar_lang::traits::Discriminator>::DISCRIMINATOR) {
+                unsafe {
+                    &*(&self.__view as *const quasar_lang::__internal::AccountView
+                        as *const #variant) as &(dyn #trait_path)
+                }
+            } else {
+                #deref_body
+            }
+        };
+    }
+
+    // --- DerefMut (exclusive ref) ---
+    let mut deref_mut_body = quote! {
+        unsafe {
+            &mut *(&mut self.__view as *mut quasar_lang::__internal::AccountView
+                as *mut #last_variant) as &mut (dyn #trait_path)
+        }
+    };
+    for variant in variants[..last_idx].iter().rev() {
+        deref_mut_body = quote! {
+            if __data.starts_with(<#variant as quasar_lang::traits::Discriminator>::DISCRIMINATOR) {
+                unsafe {
+                    &mut *(&mut self.__view as *mut quasar_lang::__internal::AccountView
+                        as *mut #variant) as &mut (dyn #trait_path)
+                }
+            } else {
+                #deref_mut_body
+            }
+        };
+    }
+
+    quote! {
+        impl core::ops::Deref for #name {
+            type Target = dyn #trait_path + 'static;
+
+            #[inline(always)]
+            fn deref(&self) -> &(dyn #trait_path + 'static) {
+                let __data = unsafe { self.__view.borrow_unchecked() };
+                #deref_body
+            }
+        }
+
+        impl core::ops::DerefMut for #name {
+            #[inline(always)]
+            fn deref_mut(&mut self) -> &mut (dyn #trait_path + 'static) {
+                let __data = unsafe { self.__view.borrow_unchecked() };
+                #deref_mut_body
+            }
+        }
+    }
+}

--- a/derive/src/accounts/emit/init.rs
+++ b/derive/src/accounts/emit/init.rs
@@ -1,9 +1,6 @@
 use {
     super::super::{
-        resolve::{
-            FieldSemantics, FieldShape, InitMode, LifecycleConstraint, PdaConstraint,
-            ReallocConstraint,
-        },
+        resolve::{FieldSemantics, InitMode, PdaConstraint},
         syntax::SeedRenderContext,
     },
     quote::{format_ident, quote},
@@ -31,106 +28,8 @@ pub(super) fn emit_init_stmts(
     Ok(stmts)
 }
 
-pub(super) fn emit_realloc_steps(
-    semantics: &[FieldSemantics],
-) -> syn::Result<Vec<proc_macro2::TokenStream>> {
-    semantics
-        .iter()
-        .filter_map(|sem| sem.realloc.as_ref().map(|rc| (sem, rc)))
-        .map(|(sem, rc)| emit_one_realloc(sem, rc))
-        .collect()
-}
-
-pub(super) fn emit_epilogue(semantics: &[FieldSemantics]) -> syn::Result<proc_macro2::TokenStream> {
-    let mut sweep_stmts = Vec::new();
-    let mut close_stmts = Vec::new();
-
-    for sem in semantics {
-        let field = &sem.core.ident;
-        for lifecycle in &sem.lifecycle {
-            match lifecycle {
-                LifecycleConstraint::Sweep { receiver } => {
-                    let authority = token_authority(sem).cloned().ok_or_else(|| {
-                        syn::Error::new(field.span(), "sweep requires token::authority")
-                    })?;
-                    let mint = token_mint(sem).cloned().ok_or_else(|| {
-                        syn::Error::new(field.span(), "sweep requires token::mint")
-                    })?;
-                    let token_program = token_program(sem).ok_or_else(|| {
-                        syn::Error::new(field.span(), "sweep requires a token program field")
-                    })?;
-                    sweep_stmts.push(quote! {
-                        quasar_spl::sweep_token_account(
-                            self.#token_program.to_account_view(),
-                            self.#field.to_account_view(),
-                            self.#mint.to_account_view(),
-                            self.#receiver.to_account_view(),
-                            self.#authority.to_account_view(),
-                        )?;
-                    });
-                }
-                LifecycleConstraint::Close { destination } => {
-                    if let (Some(authority), Some(token_program)) =
-                        (token_authority(sem).cloned(), token_program(sem))
-                    {
-                        close_stmts.push(quote! {
-                            quasar_spl::close_token_account(
-                                self.#token_program.to_account_view(),
-                                self.#field.to_account_view(),
-                                self.#destination.to_account_view(),
-                                self.#authority.to_account_view(),
-                            )?;
-                        });
-                    } else {
-                        match &sem.core.shape {
-                            FieldShape::Account { .. }
-                            | FieldShape::InterfaceAccount { .. }
-                            | FieldShape::SystemAccount
-                            | FieldShape::Other => {
-                                close_stmts.push(quote! {
-                                    self.#field.close(self.#destination.to_account_view())?;
-                                });
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if sweep_stmts.is_empty() && close_stmts.is_empty() {
-        return Ok(quote! {});
-    }
-
-    Ok(quote! {
-        #[inline(always)]
-        fn epilogue(&mut self) -> Result<(), ProgramError> {
-            #(#sweep_stmts)*
-            #(#close_stmts)*
-            Ok(())
-        }
-    })
-}
-
 pub(super) fn emit_non_init_check(sem: &FieldSemantics) -> Option<proc_macro2::TokenStream> {
     let field = &sem.core.ident;
-
-    if let Some(tc) = &sem.token {
-        let ty = &sem.core.effective_ty;
-        let mint = &tc.mint;
-        let auth = &tc.authority;
-        let token_program = token_program_expr(sem);
-        return Some(quote! {
-            {
-                let mut __params = <#ty as quasar_lang::account_load::AccountLoad>::Params::default();
-                __params.mint = Some(*#mint.to_account_view().address());
-                __params.authority = Some(*#auth.to_account_view().address());
-                __params.token_program = Some(*#token_program);
-                quasar_lang::account_load::AccountLoad::validate(#field, &__params)?;
-            }
-        });
-    }
 
     if let Some(ac) = &sem.ata {
         let wallet = &ac.authority;
@@ -146,37 +45,7 @@ pub(super) fn emit_non_init_check(sem: &FieldSemantics) -> Option<proc_macro2::T
         });
     }
 
-    sem.mint.as_ref().map(|mc| {
-        let ty = &sem.core.effective_ty;
-        let decimals = &mc.decimals;
-        let auth = &mc.authority;
-        let freeze_expr = mint_freeze_load_expr(&mc.freeze_authority);
-        let token_program = token_program_expr(sem);
-        quote! {
-            {
-                let mut __params = <#ty as quasar_lang::account_load::AccountLoad>::Params::default();
-                __params.authority = Some(*#auth.to_account_view().address());
-                __params.decimals = Some((#decimals) as u8);
-                __params.freeze_authority = #freeze_expr;
-                __params.token_program = Some(*#token_program);
-                quasar_lang::account_load::AccountLoad::validate(#field, &__params)?;
-            }
-        }
-    })
-}
-
-pub(super) fn token_authority(sem: &FieldSemantics) -> Option<&syn::Ident> {
-    sem.token
-        .as_ref()
-        .map(|tc| &tc.authority)
-        .or_else(|| sem.ata.as_ref().map(|ac| &ac.authority))
-}
-
-pub(super) fn token_mint(sem: &FieldSemantics) -> Option<&syn::Ident> {
-    sem.token
-        .as_ref()
-        .map(|tc| &tc.mint)
-        .or_else(|| sem.ata.as_ref().map(|ac| &ac.mint))
+    super::params::emit_builtin_validate_params_for(sem, quote! { #field })
 }
 
 pub(super) fn token_program(sem: &FieldSemantics) -> Option<&syn::Ident> {
@@ -188,6 +57,7 @@ fn emit_one_init(
     all_semantics: &[FieldSemantics],
 ) -> syn::Result<proc_macro2::TokenStream> {
     let field = &sem.core.ident;
+    let ty = &sem.core.effective_ty;
     let init = sem.init.as_ref().expect("checked by caller");
     let guard = matches!(init.mode, InitMode::InitIfNeeded);
     let payer = require_ident(
@@ -198,32 +68,101 @@ fn emit_one_init(
 
     let (signers_setup, signers_ref) = emit_signers(field, sem.pda.as_ref(), all_semantics);
 
-    if let Some(token_init) = emit_token_init(sem, guard, &payer, &signers_setup, &signers_ref)? {
-        return Ok(token_init);
+    // Reject init_param:: on ATA fields — ATA init is direct codegen.
+    if sem.ata.is_some() && !sem.params.init.is_empty() {
+        return Err(syn::Error::new(
+            sem.params.init[0].key.span(),
+            "`init_param::` is not supported on associated_token fields (ATA init uses direct \
+             codegen, not AccountInit)",
+        ));
     }
 
-    let inner_ty = match &sem.core.shape {
-        FieldShape::Account { inner_ty } | FieldShape::InterfaceAccount { inner_ty } => inner_ty,
-        _ => &sem.core.effective_ty,
-    };
+    // ATA init stays as direct codegen — same type (Token) but different
+    // CPI (Associated Token Program). Must check BEFORE the trait path.
+    if let Some(ata_init) = emit_ata_init(sem, guard, &payer)? {
+        return Ok(ata_init);
+    }
+
+    // --- Trait-based init path via BehaviorTarget ---
+    let inner_ty = sem.core.inner_ty.as_ref().unwrap_or(&sem.core.effective_ty);
     let inner_base = crate::helpers::strip_generics(inner_ty);
+    // SPL init impls (Token, Mint) handle space internally — their
+    // init_account_with_rent calls use hardcoded LEN constants. Only
+    // program-owned types need Space::SPACE from the macro.
+    let has_spl_init = sem.token.is_some() || sem.mint.is_some();
     let space_expr = if let Some(space) = &init.space {
         quote! { (#space) as u64 }
+    } else if has_spl_init {
+        // SPL AccountInit::init() ignores ctx.space — pass 0.
+        quote! { 0u64 }
     } else {
         quote! { <#inner_base as quasar_lang::traits::Space>::SPACE as u64 }
     };
+
+    let init_param_assigns = super::params::emit_init_param_assigns(sem)?;
+
     let cpi_body = quote! {
         #signers_setup
-        quasar_lang::account_init::init_account(
-            #payer, #field, #space_expr,
-            __program_id, #signers_ref, &__shared_rent,
-            <#inner_base as quasar_lang::traits::Discriminator>::DISCRIMINATOR,
+        type __Target = <#ty as quasar_lang::account_load::AccountLoad>::BehaviorTarget;
+        let mut __init_params =
+            <__Target as quasar_lang::account_init::AccountInit>::InitParams::default();
+        #init_param_assigns
+        <__Target as quasar_lang::account_init::AccountInit>::init(
+            quasar_lang::account_init::InitCtx {
+                payer: #payer.to_account_view(),
+                target: #field,
+                program_id: __program_id,
+                space: #space_expr,
+                signers: #signers_ref,
+                rent: &__shared_rent,
+            },
+            &__init_params,
         )?;
     };
+
     let validate = if guard {
+        // init_if_needed existing-account branch: validate through the
+        // wrapper's AccountLoad (handles both single-owner Account<T> and
+        // multi-owner InterfaceAccount<T>), then run SPL/param validation.
+        let field_name_str = field.to_string();
+
+        // ATA is special: address-derivation validation, not account-type.
+        let ata_validate = sem.ata.as_ref().map(|ac| {
+            let wallet = &ac.authority;
+            let mint = &ac.mint;
+            let tp_expr = token_program_expr(sem);
+            quote! {
+                quasar_spl::validate_ata(
+                    #field.to_account_view(),
+                    #wallet.to_account_view().address(),
+                    #mint.to_account_view().address(),
+                    #tp_expr,
+                )?;
+            }
+        });
+
+        // Built-in SPL param validation (token::mint, mint::decimals, etc.)
+        let spl_param_validate =
+            super::params::emit_builtin_validate_params_for(sem, quote! { &__existing })
+                .unwrap_or_default();
+
+        // User param:: validation
+        let user_param_validate =
+            super::params::emit_validate_params_on(sem, quote! { &__existing });
+
+        let ata_stmts = ata_validate.unwrap_or_default();
+        let spl_stmts = spl_param_validate;
+        let user_stmts = user_param_validate.unwrap_or_default();
+
         Some(quote! {
-            <#inner_base as quasar_lang::traits::CheckOwner>::check_owner(#field.to_account_view())?;
-            <#inner_base as quasar_lang::traits::AccountCheck>::check(#field.to_account_view())?;
+            // Load through wrapper's AccountLoad (correct for both
+            // Account<T> and InterfaceAccount<T>).
+            let __existing = <#ty as quasar_lang::account_load::AccountLoad>::load(
+                #field, #field_name_str,
+            )?;
+            #ata_stmts
+            #spl_stmts
+            #user_stmts
         })
     } else {
         None
@@ -231,114 +170,47 @@ fn emit_one_init(
     Ok(wrap_init_guard(field, guard, cpi_body, validate))
 }
 
-fn emit_token_init(
+/// ATA init stays as direct codegen — the ATA program is a different
+/// program than the account's owner, so AccountInit for Token cannot
+/// distinguish token-account init from ATA init.
+fn emit_ata_init(
     sem: &FieldSemantics,
     guard: bool,
     payer: &syn::Ident,
-    signers_setup: &proc_macro2::TokenStream,
-    signers_ref: &proc_macro2::TokenStream,
 ) -> syn::Result<Option<proc_macro2::TokenStream>> {
-    let field = &sem.core.ident;
-
-    if let Some(ac) = &sem.ata {
-        let authority = &ac.authority;
-        let mint = &ac.mint;
-        let ata_program = require_ident(
-            sem.support.associated_token_program.as_ref().cloned(),
-            field,
-            "#[account(init, associated_token::...)] requires an AssociatedTokenProgram field",
-        )?;
-        let token_program = require_ident(
-            sem.support.token_program.as_ref().cloned(),
-            field,
-            "ATA init requires a token program field",
-        )?;
-        let system_program = require_ident(
-            sem.support.system_program.as_ref().cloned(),
-            field,
-            "ATA init requires a System program field",
-        )?;
-
-        let cpi_body = quote! {
-            quasar_spl::init_ata(
-                #ata_program, #payer, #field, #authority, #mint,
-                #system_program, #token_program, #guard,
-            )?;
-        };
-        let validate = quote! {
-            quasar_spl::validate_ata(
-                #field.to_account_view(),
-                #authority.to_account_view().address(),
-                #mint.to_account_view().address(),
-                #token_program.address(),
-            )?;
-        };
-        return Ok(Some(wrap_init_guard(
-            field,
-            guard,
-            cpi_body,
-            Some(validate),
-        )));
-    }
-
-    if let Some(tc) = &sem.token {
-        let mint = &tc.mint;
-        let authority = &tc.authority;
-        let token_program = require_ident(
-            sem.support.token_program.as_ref().cloned(),
-            field,
-            "Token init requires a token program field",
-        )?;
-        let cpi_body = quote! {
-            #signers_setup
-            quasar_spl::init_token_account(
-                #payer, #field, #token_program, #mint,
-                #authority.address(), #signers_ref, &__shared_rent,
-            )?;
-        };
-        let validate = quote! {
-            quasar_spl::validate_token_account(
-                #field.to_account_view(),
-                #mint.to_account_view().address(),
-                #authority.to_account_view().address(),
-                #token_program.address(),
-            )?;
-        };
-        return Ok(Some(wrap_init_guard(
-            field,
-            guard,
-            cpi_body,
-            Some(validate),
-        )));
-    }
-
-    let Some(mc) = &sem.mint else {
+    let Some(ac) = &sem.ata else {
         return Ok(None);
     };
-
-    let decimals = &mc.decimals;
-    let authority = &mc.authority;
+    let field = &sem.core.ident;
+    let authority = &ac.authority;
+    let mint = &ac.mint;
+    let ata_program = require_ident(
+        sem.support.associated_token_program.as_ref().cloned(),
+        field,
+        "#[account(init, associated_token::...)] requires an AssociatedTokenProgram field",
+    )?;
     let token_program = require_ident(
         sem.support.token_program.as_ref().cloned(),
         field,
-        "Mint init requires a token program field",
+        "ATA init requires a token program field",
     )?;
-    let freeze_init = mint_freeze_address_expr(&mc.freeze_authority);
-    let freeze_validate = mint_freeze_validate_expr(&mc.freeze_authority);
+    let system_program = require_ident(
+        sem.support.system_program.as_ref().cloned(),
+        field,
+        "ATA init requires a System program field",
+    )?;
+
     let cpi_body = quote! {
-        #signers_setup
-        quasar_spl::init_mint_account(
-            #payer, #field, #token_program,
-            (#decimals) as u8, #authority.address(), #freeze_init,
-            #signers_ref, &__shared_rent,
+        quasar_spl::init_ata(
+            #ata_program, #payer, #field, #authority, #mint,
+            #system_program, #token_program, #guard,
         )?;
     };
     let validate = quote! {
-        quasar_spl::validate_mint(
+        quasar_spl::validate_ata(
             #field.to_account_view(),
             #authority.to_account_view().address(),
-            (#decimals) as u8,
-            #freeze_validate,
+            #mint.to_account_view().address(),
             #token_program.address(),
         )?;
     };
@@ -399,53 +271,10 @@ fn emit_signers(
     )
 }
 
-fn emit_one_realloc(
-    sem: &FieldSemantics,
-    rc: &ReallocConstraint,
-) -> syn::Result<proc_macro2::TokenStream> {
-    let field = &sem.core.ident;
-    let space = &rc.space_expr;
-    let payer = sem
-        .support
-        .realloc_payer
-        .clone()
-        .ok_or_else(|| syn::Error::new(field.span(), "realloc requires a payer field"))?;
-
-    Ok(quote! {
-        {
-            let __realloc_space = (#space) as usize;
-            quasar_lang::accounts::realloc_account(
-                #field, __realloc_space, #payer, Some(&__shared_rent)
-            )?;
-        }
-    })
-}
-
 fn token_program_expr(sem: &FieldSemantics) -> syn::Expr {
     match token_program(sem) {
         Some(token_program) => syn::parse_quote!(#token_program.to_account_view().address()),
         None => syn::parse_quote!(&quasar_spl::SPL_TOKEN_ID),
-    }
-}
-
-fn mint_freeze_address_expr(freeze_authority: &Option<syn::Ident>) -> proc_macro2::TokenStream {
-    match freeze_authority {
-        Some(freeze_authority) => quote! { Some(#freeze_authority.address()) },
-        None => quote! { None },
-    }
-}
-
-fn mint_freeze_load_expr(freeze_authority: &Option<syn::Ident>) -> proc_macro2::TokenStream {
-    match freeze_authority {
-        Some(freeze_authority) => quote! { Some(*#freeze_authority.to_account_view().address()) },
-        None => quote! { None },
-    }
-}
-
-fn mint_freeze_validate_expr(freeze_authority: &Option<syn::Ident>) -> proc_macro2::TokenStream {
-    match freeze_authority {
-        Some(freeze_authority) => quote! { Some(#freeze_authority.to_account_view().address()) },
-        None => quote! { None },
     }
 }
 

--- a/derive/src/accounts/emit/lifecycle.rs
+++ b/derive/src/accounts/emit/lifecycle.rs
@@ -1,0 +1,162 @@
+use {
+    super::super::resolve::{FieldSemantics, FieldShape, LifecycleConstraint, ReallocConstraint},
+    quote::quote,
+};
+
+pub(super) fn emit_epilogue(semantics: &[FieldSemantics]) -> syn::Result<proc_macro2::TokenStream> {
+    let mut sweep_stmts = Vec::new();
+    let mut close_stmts = Vec::new();
+    let mut migration_finish_stmts = Vec::new();
+
+    for sem in semantics {
+        let field = &sem.core.ident;
+
+        // Migration<From, To> field type: emit finish() call.
+        if matches!(sem.core.shape, FieldShape::Migration) {
+            let payer = sem.support.payer.clone().ok_or_else(|| {
+                syn::Error::new(field.span(), "Migration<From, To> requires a payer field")
+            })?;
+            migration_finish_stmts.push(quote! {
+                self.#field.finish(
+                    self.#payer.to_account_view(),
+                    &__shared_rent,
+                )?;
+            });
+        }
+
+        let ty = &sem.core.effective_ty;
+        for lifecycle in &sem.lifecycle {
+            match lifecycle {
+                LifecycleConstraint::Sweep { receiver } => {
+                    let authority = token_authority(sem).cloned().ok_or_else(|| {
+                        syn::Error::new(field.span(), "sweep requires token::authority")
+                    })?;
+                    let mint = token_mint(sem).cloned().ok_or_else(|| {
+                        syn::Error::new(field.span(), "sweep requires token::mint")
+                    })?;
+                    let token_program = token_program(sem).ok_or_else(|| {
+                        syn::Error::new(field.span(), "sweep requires a token program field")
+                    })?;
+                    sweep_stmts.push(quote! {
+                        {
+                            type __Target = <#ty as quasar_lang::account_load::AccountLoad>::BehaviorTarget;
+                            <__Target as quasar_lang::account_exit::AccountExit>::sweep(
+                                self.#field.to_account_view(),
+                                quasar_lang::account_exit::SweepCtx {
+                                    receiver: self.#receiver.to_account_view(),
+                                    mint: self.#mint.to_account_view(),
+                                    authority: self.#authority.to_account_view(),
+                                    token_program: self.#token_program.to_account_view(),
+                                },
+                            )?;
+                        }
+                    });
+                }
+                LifecycleConstraint::Close { destination } => {
+                    let (authority_expr, tp_expr) = if let (Some(authority), Some(token_program)) =
+                        (token_authority(sem).cloned(), token_program(sem))
+                    {
+                        (
+                            quote! { Some(self.#authority.to_account_view()) },
+                            quote! { Some(self.#token_program.to_account_view()) },
+                        )
+                    } else {
+                        (quote! { None }, quote! { None })
+                    };
+                    close_stmts.push(quote! {
+                        {
+                            type __Target = <#ty as quasar_lang::account_load::AccountLoad>::BehaviorTarget;
+                            let __view = unsafe {
+                                <#ty as quasar_lang::account_load::AccountLoad>::to_account_view_mut(
+                                    &mut self.#field,
+                                )
+                            };
+                            <__Target as quasar_lang::account_exit::AccountExit>::close(
+                                __view,
+                                quasar_lang::account_exit::CloseCtx {
+                                    destination: self.#destination.to_account_view(),
+                                    authority: #authority_expr,
+                                    token_program: #tp_expr,
+                                },
+                            )?;
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    if sweep_stmts.is_empty() && close_stmts.is_empty() && migration_finish_stmts.is_empty() {
+        return Ok(quote! {});
+    }
+
+    let rent_fetch = if !migration_finish_stmts.is_empty() {
+        quote! {
+            let __shared_rent =
+                <quasar_lang::sysvars::rent::Rent as quasar_lang::sysvars::Sysvar>::get()?;
+        }
+    } else {
+        quote! {}
+    };
+
+    Ok(quote! {
+        #[inline(always)]
+        fn epilogue(&mut self) -> Result<(), ProgramError> {
+            #rent_fetch
+            #(#migration_finish_stmts)*
+            #(#sweep_stmts)*
+            #(#close_stmts)*
+            Ok(())
+        }
+    })
+}
+
+pub(super) fn emit_realloc_steps(
+    semantics: &[FieldSemantics],
+) -> syn::Result<Vec<proc_macro2::TokenStream>> {
+    semantics
+        .iter()
+        .filter_map(|sem| sem.realloc.as_ref().map(|rc| (sem, rc)))
+        .map(|(sem, rc)| emit_one_realloc(sem, rc))
+        .collect()
+}
+
+fn emit_one_realloc(
+    sem: &FieldSemantics,
+    rc: &ReallocConstraint,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let field = &sem.core.ident;
+    let space = &rc.space_expr;
+    let payer = sem
+        .support
+        .realloc_payer
+        .clone()
+        .ok_or_else(|| syn::Error::new(field.span(), "realloc requires a payer field"))?;
+
+    Ok(quote! {
+        {
+            let __realloc_space = (#space) as usize;
+            quasar_lang::accounts::realloc_account(
+                #field, __realloc_space, #payer, Some(&__shared_rent)
+            )?;
+        }
+    })
+}
+
+fn token_authority(sem: &FieldSemantics) -> Option<&syn::Ident> {
+    sem.token
+        .as_ref()
+        .map(|tc| &tc.authority)
+        .or_else(|| sem.ata.as_ref().map(|ac| &ac.authority))
+}
+
+fn token_mint(sem: &FieldSemantics) -> Option<&syn::Ident> {
+    sem.token
+        .as_ref()
+        .map(|tc| &tc.mint)
+        .or_else(|| sem.ata.as_ref().map(|ac| &ac.mint))
+}
+
+fn token_program(sem: &FieldSemantics) -> Option<&syn::Ident> {
+    sem.support.token_program.as_ref()
+}

--- a/derive/src/accounts/emit/migrate.rs
+++ b/derive/src/accounts/emit/migrate.rs
@@ -1,0 +1,8 @@
+// Migration codegen has moved to the runtime `Migration<From, To>::finish()`
+// method. The derive now emits `self.field.finish(payer, &rent)?` in the
+// epilogue (see lifecycle.rs). The old inline codegen that lived here is no
+// longer needed since `#[account(migrate = X)]` is deprecated in favor of the
+// `Migration<From, To>` field type.
+//
+// This module is kept as a placeholder for any future migration-related
+// codegen utilities.

--- a/derive/src/accounts/emit/mod.rs
+++ b/derive/src/accounts/emit/mod.rs
@@ -1,7 +1,10 @@
 //! Emit layer: renders from the resolved accounts model and plan.
 
 mod init;
+mod lifecycle;
+pub(crate) mod migrate;
 mod output;
+pub(super) mod params;
 mod parse;
 
 pub(crate) struct EmitCx {
@@ -16,5 +19,5 @@ pub(crate) use {
 pub(crate) fn emit_epilogue(
     semantics: &[super::resolve::FieldSemantics],
 ) -> syn::Result<proc_macro2::TokenStream> {
-    init::emit_epilogue(semantics)
+    lifecycle::emit_epilogue(semantics)
 }

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -14,6 +14,7 @@ pub(crate) struct AccountsOutput<'a> {
     pub parse_body: proc_macro2::TokenStream,
     pub bumps_struct: proc_macro2::TokenStream,
     pub epilogue_method: proc_macro2::TokenStream,
+    pub has_epilogue: bool,
     pub seeds_methods: proc_macro2::TokenStream,
     pub client_macro: proc_macro2::TokenStream,
     pub ix_arg_extraction: proc_macro2::TokenStream,
@@ -34,6 +35,7 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         parse_body,
         bumps_struct,
         epilogue_method,
+        has_epilogue,
         seeds_methods,
         client_macro,
         ix_arg_extraction,
@@ -53,9 +55,26 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         }
     };
 
+    let has_epilogue_const = if has_epilogue {
+        quote! { const HAS_EPILOGUE: bool = true; }
+    } else {
+        quote! {}
+    };
+
+    // Always emit HAS_VALIDATE = true. The instruction macro always calls
+    // ctx.accounts.validate(). On concrete types, inherent methods shadow
+    // trait methods — so if the user writes an inherent validate(), it runs.
+    // If they don't, the ParseAccounts default (Ok(())) runs and LLVM elides it.
+    //
+    // #[accounts(validate)] is accepted but optional — it serves as
+    // documentation/intent signal. The validate call happens unconditionally.
+    let has_validate_const = quote! { const HAS_VALIDATE: bool = true; };
+
     let parse_accounts_impl = quote! {
         impl #parse_impl_generics ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
             type Bumps = #bumps_name;
+            #has_epilogue_const
+            #has_validate_const
 
             #[inline(always)]
             fn parse(accounts: &'input mut [AccountView], program_id: &Address) -> Result<(Self, Self::Bumps), ProgramError> {

--- a/derive/src/accounts/emit/params.rs
+++ b/derive/src/accounts/emit/params.rs
@@ -1,0 +1,176 @@
+use {super::super::resolve::FieldSemantics, quote::quote};
+
+/// Emit generic `param::` validation — constructs a `Params::default()`,
+/// fills user-specified fields, calls `AccountLoad::validate()`.
+pub(super) fn emit_validate_params(sem: &FieldSemantics) -> Option<proc_macro2::TokenStream> {
+    let field = &sem.core.ident;
+    emit_validate_params_on(sem, quote! { #field })
+}
+
+/// Same as `emit_validate_params`, but validates a specific receiver
+/// expression.
+///
+/// Used by `init_if_needed` existing-account validation, where the raw
+/// `AccountView` has been loaded into `__existing` through `AccountLoad`.
+pub(super) fn emit_validate_params_on(
+    sem: &FieldSemantics,
+    receiver: proc_macro2::TokenStream,
+) -> Option<proc_macro2::TokenStream> {
+    if sem.params.validate.is_empty() {
+        return None;
+    }
+    let ty = &sem.core.effective_ty;
+    let assigns = sem.params.validate.iter().map(|p| {
+        let key = &p.key;
+        let value = &p.value;
+        quote! { __params.#key = #value; }
+    });
+    Some(quote! {
+        {
+            let mut __params =
+                <#ty as quasar_lang::account_load::AccountLoad>::Params::default();
+            #(#assigns)*
+            quasar_lang::account_load::AccountLoad::validate(#receiver, &__params)?;
+        }
+    })
+}
+
+/// Emit built-in SPL validation params against `receiver`.
+///
+/// This calls `AccountLoad::validate(receiver, &__params)` with the built-in
+/// token/mint constraints. ATA is handled separately because it validates the
+/// associated token address derivation in addition to token account data.
+pub(super) fn emit_builtin_validate_params_for(
+    sem: &FieldSemantics,
+    receiver: proc_macro2::TokenStream,
+) -> Option<proc_macro2::TokenStream> {
+    let ty = &sem.core.effective_ty;
+
+    if let Some(tc) = &sem.token {
+        let mint = &tc.mint;
+        let auth = &tc.authority;
+        let tp = sem
+            .support
+            .token_program
+            .as_ref()
+            .map(|tp| quote::quote! { *#tp.to_account_view().address() });
+        let tp_assign = tp
+            .map(|expr| quote::quote! { __params.token_program = Some(#expr); })
+            .unwrap_or_default();
+        return Some(quote! {
+            {
+                let mut __params =
+                    <#ty as quasar_lang::account_load::AccountLoad>::Params::default();
+                __params.mint = Some(*#mint.to_account_view().address());
+                __params.authority = Some(*#auth.to_account_view().address());
+                #tp_assign
+                quasar_lang::account_load::AccountLoad::validate(#receiver, &__params)?;
+            }
+        });
+    }
+
+    if let Some(mc) = &sem.mint {
+        let auth = &mc.authority;
+        let decimals = &mc.decimals;
+        let freeze_expr = mc.freeze_authority.as_ref().map(|fa| {
+            quote::quote! { __params.freeze_authority = Some(*#fa.to_account_view().address()); }
+        });
+        let freeze_stmts = freeze_expr.unwrap_or_default();
+        let tp = sem
+            .support
+            .token_program
+            .as_ref()
+            .map(|tp| quote::quote! { *#tp.to_account_view().address() });
+        let tp_assign = tp
+            .map(|expr| quote::quote! { __params.token_program = Some(#expr); })
+            .unwrap_or_default();
+        return Some(quote! {
+            {
+                let mut __params =
+                    <#ty as quasar_lang::account_load::AccountLoad>::Params::default();
+                __params.authority = Some(*#auth.to_account_view().address());
+                __params.decimals = Some((#decimals) as u8);
+                #freeze_stmts
+                #tp_assign
+                quasar_lang::account_load::AccountLoad::validate(#receiver, &__params)?;
+            }
+        });
+    }
+
+    None
+}
+
+/// Returns field assignments for `__init_params`, combining:
+///   1. Built-in SPL assignments (from `sem.token` / `sem.mint` + resolved
+///      support)
+///   2. User `init_param::` assignments (from `sem.params.init`)
+///
+/// The caller is responsible for:
+///   `type __Target = <#ty as AccountLoad>::BehaviorTarget;`
+///   `let mut __init_params = <__Target as
+/// AccountInit>::InitParams::default();`
+pub(super) fn emit_init_param_assigns(
+    sem: &FieldSemantics,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let mut stmts = Vec::new();
+
+    // 1. Built-in SPL token init assignments.
+    if sem.init.is_some() {
+        if let Some(tc) = &sem.token {
+            let mint = &tc.mint;
+            let authority = &tc.authority;
+            let tp = sem.support.token_program.as_ref().ok_or_else(|| {
+                syn::Error::new(
+                    sem.core.ident.span(),
+                    "token init requires a token program field",
+                )
+            })?;
+            stmts.push(quote! { __init_params.mint = Some(#mint.to_account_view()); });
+            stmts.push(quote! { __init_params.authority = Some(#authority.address()); });
+            stmts.push(quote! { __init_params.token_program = Some(#tp.to_account_view()); });
+        }
+
+        // 2. Built-in SPL mint init assignments.
+        if let Some(mc) = &sem.mint {
+            let decimals = &mc.decimals;
+            let authority = &mc.authority;
+            let tp = sem.support.token_program.as_ref().ok_or_else(|| {
+                syn::Error::new(
+                    sem.core.ident.span(),
+                    "mint init requires a token program field",
+                )
+            })?;
+            stmts.push(quote! { __init_params.decimals = Some((#decimals) as u8); });
+            stmts.push(quote! { __init_params.authority = Some(#authority.address()); });
+            if let Some(fa) = &mc.freeze_authority {
+                stmts.push(quote! { __init_params.freeze_authority = Some(#fa.address()); });
+            }
+            stmts.push(quote! { __init_params.token_program = Some(#tp.to_account_view()); });
+        }
+    }
+
+    // 3. User init_param:: assignments — reject overrides of built-in SPL fields.
+    let builtin_keys: &[&str] = if sem.token.is_some() && sem.init.is_some() {
+        &["mint", "authority", "token_program"]
+    } else if sem.mint.is_some() && sem.init.is_some() {
+        &["decimals", "authority", "freeze_authority", "token_program"]
+    } else {
+        &[]
+    };
+    for p in &sem.params.init {
+        if builtin_keys.iter().any(|k| p.key == k) {
+            return Err(syn::Error::new(
+                p.key.span(),
+                format!(
+                    "`init_param::{}` conflicts with built-in SPL init constraint",
+                    p.key,
+                ),
+            ));
+        }
+        let key = &p.key;
+        let value = &p.value;
+        stmts.push(quote! { __init_params.#key = #value; });
+    }
+
+    Ok(quote! { #(#stmts)* })
+}

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -17,7 +17,7 @@ pub(crate) fn emit_parse_body(
 ) -> syn::Result<proc_macro2::TokenStream> {
     let rent_fetch = emit_rent_fetch(semantics);
     let init_stmts = super::init::emit_init_stmts(semantics)?;
-    let realloc_stmts = super::init::emit_realloc_steps(semantics)?;
+    let realloc_stmts = super::lifecycle::emit_realloc_steps(semantics)?;
     let construct_stmts = emit_construct_steps(semantics);
     let check_stmts = emit_check_blocks(semantics);
     let bump_vars = emit_bump_vars(semantics);
@@ -116,10 +116,7 @@ fn emit_inner_expr(sem: &FieldSemantics) -> proc_macro2::TokenStream {
     if matches!(sem.core.shape, FieldShape::Composite) {
         quote! { #ident }
     } else if sem.core.dynamic {
-        let inner_ty = match &sem.core.shape {
-            FieldShape::Account { inner_ty } => inner_ty,
-            _ => &sem.core.effective_ty,
-        };
+        let inner_ty = sem.core.inner_ty.as_ref().unwrap_or(&sem.core.effective_ty);
         let base = strip_generics(inner_ty);
         quote! { #base::from_account_view(#ident)? }
     } else if skip_checks {
@@ -153,6 +150,16 @@ fn emit_one_check_block(
     let field_ident = &sem.core.ident;
     let mut stmts = Vec::new();
 
+    // For Migration<From, To> fields, user checks access source data via
+    // source().unwrap() instead of Deref. At check time (before handler),
+    // the source discriminator is guaranteed present (validated in parse).
+    let is_migration = matches!(sem.core.shape, FieldShape::Migration);
+    let field_access = if is_migration {
+        quote! { #field_ident.source().unwrap() }
+    } else {
+        quote! { #field_ident }
+    };
+
     for uc in &sem.user_checks {
         match &uc.kind {
             UserCheckKind::HasOne { target } => {
@@ -164,14 +171,14 @@ fn emit_one_check_block(
                 let target_str = target.to_string();
                 stmts.push(quote! {
                     #[cfg(feature = "debug")]
-                    if !quasar_lang::keys_eq(&#field_ident.#target, #target.to_account_view().address()) {
+                    if !quasar_lang::keys_eq(&#field_access.#target, #target.to_account_view().address()) {
                         quasar_lang::prelude::log(concat!(
                             "has_one mismatch: ", #field_name_str, ".", #target_str,
                             " != ", #target_str, ".address()"
                         ));
                     }
                     quasar_lang::validation::check_address_match(
-                        &#field_ident.#target,
+                        &#field_access.#target,
                         #target.to_account_view().address(),
                         #err,
                     )?;
@@ -208,6 +215,9 @@ fn emit_one_check_block(
         }
         if let Some(token_check) = super::init::emit_non_init_check(sem) {
             stmts.push(token_check);
+        }
+        if let Some(generic_check) = super::params::emit_validate_params(sem) {
+            stmts.push(generic_check);
         }
     }
 
@@ -246,7 +256,7 @@ fn emit_pda_check(
             addr_expr: &addr_access,
             seed_array_name: &seed_array_name,
             explicit_bump_name: &explicit_bump_name,
-            bare_mode: if sem.core.shape.supports_existing_pda_fast_path() {
+            bare_mode: if sem.core.supports_existing_pda_fast_path {
                 PdaBareMode::KnownAddress
             } else {
                 PdaBareMode::DeriveExpected

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -120,10 +120,12 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         Ok(ts) => ts,
         Err(e) => return e.to_compile_error().into(),
     };
+    let has_epilogue = !epilogue_method.is_empty();
 
     // --- Seeds impl ---
 
     let seeds_methods = emit::emit_seed_methods(&semantics, &emit_cx);
+
     // --- Client macro ---
 
     let client_macro = crate::client_macro::generate_accounts_macro(name, &semantics);
@@ -150,6 +152,7 @@ pub(crate) fn derive_accounts(input: TokenStream) -> TokenStream {
         parse_body,
         bumps_struct,
         epilogue_method,
+        has_epilogue,
         seeds_methods,
         client_macro,
         ix_arg_extraction,

--- a/derive/src/accounts/plan.rs
+++ b/derive/src/accounts/plan.rs
@@ -47,7 +47,7 @@ impl HeaderPlan {
                 || sem.client_requires_signer(),
             requires_executable: matches!(
                 sem.core.shape,
-                resolve::FieldShape::Program { .. } | resolve::FieldShape::Interface { .. }
+                resolve::FieldShape::Program | resolve::FieldShape::Interface
             ),
             writable: sem.is_writable(),
             optional: sem.core.optional,

--- a/derive/src/accounts/resolve/lower.rs
+++ b/derive/src/accounts/resolve/lower.rs
@@ -3,9 +3,9 @@ use {
         super::syntax::{classify_seed, lower_bump, parse_field_attrs, AccountDirective},
         rules::validate_semantics,
         support::resolve_supports,
-        FieldCore, FieldSemantics, FieldShape, FieldSupport, InitConstraint, InitMode,
-        LifecycleConstraint, MintConstraint, PdaConstraint, PdaSource, ReallocConstraint, SeedNode,
-        TokenConstraint, UserCheckConstraint, UserCheckKind,
+        FieldCore, FieldParams, FieldSemantics, FieldShape, FieldSupport, InitConstraint, InitMode,
+        LifecycleConstraint, MintConstraint, ParamAssign, PdaConstraint, PdaSource,
+        ReallocConstraint, SeedNode, TokenConstraint, UserCheckConstraint, UserCheckKind,
     },
     crate::helpers::{extract_generic_inner_type, is_composite_type},
     syn::{Expr, Ident, Type},
@@ -42,6 +42,7 @@ pub(super) fn lower_semantics(
             let mut sem = FieldSemantics {
                 core,
                 support: FieldSupport::default(),
+                params: FieldParams::default(),
                 init: None,
                 pda: None,
                 token: None,
@@ -80,8 +81,24 @@ fn lower_core(field: &syn::Field, directives: &[AccountDirective]) -> FieldCore 
         other => other.clone(),
     };
 
-    let shape = classify_shape(&effective_ty, ty);
-    let dynamic = detect_dynamic(&shape);
+    let (shape, raw_inner_ty) = classify_shape(&effective_ty, ty);
+    let inner_name = raw_inner_ty.as_ref().and_then(type_base_name).cloned();
+    let is_token_account = inner_name_matches(&inner_name, &["Token", "Token2022"]);
+    let is_mint = inner_name_matches(&inner_name, &["Mint", "Mint2022"]);
+    let is_token_or_mint = is_token_account || is_mint;
+    let supports_existing_pda_fast_path = matches!(shape, FieldShape::Account)
+        || (matches!(shape, FieldShape::InterfaceAccount) && is_token_or_mint);
+    let inner_ty = if matches!(
+        shape,
+        FieldShape::Account | FieldShape::InterfaceAccount | FieldShape::Migration
+    ) {
+        raw_inner_ty
+    } else {
+        None
+    };
+    let dynamic = detect_dynamic(shape, inner_ty.as_ref());
+
+    let is_migration = matches!(shape, FieldShape::Migration);
 
     FieldCore {
         ident: field
@@ -91,53 +108,79 @@ fn lower_core(field: &syn::Field, directives: &[AccountDirective]) -> FieldCore 
         field: field.clone(),
         effective_ty,
         shape,
+        inner_ty,
+        inner_name,
+        is_token_account,
+        is_mint,
+        is_token_or_mint,
+        supports_existing_pda_fast_path,
         optional,
         dynamic,
-        is_mut: directives
-            .iter()
-            .any(|d| matches!(d, AccountDirective::Mut)),
+        // Migration fields are implicitly mutable (realloc + write target).
+        is_mut: is_migration
+            || directives
+                .iter()
+                .any(|d| matches!(d, AccountDirective::Mut)),
         dup: directives
             .iter()
             .any(|d| matches!(d, AccountDirective::Dup)),
     }
 }
 
-fn classify_shape(effective_ty: &Type, raw_ty: &Type) -> FieldShape {
+fn classify_shape(effective_ty: &Type, raw_ty: &Type) -> (FieldShape, Option<Type>) {
     if is_composite_type(raw_ty) {
-        return FieldShape::Composite;
+        return (FieldShape::Composite, None);
+    }
+
+    // Migration<From, To> — must check before Account<T> since both are
+    // generic wrappers. The `From` type is used for source-data access.
+    if let Some(from_ty) = extract_migration_from_type(effective_ty) {
+        return (FieldShape::Migration, Some(from_ty));
     }
 
     if let Some(inner) = extract_generic_inner_type(effective_ty, "Account") {
-        return FieldShape::Account {
-            inner_ty: inner.clone(),
-        };
+        return (FieldShape::Account, Some(inner.clone()));
     }
     if let Some(inner) = extract_generic_inner_type(effective_ty, "InterfaceAccount") {
-        return FieldShape::InterfaceAccount {
-            inner_ty: inner.clone(),
-        };
+        return (FieldShape::InterfaceAccount, Some(inner.clone()));
     }
     if let Some(inner) = extract_generic_inner_type(effective_ty, "Program") {
-        return FieldShape::Program {
-            inner_ty: inner.clone(),
-        };
+        return (FieldShape::Program, Some(inner.clone()));
     }
     if let Some(inner) = extract_generic_inner_type(effective_ty, "Interface") {
-        return FieldShape::Interface {
-            inner_ty: inner.clone(),
-        };
+        return (FieldShape::Interface, Some(inner.clone()));
     }
     if let Some(inner) = extract_generic_inner_type(effective_ty, "Sysvar") {
-        return FieldShape::Sysvar {
-            inner_ty: inner.clone(),
-        };
+        return (FieldShape::Sysvar, Some(inner.clone()));
     }
 
-    match type_base_name(effective_ty) {
+    let shape = match type_base_name(effective_ty) {
         Some(ident) if ident == "SystemAccount" => FieldShape::SystemAccount,
         Some(ident) if ident == "Signer" => FieldShape::Signer,
         _ => FieldShape::Other,
+    };
+    (shape, None)
+}
+
+/// Extract the `From` type param from `Migration<From, To>`.
+fn extract_migration_from_type(ty: &Type) -> Option<Type> {
+    if let Type::Path(type_path) = ty {
+        if let Some(last) = type_path.path.segments.last() {
+            if last.ident == "Migration" {
+                if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
+                    let mut iter = args.args.iter();
+                    if let (
+                        Some(syn::GenericArgument::Type(from)),
+                        Some(syn::GenericArgument::Type(_to)),
+                    ) = (iter.next(), iter.next())
+                    {
+                        return Some(from.clone());
+                    }
+                }
+            }
+        }
     }
+    None
 }
 
 fn type_base_name(ty: &Type) -> Option<&syn::Ident> {
@@ -147,10 +190,18 @@ fn type_base_name(ty: &Type) -> Option<&syn::Ident> {
     }
 }
 
-fn detect_dynamic(shape: &FieldShape) -> bool {
-    let inner = match shape {
-        FieldShape::Account { inner_ty } => inner_ty,
-        _ => return false,
+fn inner_name_matches(inner_name: &Option<Ident>, names: &[&str]) -> bool {
+    inner_name
+        .as_ref()
+        .is_some_and(|ident| names.iter().any(|name| ident == *name))
+}
+
+fn detect_dynamic(shape: FieldShape, inner_ty: Option<&Type>) -> bool {
+    if !matches!(shape, FieldShape::Account) {
+        return false;
+    }
+    let Some(inner) = inner_ty else {
+        return false;
     };
     if let Type::Path(tp) = inner {
         if let Some(last) = tp.path.segments.last() {
@@ -253,11 +304,21 @@ fn lower_constraints(
             AccountDirective::MintInitAuthority(v) => mint_authority = Some(v),
             AccountDirective::MintFreezeAuthority(v) => mint_freeze_authority = Some(v),
             AccountDirective::MintTokenProgram(v) => mint_token_program = Some(v),
+            AccountDirective::Param { key, value } => {
+                sem.params.validate.push(ParamAssign { key, value });
+            }
+            AccountDirective::InitParam { key, value } => {
+                sem.params.init.push(ParamAssign { key, value });
+            }
         }
     }
 
     if let Some(mode) = init_mode {
-        sem.init = Some(InitConstraint { mode, payer, space });
+        sem.init = Some(InitConstraint {
+            mode,
+            payer: payer.clone(),
+            space,
+        });
     }
 
     if let (Some(mint), Some(authority)) = (token_mint, token_authority) {
@@ -290,6 +351,14 @@ fn lower_constraints(
             space_expr,
             payer: realloc_payer,
         });
+    }
+
+    // For Migration<From, To> fields, store explicit payer directly on support
+    // so resolve_supports can find it. Without init, payer has nowhere else to go.
+    if matches!(sem.core.shape, FieldShape::Migration) {
+        if let Some(p) = payer {
+            sem.support.payer = Some(p);
+        }
     }
 }
 

--- a/derive/src/accounts/resolve/model.rs
+++ b/derive/src/accounts/resolve/model.rs
@@ -1,59 +1,17 @@
 use syn::{Expr, Ident, Type};
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FieldShape {
-    Account { inner_ty: Type },
-    InterfaceAccount { inner_ty: Type },
-    Program { inner_ty: Type },
-    Interface { inner_ty: Type },
-    Sysvar { inner_ty: Type },
+    Account,
+    Migration,
+    InterfaceAccount,
+    Program,
+    Interface,
+    Sysvar,
     Signer,
     SystemAccount,
     Composite,
     Other,
-}
-
-impl FieldShape {
-    pub fn inner_base_name(&self) -> Option<&syn::Ident> {
-        let inner = match self {
-            Self::Account { inner_ty }
-            | Self::InterfaceAccount { inner_ty }
-            | Self::Program { inner_ty }
-            | Self::Interface { inner_ty }
-            | Self::Sysvar { inner_ty } => inner_ty,
-            Self::Signer | Self::SystemAccount | Self::Composite | Self::Other => return None,
-        };
-        match inner {
-            Type::Path(tp) => tp.path.segments.last().map(|s| &s.ident),
-            _ => None,
-        }
-    }
-
-    pub fn inner_name_matches(&self, names: &[&str]) -> bool {
-        self.inner_base_name()
-            .is_some_and(|ident| names.iter().any(|name| ident == name))
-    }
-
-    pub fn is_token_account(&self) -> bool {
-        self.inner_name_matches(&["Token", "Token2022"])
-    }
-
-    pub fn is_mint(&self) -> bool {
-        self.inner_name_matches(&["Mint", "Mint2022"])
-    }
-
-    pub fn is_token_or_mint(&self) -> bool {
-        self.inner_name_matches(&["Token", "Token2022", "Mint", "Mint2022"])
-    }
-
-    /// Whether an existing account of this shape can use the PDA bump fast
-    /// path once wrapper validation has already run.
-    pub fn supports_existing_pda_fast_path(&self) -> bool {
-        match self {
-            Self::Account { .. } => true,
-            Self::InterfaceAccount { .. } => self.is_token_or_mint(),
-            _ => false,
-        }
-    }
 }
 
 pub(crate) struct FieldCore {
@@ -61,6 +19,17 @@ pub(crate) struct FieldCore {
     pub field: syn::Field,
     pub effective_ty: Type,
     pub shape: FieldShape,
+    /// Inner/source type for account-bearing wrappers.
+    ///
+    /// For `Migration<From, To>`, this is `From`.
+    pub inner_ty: Option<Type>,
+    /// Base name of the generic inner type for any generic wrapper.
+    pub inner_name: Option<Ident>,
+    pub is_token_account: bool,
+    pub is_mint: bool,
+    pub is_token_or_mint: bool,
+    /// Existing-account PDA bump fast path is valid after wrapper validation.
+    pub supports_existing_pda_fast_path: bool,
     pub optional: bool,
     pub dynamic: bool,
     pub is_mut: bool,
@@ -70,6 +39,7 @@ pub(crate) struct FieldCore {
 pub(crate) struct FieldSemantics {
     pub core: FieldCore,
     pub support: FieldSupport,
+    pub params: FieldParams,
     pub init: Option<InitConstraint>,
     pub pda: Option<PdaConstraint>,
     pub token: Option<TokenConstraint>,
@@ -86,7 +56,9 @@ impl FieldSemantics {
     }
 
     pub fn needs_rent(&self) -> bool {
-        self.init.is_some() || self.realloc.is_some()
+        self.init.is_some()
+            || self.realloc.is_some()
+            || matches!(self.core.shape, FieldShape::Migration)
     }
 
     pub fn has_realloc(&self) -> bool {
@@ -98,7 +70,11 @@ impl FieldSemantics {
     }
 
     pub fn is_writable(&self) -> bool {
-        self.core.is_mut || self.has_init() || self.has_lifecycle() || self.has_realloc()
+        self.core.is_mut
+            || self.has_init()
+            || self.has_lifecycle()
+            || self.has_realloc()
+            || matches!(self.core.shape, FieldShape::Migration)
     }
 
     pub fn client_requires_signer(&self) -> bool {
@@ -210,6 +186,17 @@ pub(crate) struct MintConstraint {
     pub authority: Ident,
     pub freeze_authority: Option<Ident>,
     pub token_program: Option<Ident>,
+}
+
+pub(crate) struct ParamAssign {
+    pub key: syn::Ident,
+    pub value: syn::Expr,
+}
+
+#[derive(Default)]
+pub(crate) struct FieldParams {
+    pub validate: Vec<ParamAssign>,
+    pub init: Vec<ParamAssign>,
 }
 
 pub(crate) struct UserCheckConstraint {

--- a/derive/src/accounts/resolve/rules.rs
+++ b/derive/src/accounts/resolve/rules.rs
@@ -34,7 +34,7 @@ fn validate_field(sem: &FieldSemantics) -> syn::Result<()> {
                 "#[account(sweep)] requires `token::mint` and `token::authority`",
             ),
             (
-                sem.has_realloc() && !matches!(sem.core.shape, FieldShape::Account { .. }),
+                sem.has_realloc() && !matches!(sem.core.shape, FieldShape::Account),
                 "#[account(realloc)] is only valid on Account<T> fields",
             ),
             (
@@ -42,18 +42,47 @@ fn validate_field(sem: &FieldSemantics) -> syn::Result<()> {
                 "#[account(realloc)] cannot be used on Option<Account<T>> fields",
             ),
             (
-                sem.has_realloc() && sem.core.shape.is_token_or_mint(),
+                matches!(sem.core.shape, FieldShape::Migration) && sem.core.optional,
+                "Migration<From, To> cannot be wrapped in Option",
+            ),
+            (
+                matches!(sem.core.shape, FieldShape::Migration) && sem.has_init(),
+                "Migration<From, To> cannot be combined with init",
+            ),
+            (
+                matches!(sem.core.shape, FieldShape::Migration) && sem.has_close(),
+                "Migration<From, To> cannot be combined with close",
+            ),
+            (
+                matches!(sem.core.shape, FieldShape::Migration) && sem.support.payer.is_none(),
+                "Migration<From, To> requires a payer. Add a `payer` field or specify `payer = \
+                 <field>` on the field.",
+            ),
+            (
+                sem.has_realloc() && sem.core.is_token_or_mint,
                 "#[account(realloc)] cannot be used on token or mint accounts — their size is \
                  fixed by the token program",
             ),
             (
-                sem.has_sweep() && !sem.core.shape.is_token_account(),
+                sem.has_sweep() && !sem.core.is_token_account,
                 "#[account(sweep)] is only valid on token accounts, not mint accounts",
             ),
             (
-                sem.has_close() && sem.core.shape.is_mint(),
+                sem.has_close() && sem.core.is_mint,
                 "#[account(close)] cannot be used on mint accounts. Mint closing is not supported \
                  through the token-account close path.",
+            ),
+            (
+                sem.has_close()
+                    && sem.core.is_token_account
+                    && sem.token.is_none()
+                    && sem.ata.is_none(),
+                "#[account(close)] on token accounts requires `token::authority` or \
+                 `associated_token::authority`",
+            ),
+            (
+                sem.has_close() && sem.core.is_token_account && sem.support.token_program.is_none(),
+                "#[account(close)] on token accounts requires a token program field",
             ),
         ],
     )?;
@@ -78,8 +107,8 @@ fn validate_field(sem: &FieldSemantics) -> syn::Result<()> {
         span,
         &[(
             sem.has_raw_pda()
-                && matches!(sem.core.shape, FieldShape::Account { .. })
-                && !sem.core.shape.is_token_or_mint()
+                && matches!(sem.core.shape, FieldShape::Account)
+                && !sem.core.is_token_or_mint
                 && !sem.has_init(),
             "Raw `seeds` are not allowed on `Account<T>` fields; use `typed_seeds` instead",
         )],

--- a/derive/src/accounts/resolve/support.rs
+++ b/derive/src/accounts/resolve/support.rs
@@ -40,6 +40,17 @@ pub(super) fn resolve_supports(semantics: &mut [FieldSemantics]) -> syn::Result<
             sem.support.rent_sysvar = index.rent_sysvar.clone();
         }
 
+        // Migration<From, To> field type implies payer + system program.
+        // Explicit payer is already set by lower_constraints when
+        // #[account(payer = X)] is present on the field.
+        if matches!(sem.core.shape, FieldShape::Migration) {
+            if sem.support.payer.is_none() {
+                sem.support.payer = index.payer_default.clone();
+            }
+            sem.support.system_program = index.system_program.clone();
+            sem.support.rent_sysvar = index.rent_sysvar.clone();
+        }
+
         if uses_token_program(sem) {
             if explicit_token_program.is_none() && index.token_program_candidates.len() > 1 {
                 return Err(syn::Error::new_spanned(
@@ -70,34 +81,26 @@ fn build_accounts_index(semantics: &[FieldSemantics]) -> AccountsIndex {
     for sem in semantics {
         let ident = &sem.core.ident;
 
-        match &sem.core.shape {
-            FieldShape::Program { .. } => {
-                if let Some(name) = sem.core.shape.inner_base_name() {
-                    match name.to_string().as_str() {
-                        "System" if system_program.is_none() => {
-                            system_program = Some(ident.clone())
-                        }
-                        "Token" | "Token2022" => {
-                            token_program_candidates.push(ident.clone());
-                        }
-                        "AssociatedTokenProgram" if associated_token_program.is_none() => {
-                            associated_token_program = Some(ident.clone());
-                        }
-                        _ => {}
+        match sem.core.shape {
+            FieldShape::Program => {
+                if let Some(name) = sem.core.inner_name.as_ref() {
+                    if name == "System" && system_program.is_none() {
+                        system_program = Some(ident.clone());
+                    } else if name == "Token" || name == "Token2022" {
+                        token_program_candidates.push(ident.clone());
+                    } else if name == "AssociatedTokenProgram" && associated_token_program.is_none()
+                    {
+                        associated_token_program = Some(ident.clone());
                     }
                 }
             }
-            FieldShape::Interface { .. }
-                if sem.core.shape.inner_name_matches(&["TokenInterface"]) =>
-            {
+            FieldShape::Interface if inner_name_is(sem, "TokenInterface") => {
                 token_program_candidates.push(ident.clone());
             }
-            FieldShape::Sysvar { .. }
-                if sem.core.shape.inner_name_matches(&["Rent"]) && rent_sysvar.is_none() =>
-            {
+            FieldShape::Sysvar if inner_name_is(sem, "Rent") && rent_sysvar.is_none() => {
                 rent_sysvar = Some(ident.clone());
             }
-            FieldShape::Account { .. } | FieldShape::InterfaceAccount { .. } => {}
+            FieldShape::Account | FieldShape::InterfaceAccount => {}
             FieldShape::Composite => {}
             _ => {}
         }
@@ -120,6 +123,13 @@ fn build_accounts_index(semantics: &[FieldSemantics]) -> AccountsIndex {
         associated_token_program,
         rent_sysvar,
     }
+}
+
+fn inner_name_is(sem: &FieldSemantics, expected: &str) -> bool {
+    sem.core
+        .inner_name
+        .as_ref()
+        .is_some_and(|name| name == expected)
 }
 
 fn uses_token_program(sem: &FieldSemantics) -> bool {

--- a/derive/src/accounts/syntax/attrs.rs
+++ b/derive/src/accounts/syntax/attrs.rs
@@ -43,6 +43,8 @@ pub(crate) enum AccountDirective {
     MintInitAuthority(Ident),
     MintFreezeAuthority(Ident),
     MintTokenProgram(Ident),
+    Param { key: Ident, value: Expr },
+    InitParam { key: Ident, value: Expr },
 }
 
 struct ParsedDirective {
@@ -141,6 +143,13 @@ fn lower_directive(directive: ParsedDirective) -> syn::Result<AccountDirective> 
         [name] if *name == "seeds" => lower_seeds_directive(directive),
         [name] if *name == "bump" => Ok(AccountDirective::Bump(expect_optional_expr(directive)?)),
         [name] if *name == "sweep" => Ok(AccountDirective::Sweep(expect_ident_value(directive)?)),
+        [name] if *name == "migrate" => Err(syn::Error::new(
+            name.span(),
+            "#[account(migrate = X)] is deprecated. Use the `Migration<From, To>` field type \
+             instead:\n\n  Before: #[account(migrate = ConfigV2, payer = payer)]\n  pub config: \
+             Account<ConfigV1>,\n\n  After:  #[account(payer = payer)]\n  pub config: \
+             Migration<ConfigV1, ConfigV2>,",
+        )),
         [ns] if *ns == "realloc" => Ok(AccountDirective::Realloc(expect_expr_value(directive)?)),
         [ns, sub] if *ns == "realloc" && *sub == "payer" => Ok(AccountDirective::ReallocPayer(
             expect_ident_value(directive)?,
@@ -191,6 +200,14 @@ fn lower_directive(directive: ParsedDirective) -> syn::Result<AccountDirective> 
             path.segments.last().expect("non-empty path").ident.span(),
             format!("unknown associated_token attribute: `associated_token::{sub_key}`"),
         )),
+        [ns, key] if *ns == "param" => Ok(AccountDirective::Param {
+            key: (*key).clone(),
+            value: expect_expr_value(directive)?,
+        }),
+        [ns, key] if *ns == "init_param" => Ok(AccountDirective::InitParam {
+            key: (*key).clone(),
+            value: expect_expr_value(directive)?,
+        }),
         _ => Err(syn::Error::new(
             path.segments.first().expect("non-empty path").ident.span(),
             format!("unknown account attribute: `{}`", join_path(path)),
@@ -328,7 +345,7 @@ fn directive_path(directive: &ParsedDirective) -> syn::Result<&Path> {
     match &directive.key {
         DirectiveKey::Mut => Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "`mut` does not have a directive path",
+            "directive does not have a path",
         )),
         DirectiveKey::Path(path) => Ok(path),
     }

--- a/derive/src/accounts/syntax/pda.rs
+++ b/derive/src/accounts/syntax/pda.rs
@@ -340,13 +340,13 @@ fn resolve_field_type_info(
     all_semantics: &[FieldSemantics],
 ) -> (Option<syn::Type>, Option<AccountWrapperKind>) {
     if let Some(sem) = all_semantics.iter().find(|s| s.core.ident == *root) {
-        match &sem.core.shape {
-            FieldShape::Account { inner_ty } => {
-                return (Some(inner_ty.clone()), Some(AccountWrapperKind::Account));
+        match sem.core.shape {
+            FieldShape::Account => {
+                return (sem.core.inner_ty.clone(), Some(AccountWrapperKind::Account));
             }
-            FieldShape::InterfaceAccount { inner_ty } => {
+            FieldShape::InterfaceAccount => {
                 return (
-                    Some(inner_ty.clone()),
+                    sem.core.inner_ty.clone(),
                     Some(AccountWrapperKind::InterfaceAccount),
                 );
             }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -113,7 +113,8 @@ fn describe_accounts(
             signer: matches!(sem.core.shape, crate::accounts::resolve::FieldShape::Signer)
                 || sem.client_requires_signer(),
             pda: sem.pda.as_ref().map(describe_pda),
-            address: known_address(&sem.core.shape).map(str::to_owned),
+            address: known_address(sem).map(str::to_owned),
+            migration: None,
         })
         .collect()
 }
@@ -159,14 +160,13 @@ fn join_path(root: &syn::Ident, path: &[syn::Ident]) -> String {
     joined
 }
 
-fn known_address(shape: &crate::accounts::resolve::FieldShape) -> Option<&'static str> {
-    match shape {
-        crate::accounts::resolve::FieldShape::Program { .. } => {
-            let inner = shape.inner_base_name().map(|name| name.to_string());
+fn known_address(sem: &crate::accounts::resolve::FieldSemantics) -> Option<&'static str> {
+    let inner = sem.core.inner_name.as_ref().map(|name| name.to_string());
+    match sem.core.shape {
+        crate::accounts::resolve::FieldShape::Program => {
             known_address_for_type("Program", inner.as_deref())
         }
-        crate::accounts::resolve::FieldShape::Sysvar { .. } => {
-            let inner = shape.inner_base_name().map(|name| name.to_string());
+        crate::accounts::resolve::FieldShape::Sysvar => {
             known_address_for_type("Sysvar", inner.as_deref())
         }
         _ => None,

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -12,6 +12,13 @@ pub(crate) struct AccountAttr {
     pub unsafe_no_disc: bool,
     pub set_inner: bool,
     pub fixed_capacity: bool,
+    /// `custom` — transparent wrapper over AccountView with user-provided
+    /// check().
+    pub custom: bool,
+    /// `one_of` — polymorphic account on enum declarations.
+    pub one_of: bool,
+    /// `implements(TraitPath)` — trait all variants implement; generates Deref.
+    pub implements: Option<syn::Path>,
 }
 
 impl Parse for AccountAttr {
@@ -20,6 +27,9 @@ impl Parse for AccountAttr {
         let mut unsafe_no_disc = false;
         let mut set_inner = false;
         let mut fixed_capacity = false;
+        let mut custom = false;
+        let mut one_of = false;
+        let mut implements: Option<syn::Path> = None;
 
         while !input.is_empty() {
             let ident: Ident = input.parse()?;
@@ -29,21 +39,54 @@ impl Parse for AccountAttr {
                 set_inner = true;
             } else if ident == "fixed_capacity" {
                 fixed_capacity = true;
+            } else if ident == "custom" {
+                custom = true;
+            } else if ident == "one_of" {
+                one_of = true;
             } else if ident == "discriminator" {
                 disc_bytes = parse_discriminator_value(input)?;
+            } else if ident == "implements" {
+                let content;
+                syn::parenthesized!(content in input);
+                implements = Some(content.parse::<syn::Path>()?);
             } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    "expected `discriminator`, `unsafe_no_disc`, `set_inner`, or `fixed_capacity`",
+                    "expected `discriminator`, `unsafe_no_disc`, `set_inner`, `fixed_capacity`, \
+                     `custom`, `one_of`, or `implements`",
                 ));
             }
             let _ = input.parse::<Option<Token![,]>>();
         }
 
-        if disc_bytes.is_empty() && !unsafe_no_disc {
+        // custom accounts don't have discriminators
+        if custom && (!disc_bytes.is_empty() || unsafe_no_disc || set_inner || fixed_capacity) {
+            return Err(syn::Error::new(
+                input.span(),
+                "`custom` cannot be combined with `discriminator`, `unsafe_no_disc`, `set_inner`, \
+                 or `fixed_capacity`",
+            ));
+        }
+
+        if !custom && !one_of && disc_bytes.is_empty() && !unsafe_no_disc {
             return Err(syn::Error::new(
                 input.span(),
                 "expected `discriminator` or `unsafe_no_disc`",
+            ));
+        }
+
+        if implements.is_some() && !one_of {
+            return Err(syn::Error::new(
+                input.span(),
+                "`implements` can only be used with `one_of`",
+            ));
+        }
+
+        // one_of doesn't have its own discriminator
+        if one_of && (!disc_bytes.is_empty() || unsafe_no_disc) {
+            return Err(syn::Error::new(
+                input.span(),
+                "`one_of` cannot be combined with `discriminator` or `unsafe_no_disc`",
             ));
         }
 
@@ -52,6 +95,9 @@ impl Parse for AccountAttr {
             unsafe_no_disc,
             set_inner,
             fixed_capacity,
+            custom,
+            one_of,
+            implements,
         })
     }
 }
@@ -59,23 +105,33 @@ impl Parse for AccountAttr {
 pub(crate) struct InstructionArgs {
     pub discriminator: Option<Vec<LitInt>>,
     pub heap: bool,
+    pub raw: bool,
 }
 
 impl Parse for InstructionArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut discriminator = None;
         let mut heap = false;
+        let mut raw = false;
 
         while !input.is_empty() {
             let ident: Ident = input.parse()?;
             if ident == "heap" {
                 heap = true;
+            } else if ident == "raw" {
+                raw = true;
             } else if ident == "discriminator" {
                 discriminator = Some(parse_discriminator_value(input)?);
+            } else if ident == "pre_hook" || ident == "post_hook" {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "pre_hook and post_hook have been removed. Use `#[accounts(validate)]` for \
+                     pre-handler validation, or move logic into the handler body.",
+                ));
             } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    "expected `discriminator` or `heap`",
+                    "expected `discriminator`, `heap`, or `raw`",
                 ));
             }
             let _ = input.parse::<Option<Token![,]>>();
@@ -84,6 +140,7 @@ impl Parse for InstructionArgs {
         Ok(Self {
             discriminator,
             heap,
+            raw,
         })
     }
 }

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -20,6 +20,10 @@ use {
     syn::{parse_macro_input, FnArg, Ident, ItemFn, Pat, ReturnType, Type},
 };
 
+// Note: pre_hook/post_hook have been removed. Users should use
+// #[accounts(validate)] for pre-handler validation, or write logic
+// directly in the handler body.
+
 /// Emit the ZeroPodFixed schema codegen block: derive struct, size check,
 /// validate, cast, and per-field `from_zc` extraction.
 fn emit_fixed_schema_stmts(
@@ -83,6 +87,70 @@ fn parse_max_attr_from_fn_arg(pt: &syn::PatType) -> Option<Result<(usize, usize)
     None
 }
 
+/// Build the handler tail: user body + epilogue, with optional return-data
+/// wrapping. This is the single canonical emission point for the instruction
+/// lifecycle after validate has run.
+///
+/// Lifecycle: parse → validate → handler → epilogue
+fn emit_handler_tail(
+    param_ident: &Ident,
+    stmts: &[syn::Stmt],
+    has_return_data: bool,
+    return_ok_type: Option<&Type>,
+) -> Vec<syn::Stmt> {
+    let user_body: proc_macro2::TokenStream = stmts.iter().map(|s| quote!(#s)).collect();
+    let mut tail = Vec::new();
+
+    // Const-elide via HAS_EPILOGUE. When the struct has no close/sweep/migrate,
+    // this branch is eliminated at compile time — saving ~2-7 CU on sBPF.
+    let epilogue_call = quote! {
+        if #param_ident.has_epilogue() {
+            #param_ident.accounts.epilogue()?;
+        }
+    };
+
+    if has_return_data {
+        let ok_ty =
+            return_ok_type.expect("return_ok_type must be set when has_return_data is true");
+        tail.push(syn::parse_quote!(
+            const _: () = assert!(
+                core::mem::align_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>() == 1,
+                "return data type must implement InstructionArg with an alignment-1 Zc companion"
+            );
+        ));
+        tail.push(syn::parse_quote!(
+            {
+                let __result: Result<#ok_ty, ProgramError> = (|| { #user_body })();
+                match __result {
+                    Ok(ref __val) => {
+                        #epilogue_call
+                        let __zc =
+                            <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::to_zc(__val);
+                        let __bytes = unsafe {
+                            core::slice::from_raw_parts(
+                                &__zc as *const <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc as *const u8,
+                                core::mem::size_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>(),
+                            )
+                        };
+                        quasar_lang::return_data::set_return_data(__bytes);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        ));
+    } else {
+        tail.push(syn::parse_quote!({
+            let __user_result: Result<(), ProgramError> = { #user_body };
+            __user_result?;
+            #epilogue_call
+            Ok(())
+        }));
+    }
+
+    tail
+}
+
 pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as InstructionArgs);
     let mut func = parse_macro_input!(item as ItemFn);
@@ -116,6 +184,57 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into();
     }
 
+    // ── Raw path ────────────────────────────────────────────────────
+    // When `raw` is set, the handler receives a bare `Context` — no
+    // Ctx<T>, no arg decoding, no validate(), no epilogue. The macro
+    // just validates the signature and emits the function unchanged.
+    // The `#[program]` codegen is responsible for generating the
+    // dispatch arm that constructs and passes the `Context`.
+    if args.raw {
+        let first_arg = match func.sig.inputs.first() {
+            Some(FnArg::Typed(pt)) => pt.clone(),
+            _ => {
+                return syn::Error::new_spanned(
+                    &func.sig.ident,
+                    "#[instruction(raw)] requires a single parameter of type Context",
+                )
+                .to_compile_error()
+                .into();
+            }
+        };
+
+        // Check the type path ends with "Context".
+        let is_context = match &*first_arg.ty {
+            Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "Context"),
+            _ => false,
+        };
+        if !is_context {
+            return syn::Error::new_spanned(
+                &first_arg.ty,
+                "#[instruction(raw)] parameter must be of type Context",
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        if func.sig.inputs.len() > 1 {
+            return syn::Error::new_spanned(
+                &func.sig,
+                "#[instruction(raw)] handler must have exactly one parameter: Context",
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        // Emit the function unchanged — no wrapping, no codegen.
+        return quote!(#func).into();
+    }
+
+    // ── Normal path ──────────────────────────────────────────────────
     let first_arg = match func.sig.inputs.first() {
         Some(FnArg::Typed(pt)) => pt.clone(),
         _ => {
@@ -266,49 +385,13 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
                     #param_ident.data = &[];
                 ));
 
-                if has_return_data {
-                    let ok_ty = return_ok_type
-                        .expect("return_ok_type must be set when has_return_data is true");
-                    let user_body: proc_macro2::TokenStream =
-                        stmts.iter().map(|s| quote!(#s)).collect();
-                    new_stmts.push(syn::parse_quote!(
-                        const _: () = assert!(
-                            core::mem::align_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>() == 1,
-                            "return data type must implement InstructionArg with an alignment-1 Zc companion"
-                        );
-                    ));
-                    new_stmts.push(syn::parse_quote!(
-                        {
-                            let __result: Result<#ok_ty, ProgramError> = (|| { #user_body })();
-                            match __result {
-                                Ok(ref __val) => {
-                                    #param_ident.accounts.epilogue()?;
-                                    let __zc =
-                                        <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::to_zc(__val);
-                                    let __bytes = unsafe {
-                                        core::slice::from_raw_parts(
-                                            &__zc as *const <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc as *const u8,
-                                            core::mem::size_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>(),
-                                        )
-                                    };
-                                    quasar_lang::return_data::set_return_data(__bytes);
-                                    Ok(())
-                                }
-                                Err(e) => Err(e),
-                            }
-                        }
-                    ));
-                    func.block.stmts = new_stmts;
-                } else {
-                    let user_body: proc_macro2::TokenStream =
-                        stmts.iter().map(|s| quote!(#s)).collect();
-                    new_stmts.push(syn::parse_quote!({
-                        let __user_result: Result<(), ProgramError> = { #user_body };
-                        __user_result?;
-                        #param_ident.accounts.epilogue()
-                    }));
-                    func.block.stmts = new_stmts;
-                }
+                new_stmts.extend(emit_handler_tail(
+                    &param_ident,
+                    &stmts,
+                    has_return_data,
+                    return_ok_type.as_ref(),
+                ));
+                func.block.stmts = new_stmts;
 
                 return quote!(#func).into();
             } else {
@@ -434,47 +517,13 @@ pub(crate) fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
         ));
     }
 
-    if has_return_data {
-        let ok_ty =
-            return_ok_type.expect("return_ok_type must be set when has_return_data is true");
-        let user_body: proc_macro2::TokenStream = stmts.iter().map(|s| quote!(#s)).collect();
-        new_stmts.push(syn::parse_quote!(
-            const _: () = assert!(
-                core::mem::align_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>() == 1,
-                "return data type must implement InstructionArg with an alignment-1 Zc companion"
-            );
-        ));
-        new_stmts.push(syn::parse_quote!(
-            {
-                let __result: Result<#ok_ty, ProgramError> = (|| { #user_body })();
-                match __result {
-                    Ok(ref __val) => {
-                        #param_ident.accounts.epilogue()?;
-                        let __zc =
-                            <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::to_zc(__val);
-                        let __bytes = unsafe {
-                            core::slice::from_raw_parts(
-                                &__zc as *const <#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc as *const u8,
-                                core::mem::size_of::<<#ok_ty as quasar_lang::instruction_arg::InstructionArg>::Zc>(),
-                            )
-                        };
-                        quasar_lang::return_data::set_return_data(__bytes);
-                        Ok(())
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-        ));
-        func.block.stmts = new_stmts;
-    } else {
-        let user_body: proc_macro2::TokenStream = stmts.iter().map(|s| quote!(#s)).collect();
-        new_stmts.push(syn::parse_quote!({
-            let __user_result: Result<(), ProgramError> = { #user_body };
-            __user_result?;
-            #param_ident.accounts.epilogue()
-        }));
-        func.block.stmts = new_stmts;
-    }
+    new_stmts.extend(emit_handler_tail(
+        &param_ident,
+        &stmts,
+        has_return_data,
+        return_ok_type.as_ref(),
+    ));
+    func.block.stmts = new_stmts;
 
     quote!(#func).into()
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -49,7 +49,7 @@ mod serialize;
 ///   struct
 /// - A `Bumps` companion struct containing PDA bump seeds
 /// - `AccountCount` implementation for dispatch buffer sizing
-#[proc_macro_derive(Accounts, attributes(account, instruction))]
+#[proc_macro_derive(Accounts, attributes(account, accounts, instruction))]
 pub fn derive_accounts(input: TokenStream) -> TokenStream {
     accounts::derive_accounts(input)
 }

--- a/derive/src/program.rs
+++ b/derive/src/program.rs
@@ -14,6 +14,46 @@ use {
     syn::{parse_macro_input, FnArg, Ident, Item, ItemMod, LitInt, Pat, Type},
 };
 
+/// Emit the heap cursor init or poison block for a dispatch arm.
+///
+/// - `heap = true`: reset cursor to start (this endpoint uses the allocator)
+/// - `heap = false, any_heap = true`: poison cursor in release, reset in debug
+///   (this endpoint must NOT allocate — trap accidental allocations)
+/// - `any_heap = false`: no-op (global heap init in entrypoint handles it)
+fn emit_heap_cursor_block(heap: bool, any_heap: bool) -> TokenStream2 {
+    if heap {
+        quote! {
+            #[cfg(feature = "alloc")]
+            {
+                unsafe {
+                    let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
+                    *(heap_start as *mut usize) =
+                        heap_start + core::mem::size_of::<usize>();
+                }
+            }
+        }
+    } else if any_heap {
+        quote! {
+            #[cfg(feature = "alloc")]
+            {
+                #[cfg(feature = "debug")]
+                unsafe {
+                    let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
+                    *(heap_start as *mut usize) =
+                        heap_start + core::mem::size_of::<usize>();
+                }
+                #[cfg(not(feature = "debug"))]
+                unsafe {
+                    *(super::allocator::HEAP_START_ADDRESS as *mut usize) =
+                        super::allocator::HEAP_CURSOR_POISONED;
+                }
+            }
+        }
+    } else {
+        quote! {}
+    }
+}
+
 /// Parse `#[max(N)]` or `#[max(N, pfx = P)]` from a function parameter's
 /// attributes. Used by the `#[program]` macro to map borrowed args to
 /// compact client types.
@@ -90,6 +130,15 @@ struct ClientArgSpec {
     ty: Type,
 }
 
+/// Lightweight spec for `#[instruction(raw)]` — only discriminator + heap flag.
+/// Raw instructions have no accounts type, no client args, no remaining.
+struct RawInstructionSpec {
+    fn_name: Ident,
+    disc_bytes: Vec<LitInt>,
+    disc_values: Vec<u8>,
+    heap: bool,
+}
+
 struct InstructionSpec {
     fn_name: Ident,
     disc_bytes: Vec<LitInt>,
@@ -112,36 +161,8 @@ impl InstructionSpec {
         }
     }
 
-    fn heap_dispatch_arm(&self) -> TokenStream2 {
-        let cursor_init = if self.heap {
-            quote! {
-                #[cfg(feature = "alloc")]
-                {
-                    unsafe {
-                        let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
-                        *(heap_start as *mut usize) =
-                            heap_start + core::mem::size_of::<usize>();
-                    }
-                }
-            }
-        } else {
-            quote! {
-                #[cfg(feature = "alloc")]
-                {
-                    #[cfg(feature = "debug")]
-                    unsafe {
-                        let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
-                        *(heap_start as *mut usize) =
-                            heap_start + core::mem::size_of::<usize>();
-                    }
-                    #[cfg(not(feature = "debug"))]
-                    unsafe {
-                        *(super::allocator::HEAP_START_ADDRESS as *mut usize) =
-                            super::allocator::HEAP_CURSOR_POISONED;
-                    }
-                }
-            }
-        };
+    fn heap_dispatch_arm(&self, any_heap: bool) -> TokenStream2 {
+        let cursor_init = emit_heap_cursor_block(self.heap, any_heap);
         let fn_name = &self.fn_name;
         let accounts_type = &self.accounts_type;
         let disc_bytes = &self.disc_bytes;
@@ -167,7 +188,29 @@ impl InstructionSpec {
     }
 }
 
-pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
+/// Parsed attributes from `#[program(...)]`.
+struct ProgramArgs {
+    no_entrypoint: bool,
+}
+
+impl syn::parse::Parse for ProgramArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut no_entrypoint = false;
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            if ident == "no_entrypoint" {
+                no_entrypoint = true;
+            } else {
+                return Err(syn::Error::new(ident.span(), "expected `no_entrypoint`"));
+            }
+            let _ = input.parse::<Option<syn::Token![,]>>();
+        }
+        Ok(Self { no_entrypoint })
+    }
+}
+
+pub(crate) fn program(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let program_args = parse_macro_input!(attr as ProgramArgs);
     let mut module = parse_macro_input!(item as ItemMod);
     let mod_name = module.ident.clone();
     let program_type_name = format_ident!("{}", snake_to_pascal(&mod_name.to_string()));
@@ -186,6 +229,7 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Scan for #[instruction(discriminator = ...)] functions
     let mut instruction_specs = Vec::new();
+    let mut raw_instruction_specs: Vec<RawInstructionSpec> = Vec::new();
     let mut seen_discriminators: Vec<(Vec<u8>, String)> = Vec::new();
     let mut disc_len: Option<usize> = None;
 
@@ -209,12 +253,6 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     };
                     let fn_name = &func.sig.ident;
-                    let ctx_kind = match CtxKind::classify(&func.sig) {
-                        Ok(k) => k,
-                        Err(e) => return e.to_compile_error().into(),
-                    };
-                    let inner_ty = ctx_kind.inner_ty();
-                    let accounts_type = quote!(#inner_ty);
 
                     // Validate same length across all instructions
                     match disc_len {
@@ -255,6 +293,24 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         .into();
                     }
                     seen_discriminators.push((disc_values.clone(), fn_name.to_string()));
+
+                    if args.raw {
+                        // Raw instruction — no CtxKind, no accounts_type, no client args.
+                        raw_instruction_specs.push(RawInstructionSpec {
+                            fn_name: fn_name.clone(),
+                            disc_bytes: disc_bytes.clone(),
+                            disc_values: disc_values.clone(),
+                            heap: args.heap,
+                        });
+                        break;
+                    }
+
+                    let ctx_kind = match CtxKind::classify(&func.sig) {
+                        Ok(k) => k,
+                        Err(e) => return e.to_compile_error().into(),
+                    };
+                    let inner_ty = ctx_kind.inner_ty();
+                    let accounts_type = quote!(#inner_ty);
 
                     // Collect data for client module generation — invoke the macro_rules
                     // bridge emitted by derive(Accounts)
@@ -372,7 +428,190 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .map(InstructionSpec::client_item)
         .collect();
 
-    let any_heap = instruction_specs.iter().any(|spec| spec.heap);
+    let any_heap = instruction_specs.iter().any(|spec| spec.heap)
+        || raw_instruction_specs.iter().any(|spec| spec.heap);
+
+    // ── Raw dispatch early-return block ──────────────────────────
+    // Each raw instruction gets a match arm that walks the SVM buffer
+    // to build a `Context` with all accounts, then calls the handler
+    // directly. This block is inserted in __dispatch before the
+    // normal dispatch! call.
+    let raw_dispatch_block = if raw_instruction_specs.is_empty() {
+        quote! {}
+    } else {
+        // Sort raw specs by discriminator value for table construction.
+        let mut sorted_raw: Vec<&RawInstructionSpec> = raw_instruction_specs.iter().collect();
+        sorted_raw.sort_by_key(|spec| spec.disc_values.clone());
+
+        // For 1-byte discriminators with contiguous values: use O(1) function
+        // pointer table dispatch. The SVM verifier accepts callx (indirect
+        // calls) — verified by the callx_dispatch integration test.
+        //
+        // Contiguity check: sorted disc values must form a gap-free sequence.
+        // If not (e.g. raw discs 1,2,5 with normal at 3,4), fall back to match.
+        let is_contiguous = sorted_raw.len() == 1
+            || sorted_raw
+                .windows(2)
+                .all(|w| w[1].disc_values[0] == w[0].disc_values[0] + 1);
+        let use_table = disc_len_lit == 1 && is_contiguous && !sorted_raw.is_empty();
+
+        if use_table {
+            let raw_min = sorted_raw.first().unwrap().disc_values[0];
+            let raw_max = sorted_raw.last().unwrap().disc_values[0];
+            let table_size = (raw_max - raw_min + 1) as usize;
+
+            // Build the function pointer table. Slots are filled for each
+            // raw disc value. Gaps (if any non-raw instruction sits between
+            // raw ones) should not exist — the disc collision check prevents it.
+            let raw_fn_names: Vec<&Ident> = sorted_raw.iter().map(|s| &s.fn_name).collect();
+            let table_size_lit = table_size;
+            let raw_min_lit = raw_min;
+
+            // Heap: init once before dispatch if any raw instruction uses heap.
+            let heap_init = emit_heap_cursor_block(sorted_raw.iter().any(|s| s.heap), any_heap);
+
+            quote! {
+                if instruction_data.len() >= 1 {
+                    let __raw_disc_byte = instruction_data[0];
+                    let __raw_idx = __raw_disc_byte.wrapping_sub(#raw_min_lit) as usize;
+                    if __raw_idx < #table_size_lit {
+                        #heap_init
+
+                        // SAFETY: Program ID follows instruction data in the SVM buffer.
+                        let __raw_program_id: &[u8; 32] = unsafe {
+                            &*(instruction_data.as_ptr().add(instruction_data.len())
+                                as *const [u8; 32])
+                        };
+                        const __RAW_U64: usize = core::mem::size_of::<u64>();
+                        let __raw_num_accounts = unsafe { *(ptr as *const u64) };
+                        let __raw_accounts_start = unsafe { (ptr as *mut u8).add(__RAW_U64) };
+                        let __raw_boundary = unsafe { instruction_data.as_ptr().sub(__RAW_U64) };
+
+                        const __RAW_MAX: usize = 64;
+                        let __raw_count = core::cmp::min(__raw_num_accounts as usize, __RAW_MAX);
+                        let mut __raw_buf = core::mem::MaybeUninit::<
+                            [quasar_lang::__internal::AccountView; __RAW_MAX]
+                        >::uninit();
+
+                        let (__raw_parsed, __raw_remaining) = unsafe {
+                            quasar_lang::__internal::parse_all_accounts_unchecked(
+                                __raw_accounts_start,
+                                __raw_buf.as_mut_ptr()
+                                    as *mut quasar_lang::__internal::AccountView,
+                                __raw_count,
+                                __raw_boundary,
+                            )?
+                        };
+
+                        let __raw_accounts = unsafe {
+                            core::slice::from_raw_parts_mut(
+                                __raw_buf.as_mut_ptr()
+                                    as *mut quasar_lang::__internal::AccountView,
+                                __raw_parsed,
+                            )
+                        };
+
+                        let __raw_ctx = Context {
+                            program_id: __raw_program_id,
+                            accounts: __raw_accounts,
+                            remaining_ptr: __raw_remaining,
+                            data: &instruction_data[1..],
+                            accounts_boundary: __raw_boundary as *const u8,
+                        };
+
+                        // O(1) dispatch: function pointer table indexed by
+                        // discriminator byte. LLVM emits `callx` for the
+                        // indirect call — ~5 CU constant overhead.
+                        type __RawHandler = fn(Context) -> Result<(), ProgramError>;
+                        let __raw_table: [__RawHandler; #table_size_lit] = [
+                            #(#raw_fn_names),*
+                        ];
+                        return __raw_table[__raw_idx](__raw_ctx);
+                    }
+                }
+            }
+        } else {
+            // Multi-byte discriminators: fall back to match chain.
+            let raw_disc_patterns: Vec<TokenStream2> = raw_instruction_specs
+                .iter()
+                .map(|spec| {
+                    let disc_bytes = &spec.disc_bytes;
+                    quote! { [#(#disc_bytes),*] }
+                })
+                .collect();
+
+            let raw_call_arms: Vec<TokenStream2> = raw_instruction_specs
+                .iter()
+                .map(|spec| {
+                    let fn_name = &spec.fn_name;
+                    let disc_bytes = &spec.disc_bytes;
+                    let cursor_init = emit_heap_cursor_block(spec.heap, any_heap);
+                    quote! {
+                        [#(#disc_bytes),*] => {
+                            #cursor_init
+                            return #fn_name(__raw_ctx);
+                        }
+                    }
+                })
+                .collect();
+
+            quote! {
+                if instruction_data.len() >= #disc_len_lit {
+                    let __raw_disc: [u8; #disc_len_lit] = unsafe {
+                        *(instruction_data.as_ptr() as *const [u8; #disc_len_lit])
+                    };
+
+                    if matches!(__raw_disc, #(#raw_disc_patterns)|*) {
+                        let __raw_program_id: &[u8; 32] = unsafe {
+                            &*(instruction_data.as_ptr().add(instruction_data.len())
+                                as *const [u8; 32])
+                        };
+                        const __RAW_U64: usize = core::mem::size_of::<u64>();
+                        let __raw_num_accounts = unsafe { *(ptr as *const u64) };
+                        let __raw_accounts_start = unsafe { (ptr as *mut u8).add(__RAW_U64) };
+                        let __raw_boundary = unsafe { instruction_data.as_ptr().sub(__RAW_U64) };
+
+                        const __RAW_MAX: usize = 64;
+                        let __raw_count = core::cmp::min(__raw_num_accounts as usize, __RAW_MAX);
+                        let mut __raw_buf = core::mem::MaybeUninit::<
+                            [quasar_lang::__internal::AccountView; __RAW_MAX]
+                        >::uninit();
+
+                        let (__raw_parsed, __raw_remaining) = unsafe {
+                            quasar_lang::__internal::parse_all_accounts_unchecked(
+                                __raw_accounts_start,
+                                __raw_buf.as_mut_ptr()
+                                    as *mut quasar_lang::__internal::AccountView,
+                                __raw_count,
+                                __raw_boundary,
+                            )?
+                        };
+
+                        let __raw_accounts = unsafe {
+                            core::slice::from_raw_parts_mut(
+                                __raw_buf.as_mut_ptr()
+                                    as *mut quasar_lang::__internal::AccountView,
+                                __raw_parsed,
+                            )
+                        };
+
+                        let __raw_ctx = Context {
+                            program_id: __raw_program_id,
+                            accounts: __raw_accounts,
+                            remaining_ptr: __raw_remaining,
+                            data: &instruction_data[#disc_len_lit..],
+                            accounts_boundary: __raw_boundary as *const u8,
+                        };
+
+                        match __raw_disc {
+                            #(#raw_call_arms)*
+                            _ => unsafe { core::hint::unreachable_unchecked() }
+                        }
+                    }
+                }
+            }
+        }
+    };
 
     // Append dispatch + entrypoint to the module
     if let Some((_, ref mut items)) = module.content {
@@ -390,50 +629,66 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         });
 
-        if any_heap {
-            // When any instruction opts into heap, build per-arm cursor init
-            // blocks and feed them into the extended dispatch! macro form.
-            // Heap endpoints get normal cursor init; non-heap endpoints poison
-            // the cursor (clean alloc trap). Debug builds exempt non-heap
-            // endpoints so alloc::format! works in error paths.
+        // Normal dispatch tail: either dispatch! with heap arms, dispatch!
+        // with simple arms, or just InvalidInstructionData if all instructions
+        // are raw.
+        let normal_dispatch_tail = if instruction_specs.is_empty() {
+            // All instructions are raw — no normal dispatch needed.
+            quote! { Err(ProgramError::InvalidInstructionData) }
+        } else if any_heap {
             let heap_dispatch_arms: Vec<proc_macro2::TokenStream> = instruction_specs
                 .iter()
-                .map(InstructionSpec::heap_dispatch_arm)
+                .map(|spec| spec.heap_dispatch_arm(any_heap))
                 .collect();
+            quote! {
+                dispatch!(ptr, instruction_data, #disc_len_lit, {
+                    #(#heap_dispatch_arms),*
+                })
+            }
+        } else {
+            quote! {
+                dispatch!(ptr, instruction_data, #disc_len_lit, {
+                    #(#dispatch_arms),*
+                })
+            }
+        };
 
+        // When no_entrypoint is set, __dispatch is pub so users can call
+        // it from a custom entrypoint. Otherwise it stays module-private.
+        let dispatch_vis = if program_args.no_entrypoint {
+            quote! { pub }
+        } else {
+            quote! {}
+        };
+
+        let dispatch_heap_init = emit_heap_cursor_block(true, true);
+
+        if any_heap {
             items.push(syn::parse_quote! {
                 #[inline(always)]
-                fn __dispatch(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
-                    // Initialize cursor to a valid state before the event check.
-                    // __handle_event itself is allocation-free, but this prevents
-                    // UB if it ever changes or if debug error paths allocate.
-                    #[cfg(feature = "alloc")]
-                    unsafe {
-                        let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
-                        *(heap_start as *mut usize) =
-                            heap_start + core::mem::size_of::<usize>();
-                    }
+                #dispatch_vis fn __dispatch(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
+                    #dispatch_heap_init
 
                     if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
                         return __handle_event(ptr, instruction_data);
                     }
-                    // Per-arm cursor init overrides the safe default above.
-                    dispatch!(ptr, instruction_data, #disc_len_lit, {
-                        #(#heap_dispatch_arms),*
-                    })
+
+                    #raw_dispatch_block
+
+                    #normal_dispatch_tail
                 }
             });
         } else {
-            // No heap annotations — use the simple dispatch! macro form
             items.push(syn::parse_quote! {
                 #[inline(always)]
-                fn __dispatch(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
+                #dispatch_vis fn __dispatch(ptr: *mut u8, instruction_data: &[u8]) -> Result<(), ProgramError> {
                     if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
                         return __handle_event(ptr, instruction_data);
                     }
-                    dispatch!(ptr, instruction_data, #disc_len_lit, {
-                        #(#dispatch_arms),*
-                    })
+
+                    #raw_dispatch_block
+
+                    #normal_dispatch_tail
                 }
             });
         }
@@ -453,24 +708,29 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         };
 
-        items.push(syn::parse_quote! {
-            #[unsafe(no_mangle)]
-            #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-            #[allow(unexpected_cfgs)]
-            pub unsafe extern "C" fn entrypoint(ptr: *mut u8, instruction_data: *const u8) -> u64 {
-                #cursor_init
-                let instruction_data = unsafe {
-                    core::slice::from_raw_parts(
-                        instruction_data,
-                        *(instruction_data.sub(8) as *const u64) as usize,
-                    )
-                };
-                match __dispatch(ptr, instruction_data) {
-                    Ok(_) => 0,
-                    Err(e) => e.into(),
+        // When no_entrypoint is set, skip the generated entrypoint so the
+        // user can write their own extern "C" fn entrypoint that calls
+        // module::__dispatch() for fallthrough (Anchor 0.30 pattern).
+        if !program_args.no_entrypoint {
+            items.push(syn::parse_quote! {
+                #[unsafe(no_mangle)]
+                #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+                #[allow(unexpected_cfgs)]
+                pub unsafe extern "C" fn entrypoint(ptr: *mut u8, instruction_data: *const u8) -> u64 {
+                    #cursor_init
+                    let instruction_data = unsafe {
+                        core::slice::from_raw_parts(
+                            instruction_data,
+                            *(instruction_data.sub(8) as *const u64) as usize,
+                        )
+                    };
+                    match __dispatch(ptr, instruction_data) {
+                        Ok(_) => 0,
+                        Err(e) => e.into(),
+                    }
                 }
-            }
-        });
+            });
+        }
 
         // Add CPI module inside the program module (instruction builders only —
         // the full client with account/event types is generated by the IDL).
@@ -533,6 +793,7 @@ pub(crate) fn program(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         impl quasar_lang::account_load::AccountLoad for EventAuthority {
+            type BehaviorTarget = Self;
             type Params = ();
 
             #[inline(always)]

--- a/derive/src/serialize.rs
+++ b/derive/src/serialize.rs
@@ -532,7 +532,9 @@ fn derive_enum(input: DeriveInput, variants: Vec<syn::Variant>) -> TokenStream {
             fn from_zc(zc: &Self::Zc) -> Self {
                 match <#repr_ty as quasar_lang::instruction_arg::InstructionArg>::from_zc(zc) {
                     #(#match_from_zc,)*
-                    _ => unreachable!("invalid enum discriminant; validate_zc must run first"),
+                    // SAFETY: validate_zc rejects invalid discriminants
+                    // before from_zc is called. This branch is unreachable.
+                    _ => unsafe { core::hint::unreachable_unchecked() },
                 }
             }
 

--- a/idl/src/lint/constraints.rs
+++ b/idl/src/lint/constraints.rs
@@ -62,7 +62,7 @@ pub fn classify_field_type(ty: &syn::Type) -> (FieldClass, Option<String>) {
     let inner_name = extract_inner_type_name(last_seg);
 
     match ident.as_str() {
-        "Account" => {
+        "Account" | "Migration" => {
             let inner = inner_name.clone().unwrap_or_else(|| "Unknown".to_string());
             (
                 FieldClass::Account {

--- a/idl/src/parser/accounts.rs
+++ b/idl/src/parser/accounts.rs
@@ -27,6 +27,8 @@ pub struct RawAccountField {
     pub inner_type_name: Option<String>,
     pub constraints: FieldConstraints,
     pub seed_type: Option<String>,
+    /// Present when field type is `Migration<From, To>`.
+    pub migration: Option<(String, String)>,
 }
 
 #[derive(Clone)]
@@ -81,6 +83,29 @@ fn has_derive_accounts(attrs: &[syn::Attribute]) -> bool {
     false
 }
 
+/// Extract `(from_type, to_type)` from `Migration<From, To>` field type.
+fn extract_migration_metadata(ty: &syn::Type) -> Option<(String, String)> {
+    if let syn::Type::Path(tp) = ty {
+        if let Some(seg) = tp.path.segments.last() {
+            if seg.ident == "Migration" {
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    let mut iter = args.args.iter();
+                    if let (
+                        Some(syn::GenericArgument::Type(from)),
+                        Some(syn::GenericArgument::Type(to)),
+                    ) = (iter.next(), iter.next())
+                    {
+                        let from_str = helpers::type_to_string(from);
+                        let to_str = helpers::type_to_string(to);
+                        return Some((from_str, to_str));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 fn has_writable_directive(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
         if !attr.path().is_ident("account") {
@@ -108,7 +133,10 @@ fn has_writable_directive(attrs: &[syn::Attribute]) -> bool {
 
 fn parse_account_field(field: &syn::Field, parent: &syn::ItemStruct) -> RawAccountField {
     let name = field.ident.as_ref().unwrap().to_string();
-    let writable = helpers::is_mut_ref(&field.ty) || has_writable_directive(&field.attrs);
+    let migration = extract_migration_metadata(&field.ty);
+    let writable = helpers::is_mut_ref(&field.ty)
+        || has_writable_directive(&field.attrs)
+        || migration.is_some();
 
     // Collect sibling field names for seed reference detection
     let sibling_names: Vec<String> = match &parent.fields {
@@ -138,6 +166,7 @@ fn parse_account_field(field: &syn::Field, parent: &syn::ItemStruct) -> RawAccou
         inner_type_name,
         constraints,
         seed_type,
+        migration,
     }
 }
 
@@ -433,11 +462,20 @@ fn to_idl_account_item(
         IdlPda { seeds }
     });
 
+    let migration = field
+        .migration
+        .as_ref()
+        .map(|(from, to)| crate::types::IdlMigration {
+            from: from.clone(),
+            to: to.clone(),
+        });
+
     IdlAccountItem {
         name: helpers::to_camel_case(&field.name),
         writable: field.writable,
         signer: field.signer,
         pda,
         address: field.address.clone(),
+        migration,
     }
 }

--- a/idl/src/parser/helpers.rs
+++ b/idl/src/parser/helpers.rs
@@ -127,6 +127,20 @@ pub fn type_inner_name(ty: &syn::Type) -> Option<String> {
     }
 }
 
+/// Convert a syn::Type to a readable string (e.g., "ConfigV1").
+pub fn type_to_string(ty: &syn::Type) -> String {
+    if let syn::Type::Path(tp) = ty {
+        tp.path
+            .segments
+            .iter()
+            .map(|seg| seg.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::")
+    } else {
+        "Unknown".to_string()
+    }
+}
+
 /// Check if a field type's reference is mutable (`&'a mut T`).
 pub fn is_mut_ref(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Reference(r) if r.mutability.is_some())

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -777,6 +777,7 @@ fn rust_codegen_account_metas() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "to".to_string(),
@@ -788,6 +789,7 @@ fn rust_codegen_account_metas() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "authority".to_string(),
@@ -799,6 +801,7 @@ fn rust_codegen_account_metas() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
             ],
         });
@@ -1663,6 +1666,7 @@ fn ts_codegen_pda_helpers_are_exported_and_reused() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             },
             RawAccountField {
                 name: "user".to_string(),
@@ -1674,6 +1678,7 @@ fn ts_codegen_pda_helpers_are_exported_and_reused() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             },
         ],
     }];
@@ -1742,6 +1747,7 @@ fn ts_codegen_pda_arg_seeds_are_encoded_by_type() {
             inner_type_name: None,
             constraints: FieldConstraints::default(),
             seed_type: None,
+            migration: None,
         }],
     }];
 
@@ -1819,6 +1825,7 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "user".to_string(),
@@ -1830,6 +1837,7 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
             ],
         },
@@ -1851,6 +1859,7 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "user".to_string(),
@@ -1862,6 +1871,7 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
             ],
         },
@@ -1927,6 +1937,7 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "user".to_string(),
@@ -1938,6 +1949,7 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
             ],
         },
@@ -1959,6 +1971,7 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
                 RawAccountField {
                     name: "user".to_string(),
@@ -1970,6 +1983,7 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     inner_type_name: None,
                     constraints: FieldConstraints::default(),
                     seed_type: None,
+                    migration: None,
                 },
             ],
         },
@@ -2199,6 +2213,7 @@ fn rust_codegen_pda_helpers() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             },
             RawAccountField {
                 name: "user".to_string(),
@@ -2210,6 +2225,7 @@ fn rust_codegen_pda_helpers() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             },
         ],
     }];
@@ -2265,6 +2281,7 @@ fn rust_codegen_pda_dedup() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             }],
         },
         RawAccountsStruct {
@@ -2279,6 +2296,7 @@ fn rust_codegen_pda_dedup() {
                 inner_type_name: None,
                 constraints: FieldConstraints::default(),
                 seed_type: None,
+                migration: None,
             }],
         },
     ];

--- a/lang/src/account_exit.rs
+++ b/lang/src/account_exit.rs
@@ -7,6 +7,52 @@ use {
     solana_program_error::{ProgramError, ProgramResult},
 };
 
+/// Context for closing an account.
+///
+/// `authority` and `token_program` are `Option` — used by token/SPL close
+/// paths, ignored by program-owned close.
+pub struct CloseCtx<'a> {
+    pub destination: &'a AccountView,
+    /// Token close authority. `None` for program-owned accounts.
+    pub authority: Option<&'a AccountView>,
+    /// Token program for CPI close. `None` for program-owned accounts.
+    pub token_program: Option<&'a AccountView>,
+}
+
+/// Context for sweeping tokens from an account before closing.
+pub struct SweepCtx<'a> {
+    pub receiver: &'a AccountView,
+    pub mint: &'a AccountView,
+    pub authority: &'a AccountView,
+    pub token_program: &'a AccountView,
+}
+
+/// Account exit lifecycle: close and sweep.
+///
+/// Implemented on the behavior target (Token, Mint, `#[account]` types).
+///
+/// # Safety Contract
+///
+/// Implementations of `close()` MUST ensure the account's discriminator is
+/// invalidated before or atomically with the lamport drain. Failure creates
+/// a revival attack window where a concurrent transaction can re-fund a
+/// closed account that still has a valid discriminator.
+///
+/// - **Program-owned**: use [`close_program_account()`] which zeros the
+///   discriminator FIRST, then drains lamports.
+/// - **CPI-based** (SPL Token): the target program handles the drain
+///   atomically.
+pub trait AccountExit {
+    fn close(view: &mut AccountView, ctx: CloseCtx<'_>) -> ProgramResult;
+
+    /// Sweep transfers all tokens out before closing. Only implemented by
+    /// token account types. Takes shared `&AccountView` — sweep only reads
+    /// account data and issues a CPI.
+    fn sweep(_view: &AccountView, _ctx: SweepCtx<'_>) -> ProgramResult {
+        Err(ProgramError::InvalidAccountData)
+    }
+}
+
 /// Close a program-owned account: zero discriminator, drain lamports, reassign
 /// to system program, resize to zero.
 ///

--- a/lang/src/account_init.rs
+++ b/lang/src/account_init.rs
@@ -8,6 +8,32 @@ use {
     solana_program_error::ProgramResult,
 };
 
+/// Context for account initialization CPI.
+pub struct InitCtx<'a> {
+    pub payer: &'a AccountView,
+    pub target: &'a mut AccountView,
+    pub program_id: &'a Address,
+    pub space: u64,
+    pub signers: &'a [Signer<'a, 'a>],
+    pub rent: &'a Rent,
+}
+
+/// Initialization behavior for account types.
+///
+/// Implemented on the behavior target (Token, Mint, `#[account]` types),
+/// NOT on wrapper types (`Account<T>`, `InterfaceAccount<T>`).
+///
+/// The `derive(Accounts)` macro calls this via:
+/// ```text
+/// type __Target = <FieldTy as AccountLoad>::BehaviorTarget;
+/// <__Target as AccountInit>::init(ctx, &params)?;
+/// ```
+pub trait AccountInit {
+    type InitParams<'a>: Default;
+
+    fn init<'a>(ctx: InitCtx<'a>, params: &Self::InitParams<'a>) -> ProgramResult;
+}
+
 /// Create account via system program + write discriminator.
 #[inline(always)]
 pub fn init_account(

--- a/lang/src/account_load.rs
+++ b/lang/src/account_load.rs
@@ -11,6 +11,19 @@ pub trait AccountLoad: AsAccountView + Sized {
     const IS_SIGNER: bool = false;
     const IS_EXECUTABLE: bool = false;
 
+    /// The type that owns lifecycle behavior (init, close, sweep).
+    ///
+    /// For `Account<T>` and `InterfaceAccount<T>` this is `T` — the inner
+    /// data type that implements `AccountInit` / `AccountExit` in its own
+    /// crate. For all other wrappers (Signer, Program, etc.) this is `Self`.
+    ///
+    /// The `derive(Accounts)` macro emits trait calls on `BehaviorTarget`:
+    /// ```text
+    /// type __Target = <FieldTy as AccountLoad>::BehaviorTarget;
+    /// <__Target as AccountInit>::init(ctx, &params)?;
+    /// ```
+    type BehaviorTarget;
+
     /// Per-type config for namespaced constraints (e.g. `token::mint`).
     type Params: Default;
 
@@ -51,5 +64,18 @@ pub trait AccountLoad: AsAccountView + Sized {
     #[inline(always)]
     fn validate(&self, _params: &Self::Params) -> Result<(), ProgramError> {
         Ok(())
+    }
+
+    /// Get a mutable view for lifecycle operations (close, realloc).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure the account is writable and that no other
+    /// references to the underlying `AccountView` are live. Only called
+    /// by generated epilogue code after writable/lifecycle checks pass.
+    #[doc(hidden)]
+    #[inline(always)]
+    unsafe fn to_account_view_mut(&mut self) -> &mut AccountView {
+        &mut *(self as *mut Self as *mut AccountView)
     }
 }

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -322,6 +322,7 @@ mod kani_proofs {
 impl<T: AsAccountView + CheckOwner + AccountCheck + StaticView> crate::account_load::AccountLoad
     for Account<T>
 {
+    type BehaviorTarget = T;
     type Params = <T as AccountCheck>::Params;
 
     #[inline(always)]

--- a/lang/src/accounts/interface.rs
+++ b/lang/src/accounts/interface.rs
@@ -18,6 +18,7 @@ impl<T: ProgramInterface> AsAccountView for Interface<T> {
 impl<T: ProgramInterface> crate::account_load::AccountLoad for Interface<T> {
     const IS_EXECUTABLE: bool = true;
 
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -62,6 +62,7 @@ impl<T: Owners + AccountCheck> InterfaceAccount<T> {
 }
 
 impl<T: Owners + AccountCheck> crate::account_load::AccountLoad for InterfaceAccount<T> {
+    type BehaviorTarget = T;
     type Params = <T as AccountCheck>::Params;
 
     #[inline(always)]

--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -1,0 +1,194 @@
+use {crate::prelude::*, core::marker::PhantomData};
+
+/// Account wrapper for type-safe on-chain migration from `From` to `To`.
+///
+/// During the handler, `source()` provides zero-copy read access to the
+/// source account's data. At epilogue, `finish()` reads the source data,
+/// calls `Migrate::migrate()`, reallocs, and writes the target.
+///
+/// # Lifecycle
+/// ```text
+/// parse:    validate source owner + discriminator
+/// handler:  read source fields via source() (zero-copy)
+/// epilogue: finish() → migrate → realloc → write target
+/// ```
+///
+/// # Safety
+/// `source()` validates the source discriminator is still present before
+/// returning a reference. After `finish()` runs, `source()` returns `None`
+/// (the buffer now contains target data). This prevents type confusion from
+/// interpreting target bytes as the source type.
+///
+/// `finish()` is idempotent — if the target discriminator is already present
+/// (e.g., the epilogue was re-entered), the call is a no-op.
+#[repr(transparent)]
+pub struct Migration<From, To> {
+    __view: AccountView,
+    _marker: PhantomData<(From, To)>,
+}
+
+impl<From: AsAccountView, To> AsAccountView for Migration<From, To> {
+    #[inline(always)]
+    fn to_account_view(&self) -> &AccountView {
+        &self.__view
+    }
+}
+
+// Safety: Migration is repr(transparent) over AccountView.
+unsafe impl<From, To> crate::traits::StaticView for Migration<From, To> {}
+
+impl<From, To> crate::account_load::AccountLoad for Migration<From, To>
+where
+    From: AsAccountView + CheckOwner + AccountCheck + crate::traits::StaticView,
+{
+    type BehaviorTarget = Self;
+    type Params = <From as AccountCheck>::Params;
+
+    #[inline(always)]
+    fn check(view: &AccountView, field_name: &str) -> Result<(), ProgramError> {
+        // Validate against source type (owner + discriminator).
+        crate::validation::check_account::<From>(view, field_name)
+    }
+
+    #[inline(always)]
+    fn validate(&self, params: &Self::Params) -> Result<(), ProgramError> {
+        <From as AccountCheck>::validate(&self.__view, params)
+    }
+}
+
+impl<From, To> Migration<From, To>
+where
+    From: crate::traits::Discriminator,
+{
+    /// Read source account data before migration (zero-copy pointer cast).
+    ///
+    /// Returns `None` after `finish()` has run (the buffer now contains
+    /// target data). This prevents type confusion.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let val: u64 = ctx.accounts.config.source().unwrap().value.into();
+    /// ```
+    #[inline(always)]
+    pub fn source(&self) -> Option<&From> {
+        let data = unsafe { self.__view.borrow_unchecked() };
+        if data.starts_with(<From as crate::traits::Discriminator>::DISCRIMINATOR) {
+            Some(unsafe { &*(&self.__view as *const AccountView as *const From) })
+        } else {
+            None
+        }
+    }
+}
+
+impl<From, To> Migration<From, To>
+where
+    From: core::ops::Deref + crate::traits::Discriminator + crate::traits::Owner,
+    From::Target: Sized + crate::traits::Migrate<To::Target>,
+    To: core::ops::Deref
+        + crate::traits::Owner
+        + crate::traits::Space
+        + crate::traits::Discriminator,
+    To::Target: Sized,
+{
+    // Compile-time safety assertions.
+    const _OWNER_EQ: () = assert!(
+        crate::keys_eq_const(
+            &<From as crate::traits::Owner>::OWNER,
+            &<To as crate::traits::Owner>::OWNER,
+        ),
+        "migration source and target must have the same Owner"
+    );
+    const _DISC_NEQ: () = {
+        let src = <From as crate::traits::Discriminator>::DISCRIMINATOR;
+        let tgt = <To as crate::traits::Discriminator>::DISCRIMINATOR;
+        // Check that neither discriminator is a prefix of the other.
+        let min_len = if src.len() < tgt.len() {
+            src.len()
+        } else {
+            tgt.len()
+        };
+        let mut i = 0;
+        let mut prefix_match = true;
+        while i < min_len {
+            if src[i] != tgt[i] {
+                prefix_match = false;
+            }
+            i += 1;
+        }
+        assert!(
+            !prefix_match,
+            "migration source and target discriminators must not be prefixes of each other"
+        );
+    };
+    const _STACK_BUDGET: () = assert!(
+        core::mem::size_of::<To::Target>() < 3584,
+        "migration target type too large for sBPF 4KB stack frame"
+    );
+
+    /// Perform migration. Safe to call multiple times (idempotent after first).
+    ///
+    /// On first call: reads source via zero-copy pointer cast, calls
+    /// `Migrate::migrate()`, reallocs, writes target disc + data.
+    /// On subsequent calls: detects target discriminator already present,
+    /// returns Ok(()) immediately (no-op).
+    ///
+    /// After this method returns, `source()` returns `None` — the buffer
+    /// now contains target data.
+    #[inline(always)]
+    pub fn finish(
+        &mut self,
+        payer: &AccountView,
+        rent: &crate::sysvars::rent::Rent,
+    ) -> Result<(), ProgramError> {
+        // Force compile-time assertion evaluation.
+        #[allow(clippy::let_unit_value)]
+        {
+            let _ = Self::_OWNER_EQ;
+            let _ = Self::_DISC_NEQ;
+            let _ = Self::_STACK_BUDGET;
+        }
+
+        let view = unsafe { &mut *(&mut self.__view as *mut AccountView) };
+
+        // Guard: if target discriminator already present, migration already done.
+        let data = unsafe { view.borrow_unchecked() };
+        if data.starts_with(<To as crate::traits::Discriminator>::DISCRIMINATOR) {
+            return Ok(());
+        }
+        // Verify source discriminator is still present (not some third state).
+        if !data.starts_with(<From as crate::traits::Discriminator>::DISCRIMINATOR) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        // 1. Zero-copy read: pointer cast into account data buffer.
+        let source_ref: &From::Target = unsafe {
+            &*(view
+                .data_ptr()
+                .add(<From as crate::traits::Discriminator>::DISCRIMINATOR.len())
+                as *const From::Target)
+        };
+
+        // 2. Call user's migration logic (produces target on stack).
+        let target: To::Target =
+            <From::Target as crate::traits::Migrate<To::Target>>::migrate(source_ref);
+
+        // 3. Realloc (handles both grow and shrink lamport adjustments).
+        super::realloc_account(view, <To as crate::traits::Space>::SPACE, payer, Some(rent))?;
+
+        // 4. Write target discriminator + data.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                <To as crate::traits::Discriminator>::DISCRIMINATOR.as_ptr(),
+                view.data_mut_ptr(),
+                <To as crate::traits::Discriminator>::DISCRIMINATOR.len(),
+            );
+            core::ptr::copy_nonoverlapping(
+                &target as *const To::Target as *const u8,
+                view.data_mut_ptr()
+                    .add(<To as crate::traits::Discriminator>::DISCRIMINATOR.len()),
+                core::mem::size_of::<To::Target>(),
+            );
+        }
+        Ok(())
+    }
+}

--- a/lang/src/accounts/mod.rs
+++ b/lang/src/accounts/mod.rs
@@ -21,3 +21,5 @@ pub mod interface;
 pub use interface::*;
 pub mod interface_account;
 pub use interface_account::*;
+pub mod migration;
+pub use migration::*;

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -21,6 +21,7 @@ impl<T: crate::traits::Id> crate::traits::Id for Program<T> {
 impl<T: crate::traits::Id> crate::account_load::AccountLoad for Program<T> {
     const IS_EXECUTABLE: bool = true;
 
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -11,6 +11,7 @@ define_account!(
 impl crate::account_load::AccountLoad for Signer {
     const IS_SIGNER: bool = true;
 
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -13,6 +13,7 @@ impl Owner for SystemAccount {
 }
 
 impl crate::account_load::AccountLoad for SystemAccount {
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/accounts/sysvar.rs
+++ b/lang/src/accounts/sysvar.rs
@@ -22,6 +22,7 @@ impl<T: crate::sysvars::Sysvar> Sysvar<T> {
 }
 
 impl<T: crate::sysvars::Sysvar> crate::account_load::AccountLoad for Sysvar<T> {
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/accounts/unchecked.rs
+++ b/lang/src/accounts/unchecked.rs
@@ -10,6 +10,7 @@ define_account!(
 );
 
 impl crate::account_load::AccountLoad for UncheckedAccount {
+    type BehaviorTarget = Self;
     type Params = ();
 
     #[inline(always)]

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -86,6 +86,13 @@ impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + Account
     pub const fn has_validate(&self) -> bool {
         T::HAS_VALIDATE
     }
+
+    /// Compile-time check for whether `T` has lifecycle operations
+    /// (close/sweep/migrate). When false, the epilogue call is elided.
+    #[inline(always)]
+    pub const fn has_epilogue(&self) -> bool {
+        T::HAS_EPILOGUE
+    }
 }
 
 /// Like [`Ctx`] but also captures the remaining accounts region.
@@ -161,6 +168,13 @@ impl<'input, T: ParseAccounts<'input> + ParseAccountsUnchecked<'input> + Account
     #[inline(always)]
     pub const fn has_validate(&self) -> bool {
         T::HAS_VALIDATE
+    }
+
+    /// Compile-time check for whether `T` has lifecycle operations
+    /// (close/sweep/migrate). When false, the epilogue call is elided.
+    #[inline(always)]
+    pub const fn has_epilogue(&self) -> bool {
+        T::HAS_EPILOGUE
     }
 
     /// Strict remaining-account accessor.

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -82,6 +82,114 @@ pub mod __internal {
         + MAX_PERMITTED_DATA_INCREASE
         + core::mem::size_of::<u64>();
 
+    /// Size of a duplicate account entry in the SVM input buffer.
+    pub const DUP_ENTRY_SIZE: usize = core::mem::size_of::<u64>();
+
+    /// Round `n` up to the next multiple of 8.
+    #[inline(always)]
+    pub const fn align_up_8(n: usize) -> usize {
+        (n.wrapping_add(7)) & !7
+    }
+
+    /// Byte stride past a non-duplicate account entry in the SVM input buffer:
+    /// header + data_len, rounded up to 8-byte alignment.
+    #[inline(always)]
+    pub const fn account_stride(data_len: usize) -> usize {
+        align_up_8(ACCOUNT_HEADER.wrapping_add(data_len))
+    }
+
+    // Platform invariant: the SVM uses 64-bit pointers and u64 data_len.
+    // The `data_len as usize` cast in account-walking code is only lossless
+    // on 64-bit targets.
+    const _: () = assert!(
+        core::mem::size_of::<usize>() >= core::mem::size_of::<u64>(),
+        "quasar requires usize >= u64 (SVM pointers are 64-bit)"
+    );
+
+    /// Walk the SVM input buffer and write `AccountView`s into a
+    /// caller-provided stack buffer, without any validation (no signer,
+    /// writable, owner, or discriminator checks). Used by
+    /// `#[instruction(raw)]` dispatch codegen.
+    ///
+    /// Returns the number of accounts actually parsed and a pointer past
+    /// the last account entry.
+    ///
+    /// # Safety
+    ///
+    /// - `input` must point to the first account entry in the SVM input buffer
+    ///   and be 8-byte aligned (guaranteed by the SVM ABI).
+    /// - `buf` must have space for at least `count` `AccountView` values.
+    /// - `count` must not exceed the actual number of account entries between
+    ///   `input` and `boundary` (the SVM's reported `num_accounts`, capped by
+    ///   the caller).
+    /// - `boundary` must point to the end of the accounts region (i.e.
+    ///   `ix_data_ptr - sizeof(u64)`).
+    #[inline(always)]
+    pub unsafe fn parse_all_accounts_unchecked(
+        input: *mut u8,
+        buf: *mut AccountView,
+        count: usize,
+        boundary: *const u8,
+    ) -> Result<(usize, *mut u8), solana_program_error::ProgramError> {
+        // SAFETY: The SVM guarantees 8-byte alignment at buffer start and
+        // after each account entry (padded strides).
+        debug_assert!(
+            input as usize & 7 == 0,
+            "parse_all_accounts_unchecked: input pointer is not 8-byte aligned"
+        );
+
+        let mut ptr = input;
+        for i in 0..count {
+            // SAFETY: Early exit if we have reached the accounts boundary.
+            // The SVM guarantees `count` entries fit, but this check is
+            // defense-in-depth against a malformed buffer.
+            if (ptr as *const u8) >= boundary {
+                return Ok((i, ptr));
+            }
+
+            // SAFETY: `ptr` is within the accounts region (checked above)
+            // and points to a valid `RuntimeAccount` header. The
+            // `borrow_state` field is at offset 0 of the `#[repr(C)]`
+            // struct.
+            let raw = ptr as *mut RuntimeAccount;
+            let borrow = (*raw).borrow_state;
+
+            if borrow == NOT_BORROWED {
+                // SAFETY: Non-duplicate entry. `raw` is a valid
+                // `RuntimeAccount` pointer. `AccountView::new_unchecked`
+                // wraps it without copying.
+                core::ptr::write(buf.add(i), AccountView::new_unchecked(raw));
+                // SAFETY: `account_stride` computes header + data_len
+                // rounded to 8-byte alignment, matching the SVM's
+                // serialization layout.
+                ptr = ptr.add(account_stride((*raw).data_len as usize));
+            } else {
+                // SAFETY: Duplicate entry. `borrow_state` encodes the
+                // index of the original (non-dup) account. The SVM
+                // guarantees dup indices always point backward to a
+                // previously-serialized non-dup entry.
+                let orig_idx = borrow as usize;
+                if orig_idx < i {
+                    // SAFETY: `orig_idx < i` ensures the source slot is
+                    // already initialized. `AccountView` does not impl
+                    // `Drop` (verified by static assert in remaining.rs),
+                    // so bitwise copy is safe. Note: the copy creates an
+                    // aliased `AccountView` — both point to the same
+                    // `RuntimeAccount`. The raw handler is responsible for
+                    // avoiding simultaneous `borrow_unchecked_mut()` on
+                    // aliased views.
+                    core::ptr::write(buf.add(i), core::ptr::read(buf.add(orig_idx)));
+                } else {
+                    return Err(solana_program_error::ProgramError::InvalidAccountData);
+                }
+                // SAFETY: Dup entries are exactly `DUP_ENTRY_SIZE` (8)
+                // bytes in the SVM buffer.
+                ptr = ptr.add(DUP_ENTRY_SIZE);
+            }
+        }
+        Ok((count, ptr))
+    }
+
     /// Packed flags for [`parse_account_dup`]. Keeps the param count under the
     /// sBPF 5-register limit to avoid stack spills.
     #[derive(Clone, Copy)]
@@ -313,6 +421,24 @@ pub fn keys_eq(a: &solana_address::Address, b: &solana_address::Address) -> bool
             && core::ptr::read_unaligned(a.add(2)) == core::ptr::read_unaligned(b.add(2))
             && core::ptr::read_unaligned(a.add(3)) == core::ptr::read_unaligned(b.add(3))
     }
+}
+
+/// Const-compatible 32-byte address comparison for use in compile-time
+/// assertions (e.g. `one_of` owner checks, migration owner equality).
+/// Not intended for runtime use — prefer [`keys_eq`] which is branchless
+/// and optimized for sBPF.
+#[inline(always)]
+pub const fn keys_eq_const(a: &solana_address::Address, b: &solana_address::Address) -> bool {
+    let a = a.as_array();
+    let b = b.as_array();
+    let mut i = 0;
+    while i < 32 {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
 }
 
 /// Check if an address is all zeros (the System program address).

--- a/lang/src/prelude.rs
+++ b/lang/src/prelude.rs
@@ -5,6 +5,8 @@
 
 pub use {
     crate::{
+        account_exit::{AccountExit, CloseCtx, SweepCtx},
+        account_init::{AccountInit, InitCtx},
         account_load::AccountLoad,
         accounts::*,
         checks,
@@ -26,7 +28,8 @@ pub use {
         sysvars::{clock::Clock, rent::Rent},
         traits::{
             AccountCheck, AccountCount, AsAccountView, CheckOwner, Discriminator, Event, HasSeeds,
-            Id, Owner, Owners, ParseAccounts, ProgramInterface, Space, StaticView, ZeroCopyDeref,
+            Id, Migrate, Owner, Owners, ParseAccounts, ProgramInterface, Space, StaticView,
+            ZeroCopyDeref,
         },
         String, Vec, ZcElem, ZcField, ZcValidate, ZeroPodError,
     },

--- a/lang/src/remaining.rs
+++ b/lang/src/remaining.rs
@@ -1,6 +1,6 @@
 use {
     crate::error::QuasarError,
-    solana_account_view::{AccountView, RuntimeAccount, MAX_PERMITTED_DATA_INCREASE, NOT_BORROWED},
+    solana_account_view::{AccountView, RuntimeAccount, NOT_BORROWED},
     solana_program_error::ProgramError,
 };
 
@@ -20,14 +20,11 @@ const _: () = assert!(
     "AccountView must not implement Drop — ptr::read copies rely on this"
 );
 
-/// Size of a non-duplicate account entry in the SVM input buffer:
-/// `RuntimeAccount` header + 10 KiB realloc region + u64 padding.
-const ACCOUNT_HEADER: usize = core::mem::size_of::<RuntimeAccount>()
-    + MAX_PERMITTED_DATA_INCREASE
-    + core::mem::size_of::<u64>();
-
-/// Size of a duplicate account entry in the SVM input buffer.
-const DUP_ENTRY_SIZE: usize = core::mem::size_of::<u64>();
+// Re-use canonical constants from __internal to avoid duplication.
+// ACCOUNT_HEADER is only referenced by Kani proof harnesses in this module.
+#[cfg(kani)]
+use crate::__internal::ACCOUNT_HEADER;
+use crate::__internal::DUP_ENTRY_SIZE;
 
 /// Maximum number of remaining accounts the iterator will yield
 /// before returning an error. Prevents unbounded stack usage in
@@ -38,19 +35,11 @@ const MAX_REMAINING_ACCOUNTS: usize = 64;
 // Pure arithmetic helpers (extracted for Kani verification)
 // ---------------------------------------------------------------------------
 
-/// Round `n` up to the next multiple of 8. Returns `n` unchanged if already
-/// aligned.
-#[inline(always)]
-const fn align_up_8(n: usize) -> usize {
-    (n.wrapping_add(7)) & !7
-}
-
-/// Compute the byte stride past a non-duplicate account entry in the SVM
-/// input buffer: header + data_len, rounded up to 8-byte alignment.
-#[inline(always)]
-const fn account_stride(data_len: usize) -> usize {
-    align_up_8(ACCOUNT_HEADER.wrapping_add(data_len))
-}
+// Re-use canonical arithmetic helper from __internal.
+use crate::__internal::account_stride;
+// align_up_8 is only referenced by Kani proof harnesses in this module.
+#[cfg(kani)]
+use crate::__internal::align_up_8;
 
 /// Target source for duplicate account resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -157,6 +157,11 @@ pub trait ParseAccounts<'input>: Sized {
     /// custom validation exists, avoiding a dead branch on sBPF.
     const HAS_VALIDATE: bool = false;
 
+    /// Set to `true` when the struct has lifecycle operations (close, sweep,
+    /// migrate). The dispatch path uses this to skip the `epilogue()` call
+    /// entirely when no lifecycle ops exist, avoiding a dead branch on sBPF.
+    const HAS_EPILOGUE: bool = false;
+
     /// User-defined validation hook called after all field-level checks pass
     /// but before the instruction handler executes.
     ///
@@ -319,6 +324,34 @@ pub trait Event {
     const DATA_SIZE: usize;
     fn write_data(&self, buf: &mut [u8]);
     fn emit(&self, f: impl FnOnce(&[u8]) -> Result<(), ProgramError>) -> Result<(), ProgramError>;
+}
+
+/// Declarative account migration.
+///
+/// Implement this trait on the source account's `Data` type, parameterized by
+/// the target account's `Data` type.  The `#[account]` macro generates a
+/// `{Name}Data` alias for every account — a `#[repr(C)]` struct with the
+/// account's field layout.
+///
+/// The framework calls `migrate()` during the epilogue, then reallocs the
+/// account and writes the returned target data along with the new
+/// discriminator.
+///
+/// # Example
+///
+/// ```ignore
+/// impl Migrate<ConfigV2Data> for ConfigV1Data {
+///     fn migrate(&self) -> ConfigV2Data {
+///         ConfigV2Data {
+///             authority: self.authority,
+///             fee_bps: self.fee_bps,
+///             new_field: PodU32::from(0),
+///         }
+///     }
+/// }
+/// ```
+pub trait Migrate<To> {
+    fn migrate(&self) -> To;
 }
 
 /// Verify that the actual account count matches the expected count.

--- a/lang/tests/compile_fail/instruction_borrowed_no_max.stderr
+++ b/lang/tests/compile_fail/instruction_borrowed_no_max.stderr
@@ -3,3 +3,9 @@ error: borrowed instruction args require #[max(N)] annotation
    |
 16 |     pub fn bad_handler(ctx: Ctx<Args>, label: &str) -> Result<(), ProgramError> {
    |                                               ^^^^
+
+error[E0425]: cannot find function `bad_handler` in this scope
+  --> tests/compile_fail/instruction_borrowed_no_max.rs:16:12
+   |
+16 |     pub fn bad_handler(ctx: Ctx<Args>, label: &str) -> Result<(), ProgramError> {
+   |            ^^^^^^^^^^^ not found in this scope

--- a/lang/tests/compile_fail/instruction_dynamic_not_suffix.stderr
+++ b/lang/tests/compile_fail/instruction_dynamic_not_suffix.stderr
@@ -3,3 +3,9 @@ error: fixed instruction args must precede all dynamic or borrowed args
    |
 20 |         flag: u8,
    |         ^^^^^^^^
+
+error[E0425]: cannot find function `update` in this scope
+  --> tests/compile_fail/instruction_dynamic_not_suffix.rs:16:12
+   |
+16 |     pub fn update(
+   |            ^^^^^^ not found in this scope

--- a/lang/tests/compile_fail/instruction_raw_extra_args.rs
+++ b/lang/tests/compile_fail/instruction_raw_extra_args.rs
@@ -1,0 +1,16 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[program]
+pub mod test_raw_extra {
+    use super::*;
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn bad_handler(ctx: Context, value: u64) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/instruction_raw_extra_args.stderr
+++ b/lang/tests/compile_fail/instruction_raw_extra_args.stderr
@@ -1,0 +1,11 @@
+error: #[instruction(raw)] handler must have exactly one parameter: Context
+  --> tests/compile_fail/instruction_raw_extra_args.rs:11:9
+   |
+11 |     pub fn bad_handler(ctx: Context, value: u64) -> Result<(), ProgramError> {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0425]: cannot find value `bad_handler` in this scope
+  --> tests/compile_fail/instruction_raw_extra_args.rs:11:12
+   |
+11 |     pub fn bad_handler(ctx: Context, value: u64) -> Result<(), ProgramError> {
+   |            ^^^^^^^^^^^ not found in this scope

--- a/lang/tests/compile_fail/instruction_raw_pre_hook.rs
+++ b/lang/tests/compile_fail/instruction_raw_pre_hook.rs
@@ -1,0 +1,16 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[program]
+pub mod test_raw_hook {
+    use super::*;
+
+    #[instruction(discriminator = 1, raw, pre_hook = [my_hook])]
+    pub fn bad_handler(ctx: Context) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/instruction_raw_pre_hook.stderr
+++ b/lang/tests/compile_fail/instruction_raw_pre_hook.stderr
@@ -1,0 +1,5 @@
+error: pre_hook and post_hook have been removed. Use `#[accounts(validate)]` for pre-handler validation, or move logic into the handler body.
+  --> tests/compile_fail/instruction_raw_pre_hook.rs:10:43
+   |
+10 |     #[instruction(discriminator = 1, raw, pre_hook = [my_hook])]
+   |                                           ^^^^^^^^

--- a/lang/tests/compile_fail/instruction_raw_wrong_param.rs
+++ b/lang/tests/compile_fail/instruction_raw_wrong_param.rs
@@ -1,0 +1,21 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct Args {
+    pub signer: Signer,
+}
+
+#[program]
+pub mod test_raw_wrong {
+    use super::*;
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn bad_handler(ctx: Ctx<Args>) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/instruction_raw_wrong_param.stderr
+++ b/lang/tests/compile_fail/instruction_raw_wrong_param.stderr
@@ -1,0 +1,11 @@
+error: #[instruction(raw)] parameter must be of type Context
+  --> tests/compile_fail/instruction_raw_wrong_param.rs:16:29
+   |
+16 |     pub fn bad_handler(ctx: Ctx<Args>) -> Result<(), ProgramError> {
+   |                             ^^^^^^^^^
+
+error[E0425]: cannot find value `bad_handler` in this scope
+  --> tests/compile_fail/instruction_raw_wrong_param.rs:16:12
+   |
+16 |     pub fn bad_handler(ctx: Ctx<Args>) -> Result<(), ProgramError> {
+   |            ^^^^^^^^^^^ not found in this scope

--- a/lang/tests/compile_fail/migrate_on_signer.rs
+++ b/lang/tests/compile_fail/migrate_on_signer.rs
@@ -1,0 +1,22 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub value: PodU64,
+}
+
+// ERROR: #[account(migrate = X)] is deprecated
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(migrate = ConfigV2, payer = payer)]
+    pub target: Signer,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/migrate_on_signer.stderr
+++ b/lang/tests/compile_fail/migrate_on_signer.stderr
@@ -1,0 +1,11 @@
+error: #[account(migrate = X)] is deprecated. Use the `Migration<From, To>` field type instead:
+
+         Before: #[account(migrate = ConfigV2, payer = payer)]
+         pub config: Account<ConfigV1>,
+
+         After:  #[account(payer = payer)]
+         pub config: Migration<ConfigV1, ConfigV2>,
+  --> tests/compile_fail/migrate_on_signer.rs:18:15
+   |
+18 |     #[account(migrate = ConfigV2, payer = payer)]
+   |               ^^^^^^^

--- a/lang/tests/compile_fail/migrate_with_close.rs
+++ b/lang/tests/compile_fail/migrate_with_close.rs
@@ -1,0 +1,29 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+pub struct ConfigV1 {
+    pub value: PodU64,
+}
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub value: PodU64,
+    pub extra: PodU32,
+}
+
+// ERROR: Migration cannot be combined with close
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+    pub destination: SystemAccount,
+
+    #[account(close = destination, payer = payer)]
+    pub config: Migration<ConfigV1, ConfigV2>,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/migrate_with_close.stderr
+++ b/lang/tests/compile_fail/migrate_with_close.stderr
@@ -1,0 +1,6 @@
+error: Migration<From, To> cannot be combined with close
+  --> tests/compile_fail/migrate_with_close.rs:25:5
+   |
+25 | /     #[account(close = destination, payer = payer)]
+26 | |     pub config: Migration<ConfigV1, ConfigV2>,
+   | |_____________________________________________^

--- a/lang/tests/compile_fail/migrate_with_init.rs
+++ b/lang/tests/compile_fail/migrate_with_init.rs
@@ -1,0 +1,28 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+pub struct ConfigV1 {
+    pub value: PodU64,
+}
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub value: PodU64,
+    pub extra: PodU32,
+}
+
+// ERROR: Migration cannot be combined with init
+#[derive(Accounts)]
+pub struct Bad {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(init, payer = payer)]
+    pub config: Migration<ConfigV1, ConfigV2>,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/migrate_with_init.stderr
+++ b/lang/tests/compile_fail/migrate_with_init.stderr
@@ -1,0 +1,6 @@
+error: Migration<From, To> cannot be combined with init
+  --> tests/compile_fail/migrate_with_init.rs:24:5
+   |
+24 | /     #[account(init, payer = payer)]
+25 | |     pub config: Migration<ConfigV1, ConfigV2>,
+   | |_____________________________________________^

--- a/lang/tests/compile_fail/migrate_without_payer.rs
+++ b/lang/tests/compile_fail/migrate_without_payer.rs
@@ -1,0 +1,25 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+pub struct ConfigV1 {
+    pub value: PodU64,
+}
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub value: PodU64,
+    pub extra: PodU32,
+}
+
+// ERROR: Migration<From, To> requires a payer
+#[derive(Accounts)]
+pub struct Bad {
+    pub signer: Signer,
+
+    pub config: Migration<ConfigV1, ConfigV2>,
+}
+
+fn main() {}

--- a/lang/tests/compile_fail/migrate_without_payer.stderr
+++ b/lang/tests/compile_fail/migrate_without_payer.stderr
@@ -1,0 +1,5 @@
+error: Migration<From, To> requires a payer. Add a `payer` field or specify `payer = <field>` on the field.
+  --> tests/compile_fail/migrate_without_payer.rs:22:5
+   |
+22 |     pub config: Migration<ConfigV1, ConfigV2>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lang/tests/compile_fail/pod_string_invalid_pfx.stderr
+++ b/lang/tests/compile_fail/pod_string_invalid_pfx.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation panicked: PodString<N, PFX>: PFX must be 1, 2, 4, or 8
- --> $RUST/core/src/panic.rs
-  |
-  = note: evaluation of `quasar_lang::String::<10, 3>::_CAP_CHECK` failed here
-  |
- ::: $CARGO/zeropod-$VERSION/src/pod/string.rs
+ --> $CARGO/zeropod-$VERSION/src/pod/string.rs
   |
   | /         assert!(
   | |             PFX == 1 || PFX == 2 || PFX == 4 || PFX == 8,
   | |             "PodString<N, PFX>: PFX must be 1, 2, 4, or 8"
   | |         );
-  | |_________- in this macro invocation
+  | |_________^ evaluation of `quasar_lang::String::<10, 3>::_CAP_CHECK` failed here
 
 note: erroneous constant encountered
  --> $CARGO/zeropod-$VERSION/src/pod/string.rs

--- a/lang/tests/compile_fail/pod_string_n_exceeds_pfx.stderr
+++ b/lang/tests/compile_fail/pod_string_n_exceeds_pfx.stderr
@@ -1,16 +1,12 @@
 error[E0080]: evaluation panicked: PodString<N, PFX>: N exceeds the maximum value representable by the PFX-byte length prefix
- --> $RUST/core/src/panic.rs
-  |
-  = note: evaluation of `quasar_lang::String::<256>::_CAP_CHECK` failed here
-  |
- ::: $CARGO/zeropod-$VERSION/src/pod/string.rs
+ --> $CARGO/zeropod-$VERSION/src/pod/string.rs
   |
   | /         assert!(
   | |             N <= max_n_for_pfx(PFX),
   | |             "PodString<N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
   | |              prefix"
   | |         );
-  | |_________- in this macro invocation
+  | |_________^ evaluation of `quasar_lang::String::<256>::_CAP_CHECK` failed here
 
 note: erroneous constant encountered
  --> $CARGO/zeropod-$VERSION/src/pod/string.rs

--- a/lang/tests/compile_fail/pod_vec_n_exceeds_pfx.stderr
+++ b/lang/tests/compile_fail/pod_vec_n_exceeds_pfx.stderr
@@ -1,16 +1,12 @@
 error[E0080]: evaluation panicked: PodVec<T, N, PFX>: N exceeds the maximum value representable by the PFX-byte length prefix
- --> $RUST/core/src/panic.rs
-  |
-  = note: evaluation of `quasar_lang::Vec::<u8, 300, 1>::_CAP_CHECK` failed here
-  |
- ::: $CARGO/zeropod-$VERSION/src/pod/vec.rs
+ --> $CARGO/zeropod-$VERSION/src/pod/vec.rs
   |
   | /         assert!(
   | |             N <= max_n_for_pfx(PFX),
   | |             "PodVec<T, N, PFX>: N exceeds the maximum value representable by the PFX-byte length \
   | |              prefix"
   | |         );
-  | |_________- in this macro invocation
+  | |_________^ evaluation of `quasar_lang::Vec::<u8, 300, 1>::_CAP_CHECK` failed here
 
 note: erroneous constant encountered
  --> $CARGO/zeropod-$VERSION/src/pod/vec.rs

--- a/lang/tests/compile_pass/account_custom.rs
+++ b/lang/tests/compile_pass/account_custom.rs
@@ -1,0 +1,77 @@
+#![allow(unexpected_cfgs)]
+//! Proves that `#[account(custom)]` works in two modes:
+//!
+//! 1. **Unit struct** — transparent AccountView wrapper, user provides check().
+//!    Use case: accept any account, verify later (ResolvedSigner).
+//!
+//! 2. **Struct with fields** — full zero-copy typed access, user provides check()
+//!    instead of framework owner/discriminator checks.
+//!    Use case: typed data with custom validation logic.
+//!
+//! For full manual control, users can implement `#[repr(transparent)]` +
+//! `AsAccountView` + `AccountLoad` directly without `#[account(custom)]`.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// ── Mode 1: unit struct (no data, just a wrapper) ──
+
+#[account(custom)]
+pub struct ResolvedSigner;
+
+impl ResolvedSigner {
+    pub fn check(
+        _view: &AccountView,
+        _field_name: &str,
+    ) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+// ── Mode 2: struct with fields (typed zero-copy access) ──
+
+#[account(custom)]
+pub struct OraclePrice {
+    pub price: u64,
+    pub confidence: u64,
+    pub slot: u64,
+}
+
+impl OraclePrice {
+    pub fn check(
+        view: &AccountView,
+        _field_name: &str,
+    ) -> Result<(), ProgramError> {
+        // Custom validation — check data length, skip owner/disc
+        let data = unsafe { view.borrow_unchecked() };
+        if data.len() < core::mem::size_of::<u64>() * 3 {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        Ok(())
+    }
+}
+
+// ── Use both in derive ──
+
+#[derive(Accounts)]
+pub struct ReadOracle {
+    pub signer: ResolvedSigner,
+    pub oracle: OraclePrice, // custom type used directly, not Account<OraclePrice>
+}
+
+#[program]
+pub mod test_custom_account {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn read_oracle(ctx: Ctx<ReadOracle>) -> Result<(), ProgramError> {
+        let _ = ctx.accounts.signer.to_account_view();
+        // Typed access to oracle fields via zero-copy deref:
+        let _price = ctx.accounts.oracle.price;
+        let _conf = ctx.accounts.oracle.confidence;
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/account_migrate.rs
+++ b/lang/tests/compile_pass/account_migrate.rs
@@ -1,0 +1,218 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// ---------------------------------------------------------------------------
+// V1: original layout (41 bytes: 1 disc + 32 addr + 8 u64)
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 1)]
+pub struct ConfigV1 {
+    pub authority: Address,
+    pub value: PodU64,
+}
+
+// ---------------------------------------------------------------------------
+// V2: larger (45 bytes: 1 disc + 32 addr + 8 u64 + 4 u32)
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub authority: Address,
+    pub value: PodU64,
+    pub new_field: PodU32,
+}
+
+impl Migrate<ConfigV2Data> for ConfigV1Data {
+    fn migrate(&self) -> ConfigV2Data {
+        ConfigV2Data {
+            authority: self.authority,
+            value: self.value,
+            new_field: PodU32::from(0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// V2slim: same size as V1 (41 bytes: 1 disc + 32 addr + 8 u64)
+// Different disc, same layout — pure disc swap migration.
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 3)]
+pub struct ConfigV2Slim {
+    pub authority: Address,
+    pub value: PodU64,
+}
+
+impl Migrate<ConfigV2SlimData> for ConfigV1Data {
+    fn migrate(&self) -> ConfigV2SlimData {
+        ConfigV2SlimData {
+            authority: self.authority,
+            value: self.value,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// V1Big: larger than V2Slim (shrink migration)
+// 45 bytes: 1 disc + 32 addr + 8 u64 + 4 u32
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 4)]
+pub struct ConfigV1Big {
+    pub authority: Address,
+    pub value: PodU64,
+    pub obsolete: PodU32,
+}
+
+impl Migrate<ConfigV2SlimData> for ConfigV1BigData {
+    fn migrate(&self) -> ConfigV2SlimData {
+        ConfigV2SlimData {
+            authority: self.authority,
+            value: self.value,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PDA account with seeds + bump
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 10)]
+#[seeds(b"vault", authority: Address)]
+pub struct VaultV1 {
+    pub authority: Address,
+    pub balance: PodU64,
+    pub bump: u8,
+}
+
+#[account(discriminator = 11)]
+pub struct VaultV2 {
+    pub authority: Address,
+    pub balance: PodU64,
+    pub fee_bps: PodU16,
+    pub bump: u8,
+}
+
+impl Migrate<VaultV2Data> for VaultV1Data {
+    fn migrate(&self) -> VaultV2Data {
+        VaultV2Data {
+            authority: self.authority,
+            balance: self.balance,
+            fee_bps: PodU16::from(30),
+            bump: self.bump,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Accounts structs — using Migration<From, To> field type
+// ---------------------------------------------------------------------------
+
+/// Basic grow migration (V1 → V2)
+#[derive(Accounts)]
+pub struct MigrateGrow {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(payer = payer, has_one = authority)]
+    pub config: Migration<ConfigV1, ConfigV2>,
+
+    /// CHECK: authority
+    pub authority: Signer,
+}
+
+/// Same-size migration (V1 → V2Slim, disc swap only)
+#[derive(Accounts)]
+pub struct MigrateSameSize {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(payer = payer)]
+    pub config: Migration<ConfigV1, ConfigV2Slim>,
+}
+
+/// Shrink migration (V1Big → V2Slim, target smaller)
+#[derive(Accounts)]
+pub struct MigrateShrink {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(payer = payer)]
+    pub config: Migration<ConfigV1Big, ConfigV2Slim>,
+}
+
+/// PDA migration with seeds + bump
+#[derive(Accounts)]
+pub struct MigrateVault {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(
+        payer = payer,
+        has_one = authority,
+        seeds = VaultV1::seeds(authority),
+        bump,
+    )]
+    pub vault: Migration<VaultV1, VaultV2>,
+
+    /// CHECK: authority
+    pub authority: Signer,
+}
+
+/// Non-default payer name (payer = funder, not payer = payer)
+#[derive(Accounts)]
+pub struct MigrateWithFunder {
+    #[account(mut)]
+    pub funder: Signer,
+    pub system_program: Program<System>,
+
+    #[account(payer = funder)]
+    pub config: Migration<ConfigV1, ConfigV2>,
+}
+
+// ---------------------------------------------------------------------------
+// Program
+// ---------------------------------------------------------------------------
+
+#[program]
+pub mod test_migrate {
+    use super::*;
+
+    #[instruction(discriminator = 1)]
+    pub fn migrate_grow(ctx: Ctx<MigrateGrow>) -> Result<(), ProgramError> {
+        let _val: u64 = ctx.accounts.config.source().unwrap().value.into();
+        Ok(())
+    }
+
+    #[instruction(discriminator = 2)]
+    pub fn migrate_same_size(ctx: Ctx<MigrateSameSize>) -> Result<(), ProgramError> {
+        let _val: u64 = ctx.accounts.config.source().unwrap().value.into();
+        Ok(())
+    }
+
+    #[instruction(discriminator = 3)]
+    pub fn migrate_shrink(ctx: Ctx<MigrateShrink>) -> Result<(), ProgramError> {
+        let _val: u64 = ctx.accounts.config.source().unwrap().value.into();
+        Ok(())
+    }
+
+    #[instruction(discriminator = 4)]
+    pub fn migrate_vault(ctx: Ctx<MigrateVault>) -> Result<(), ProgramError> {
+        let _val: u64 = ctx.accounts.vault.source().unwrap().balance.into();
+        Ok(())
+    }
+
+    #[instruction(discriminator = 5)]
+    pub fn migrate_with_funder(ctx: Ctx<MigrateWithFunder>) -> Result<(), ProgramError> {
+        let _val: u64 = ctx.accounts.config.source().unwrap().value.into();
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/account_one_of.rs
+++ b/lang/tests/compile_pass/account_one_of.rs
@@ -1,0 +1,66 @@
+#![allow(unexpected_cfgs)]
+//! Proves that `#[account(one_of)]` compiles on enum declarations,
+//! generates the ref enum, variant(), is_X(), and typed accessors.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// ── Account types (shared owner, different discriminators) ──
+
+#[account(discriminator = 1)]
+pub struct Settings {
+    pub authority: Address,
+    pub fee_bps: PodU16,
+}
+
+#[account(discriminator = 2)]
+pub struct Policy {
+    pub authority: Address,
+    pub max_amount: PodU64,
+}
+
+// ── one_of enum ──
+
+#[account(one_of)]
+pub enum ConsensusAccount {
+    Settings(Settings),
+    Policy(Policy),
+}
+
+// ── Accounts struct using one_of ──
+
+#[derive(Accounts)]
+pub struct ReadConsensus {
+    pub signer: Signer,
+
+    pub consensus: Account<ConsensusAccount>,
+}
+
+// ── Program ──
+
+#[program]
+pub mod test_one_of {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn read_consensus(ctx: Ctx<ReadConsensus>) -> Result<(), ProgramError> {
+        match ctx.accounts.consensus.variant() {
+            ConsensusAccountRef::Settings(s) => {
+                let _fee: u16 = s.fee_bps.into();
+            }
+            ConsensusAccountRef::Policy(p) => {
+                let _max: u64 = p.max_amount.into();
+            }
+        }
+
+        // Typed accessors
+        if ctx.accounts.consensus.is_settings() {
+            let _s = ctx.accounts.consensus.settings().unwrap();
+        }
+
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/init_if_needed_param.rs
+++ b/lang/tests/compile_pass/init_if_needed_param.rs
@@ -1,0 +1,65 @@
+#![allow(unexpected_cfgs)]
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[repr(transparent)]
+pub struct ParamAccount {
+    view: AccountView,
+}
+
+impl AsAccountView for ParamAccount {
+    fn to_account_view(&self) -> &AccountView {
+        &self.view
+    }
+}
+
+#[derive(Default)]
+pub struct ParamAccountParams {
+    pub expected_owner: Option<Address>,
+}
+
+impl AccountLoad for ParamAccount {
+    type BehaviorTarget = Self;
+    type Params = ParamAccountParams;
+
+    fn check(_view: &AccountView, _field_name: &str) -> Result<(), ProgramError> {
+        Ok(())
+    }
+
+    fn validate(&self, params: &Self::Params) -> Result<(), ProgramError> {
+        if let Some(expected_owner) = &params.expected_owner {
+            if !quasar_lang::keys_eq(self.to_account_view().owner(), expected_owner) {
+                return Err(ProgramError::IllegalOwner);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AccountInit for ParamAccount {
+    type InitParams<'a> = ();
+
+    fn init<'a>(_ctx: InitCtx<'a>, _params: &()) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct InitIfNeededParam {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(
+        mut,
+        init_if_needed,
+        payer = payer,
+        space = 0,
+        param::expected_owner = Some(*expected_owner.address())
+    )]
+    pub target: ParamAccount,
+    pub expected_owner: UncheckedAccount,
+    pub system_program: Program<System>,
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/instruction_pre_hook.rs
+++ b/lang/tests/compile_pass/instruction_pre_hook.rs
@@ -1,0 +1,54 @@
+#![allow(unexpected_cfgs)]
+//! Proves that inherent `validate()` methods on Accounts structs are
+//! called automatically before the instruction handler.
+//!
+//! No attribute is needed — the instruction macro always calls
+//! `ctx.accounts.validate()`, and inherent methods shadow the trait default.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+// ── Account types ──
+
+/// Struct with custom validation. Just write an inherent validate() method.
+#[derive(Accounts)]
+pub struct Guarded {
+    pub signer: Signer,
+}
+
+impl Guarded {
+    pub fn validate(&self) -> Result<(), ProgramError> {
+        // Custom pre-handler validation: e.g. check-not-paused, authority, etc.
+        Ok(())
+    }
+}
+
+/// Struct without validation — trait default (no-op) runs, LLVM elides it.
+#[derive(Accounts)]
+pub struct Unguarded {
+    pub signer: Signer,
+}
+
+// ── Program ──
+
+#[program]
+pub mod test_validate {
+    use super::*;
+
+    // With validate
+    #[instruction(discriminator = 0)]
+    pub fn guarded_action(ctx: Ctx<Guarded>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    // Without validate — unaffected
+    #[instruction(discriminator = 1)]
+    pub fn open_action(ctx: Ctx<Unguarded>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/instruction_raw.rs
+++ b/lang/tests/compile_pass/instruction_raw.rs
@@ -1,0 +1,34 @@
+#![allow(unexpected_cfgs)]
+//! Proves that `#[instruction(raw)]` compiles: a program with both normal
+//! and raw instructions coexisting in the same module.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct Initialize {
+    pub signer: Signer,
+}
+
+#[program]
+pub mod test_raw {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn initialize(ctx: Ctx<Initialize>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn update_oracle(ctx: Context) -> Result<(), ProgramError> {
+        if ctx.accounts.is_empty() {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        let _ = ctx.data;
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/instruction_raw_asm.rs
+++ b/lang/tests/compile_pass/instruction_raw_asm.rs
@@ -1,0 +1,45 @@
+#![allow(unexpected_cfgs)]
+//! Proves that inline assembly is valid inside a `#[instruction(raw)]` handler.
+//! The raw handler is a plain function — no macro wrapping prevents `asm!()`.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct Normal {
+    pub signer: Signer,
+}
+
+#[program]
+pub mod test_raw_asm {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn setup(ctx: Ctx<Normal>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn fast_update(ctx: Context) -> Result<(), ProgramError> {
+        if ctx.accounts.is_empty() {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        // Inline asm — works because raw emits the function unchanged.
+        // Use a target-appropriate nop for the compile-pass test.
+        unsafe {
+            #[cfg(target_arch = "x86_64")]
+            core::arch::asm!("nop");
+            #[cfg(target_arch = "aarch64")]
+            core::arch::asm!("nop");
+            // On SBF, you would write sBPF instructions here:
+            // core::arch::asm!("mov64 r0, 0");
+        }
+
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/instruction_raw_heap.rs
+++ b/lang/tests/compile_pass/instruction_raw_heap.rs
@@ -1,0 +1,31 @@
+#![allow(unexpected_cfgs)]
+//! Proves that `#[instruction(raw, heap)]` compiles and composes with
+//! a normal non-heap instruction in the same program.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct Simple {
+    pub signer: Signer,
+}
+
+#[program]
+pub mod test_raw_heap {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn normal(ctx: Ctx<Simple>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 1, raw, heap)]
+    pub fn batch_update(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.accounts.len();
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/program_no_entrypoint.rs
+++ b/lang/tests/compile_pass/program_no_entrypoint.rs
@@ -1,0 +1,39 @@
+#![allow(unexpected_cfgs)]
+//! Proves that `#[program(no_entrypoint)]` compiles: the entrypoint is not
+//! generated and `__dispatch` is pub, so a custom entrypoint can call it.
+//! This follows Anchor 0.30's pattern where programs skip the entrypoint
+//! and write their own, calling back into the framework for fallthrough.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct Init {
+    pub signer: Signer,
+}
+
+#[program(no_entrypoint)]
+pub mod test_no_entrypoint {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn initialize(ctx: Ctx<Init>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn hot_path(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+}
+
+// Verify __dispatch is accessible outside the module (pub).
+fn _verify_dispatch_is_pub() {
+    let _: fn(*mut u8, &[u8]) -> Result<(), ProgramError> =
+        test_no_entrypoint::__dispatch;
+}
+
+fn main() {}

--- a/lang/tests/compile_pass/raw_callx_table.rs
+++ b/lang/tests/compile_pass/raw_callx_table.rs
@@ -1,0 +1,34 @@
+#![allow(unexpected_cfgs)]
+//! Proves that contiguous 1-byte raw discriminators compile to the O(1)
+//! function pointer table dispatch path (callx). The discriminators 0, 1, 2
+//! are contiguous, so the derive emits an indexed table instead of a match chain.
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[program]
+pub mod test_raw_callx {
+    use super::*;
+
+    /// Three contiguous raw instructions → function pointer table dispatch.
+    #[instruction(discriminator = 0, raw)]
+    pub fn fast_a(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 1, raw)]
+    pub fn fast_b(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+
+    #[instruction(discriminator = 2, raw)]
+    pub fn fast_c(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -180,6 +180,15 @@ pub struct IdlAccountItem {
     pub pda: Option<IdlPda>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
+    /// Present when the field is `Migration<From, To>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration: Option<IdlMigration>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IdlMigration {
+    pub from: String,
+    pub to: String,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -155,3 +155,112 @@ impl AccountCheck for Mint {
         validate_mint_inner(view, params, &SPL_TOKEN_ID)
     }
 }
+
+// ---------------------------------------------------------------------------
+// AccountInit — lifecycle trait impls
+// ---------------------------------------------------------------------------
+
+/// Init params for token account creation via CPI.
+#[derive(Default)]
+pub struct TokenInitParams<'a> {
+    pub mint: Option<&'a AccountView>,
+    pub authority: Option<&'a Address>,
+    pub token_program: Option<&'a AccountView>,
+}
+
+/// Init params for mint account creation via CPI.
+#[derive(Default)]
+pub struct MintInitParams<'a> {
+    pub decimals: Option<u8>,
+    pub authority: Option<&'a Address>,
+    pub freeze_authority: Option<&'a Address>,
+    pub token_program: Option<&'a AccountView>,
+}
+
+impl quasar_lang::account_init::AccountInit for Token {
+    type InitParams<'a> = TokenInitParams<'a>;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> Result<(), ProgramError> {
+        let mint = params.mint.ok_or(ProgramError::InvalidAccountData)?;
+        let authority = params.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = params
+            .token_program
+            .ok_or(ProgramError::InvalidAccountData)?;
+        crate::init::init_token_account(
+            ctx.payer,
+            ctx.target,
+            token_program,
+            mint,
+            authority,
+            ctx.signers,
+            ctx.rent,
+        )
+    }
+}
+
+impl quasar_lang::account_init::AccountInit for Mint {
+    type InitParams<'a> = MintInitParams<'a>;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> Result<(), ProgramError> {
+        let decimals = params.decimals.ok_or(ProgramError::InvalidAccountData)?;
+        let authority = params.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = params
+            .token_program
+            .ok_or(ProgramError::InvalidAccountData)?;
+        crate::init::init_mint_account(
+            ctx.payer,
+            ctx.target,
+            token_program,
+            decimals,
+            authority,
+            params.freeze_authority,
+            ctx.signers,
+            ctx.rent,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AccountExit — lifecycle trait impls
+// ---------------------------------------------------------------------------
+
+impl quasar_lang::account_exit::AccountExit for Token {
+    #[inline(always)]
+    fn close(
+        view: &mut AccountView,
+        ctx: quasar_lang::account_exit::CloseCtx<'_>,
+    ) -> Result<(), ProgramError> {
+        // SAFETY: Token close via CPI is atomically safe — the token
+        // program handles drain + zeroing in a single instruction.
+        let authority = ctx.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = ctx.token_program.ok_or(ProgramError::InvalidAccountData)?;
+        crate::exit::close_token_account(
+            token_program,
+            unsafe { &*(view as *const AccountView) },
+            ctx.destination,
+            authority,
+        )
+    }
+
+    #[inline(always)]
+    fn sweep(
+        view: &AccountView,
+        ctx: quasar_lang::account_exit::SweepCtx<'_>,
+    ) -> Result<(), ProgramError> {
+        crate::exit::sweep_token_account(
+            ctx.token_program,
+            view,
+            ctx.mint,
+            ctx.receiver,
+            ctx.authority,
+        )
+    }
+}

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -68,3 +68,91 @@ impl AccountCheck for Mint2022 {
         validate_mint_inner(view, params, &TOKEN_2022_ID)
     }
 }
+
+// ---------------------------------------------------------------------------
+// AccountInit / AccountExit — Token2022 reuses Token's param types
+// ---------------------------------------------------------------------------
+
+use crate::token::{MintInitParams, TokenInitParams};
+
+impl quasar_lang::account_init::AccountInit for Token2022 {
+    type InitParams<'a> = TokenInitParams<'a>;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> Result<(), ProgramError> {
+        let mint = params.mint.ok_or(ProgramError::InvalidAccountData)?;
+        let authority = params.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = params
+            .token_program
+            .ok_or(ProgramError::InvalidAccountData)?;
+        crate::init::init_token_account(
+            ctx.payer,
+            ctx.target,
+            token_program,
+            mint,
+            authority,
+            ctx.signers,
+            ctx.rent,
+        )
+    }
+}
+
+impl quasar_lang::account_init::AccountInit for Mint2022 {
+    type InitParams<'a> = MintInitParams<'a>;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> Result<(), ProgramError> {
+        let decimals = params.decimals.ok_or(ProgramError::InvalidAccountData)?;
+        let authority = params.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = params
+            .token_program
+            .ok_or(ProgramError::InvalidAccountData)?;
+        crate::init::init_mint_account(
+            ctx.payer,
+            ctx.target,
+            token_program,
+            decimals,
+            authority,
+            params.freeze_authority,
+            ctx.signers,
+            ctx.rent,
+        )
+    }
+}
+
+impl quasar_lang::account_exit::AccountExit for Token2022 {
+    #[inline(always)]
+    fn close(
+        view: &mut AccountView,
+        ctx: quasar_lang::account_exit::CloseCtx<'_>,
+    ) -> Result<(), ProgramError> {
+        let authority = ctx.authority.ok_or(ProgramError::InvalidAccountData)?;
+        let token_program = ctx.token_program.ok_or(ProgramError::InvalidAccountData)?;
+        crate::exit::close_token_account(
+            token_program,
+            unsafe { &*(view as *const AccountView) },
+            ctx.destination,
+            authority,
+        )
+    }
+
+    #[inline(always)]
+    fn sweep(
+        view: &AccountView,
+        ctx: quasar_lang::account_exit::SweepCtx<'_>,
+    ) -> Result<(), ProgramError> {
+        crate::exit::sweep_token_account(
+            ctx.token_program,
+            view,
+            ctx.mint,
+            ctx.receiver,
+            ctx.authority,
+        )
+    }
+}

--- a/tests/programs/test-migrate/Cargo.toml
+++ b/tests/programs/test-migrate/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "quasar-test-migrate"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true
+
+[features]
+client = []
+debug = []
+alloc = []
+
+[dependencies]
+quasar-lang = { path = "../../../lang" }
+
+[dev-dependencies]

--- a/tests/programs/test-migrate/src/instructions/migrate_config.rs
+++ b/tests/programs/test-migrate/src/instructions/migrate_config.rs
@@ -1,0 +1,23 @@
+use {crate::state::*, quasar_lang::prelude::*};
+
+#[derive(Accounts)]
+pub struct MigrateConfig {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<System>,
+
+    #[account(payer = payer, has_one = authority)]
+    pub config: Migration<ConfigV1, ConfigV2>,
+
+    /// CHECK: authority validated via has_one
+    pub authority: Signer,
+}
+
+impl MigrateConfig {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        // Handler reads V1 (source type) via source(). Returns None after finish().
+        let _val: u64 = self.config.source().unwrap().value.into();
+        Ok(())
+    }
+}

--- a/tests/programs/test-migrate/src/instructions/mod.rs
+++ b/tests/programs/test-migrate/src/instructions/mod.rs
@@ -1,0 +1,2 @@
+mod migrate_config;
+pub use migrate_config::*;

--- a/tests/programs/test-migrate/src/lib.rs
+++ b/tests/programs/test-migrate/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![allow(dead_code)]
+
+use quasar_lang::prelude::*;
+
+mod instructions;
+use instructions::*;
+pub mod state;
+
+declare_id!("MiGR8NhJhroY6hma5mfg5xM1EG6A5FNyKoDE3aTr3Sq");
+
+#[program]
+mod quasar_test_migrate {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn migrate_config(ctx: Ctx<MigrateConfig>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+}

--- a/tests/programs/test-migrate/src/state.rs
+++ b/tests/programs/test-migrate/src/state.rs
@@ -1,0 +1,36 @@
+use quasar_lang::prelude::*;
+
+// ---------------------------------------------------------------------------
+// V1: original layout (disc = 1)
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 1)]
+pub struct ConfigV1 {
+    pub authority: Address,
+    pub value: PodU64,
+}
+
+// ---------------------------------------------------------------------------
+// V2: larger layout (disc = 2) — adds a new field
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 2)]
+pub struct ConfigV2 {
+    pub authority: Address,
+    pub value: PodU64,
+    pub extra: PodU32,
+}
+
+// ---------------------------------------------------------------------------
+// Migration: V1 → V2
+// ---------------------------------------------------------------------------
+
+impl Migrate<ConfigV2Data> for ConfigV1Data {
+    fn migrate(&self) -> ConfigV2Data {
+        ConfigV2Data {
+            authority: self.authority,
+            value: self.value,
+            extra: PodU32::from(42),
+        }
+    }
+}

--- a/tests/programs/test-one-of/Cargo.toml
+++ b/tests/programs/test-one-of/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "quasar-test-one-of"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true
+
+[features]
+client = []
+debug = []
+alloc = []
+
+[dependencies]
+quasar-lang = { path = "../../../lang" }
+
+[dev-dependencies]

--- a/tests/programs/test-one-of/src/instructions/check_consensus.rs
+++ b/tests/programs/test-one-of/src/instructions/check_consensus.rs
@@ -1,0 +1,16 @@
+use {crate::state::*, quasar_lang::prelude::*};
+
+#[derive(Accounts)]
+pub struct CheckConsensus {
+    pub signer: Signer,
+    pub consensus: Account<ConsensusAccount>,
+}
+
+impl CheckConsensus {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        // Read threshold via Deref<Target = dyn Consensus>
+        let _t = self.consensus.threshold();
+        Ok(())
+    }
+}

--- a/tests/programs/test-one-of/src/instructions/mod.rs
+++ b/tests/programs/test-one-of/src/instructions/mod.rs
@@ -1,0 +1,4 @@
+mod check_consensus;
+mod typed_accessor;
+
+pub use {check_consensus::*, typed_accessor::*};

--- a/tests/programs/test-one-of/src/instructions/typed_accessor.rs
+++ b/tests/programs/test-one-of/src/instructions/typed_accessor.rs
@@ -1,0 +1,23 @@
+use {crate::state::*, quasar_lang::prelude::*};
+
+#[derive(Accounts)]
+pub struct TypedAccessor {
+    pub signer: Signer,
+    pub consensus: Account<ConsensusAccount>,
+}
+
+impl TypedAccessor {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        // Pattern match on variant()
+        match self.consensus.variant() {
+            ConsensusAccountRef::Settings(s) => {
+                let _auth = s.authority;
+            }
+            ConsensusAccountRef::Policy(p) => {
+                let _max: u64 = p.max_amount.into();
+            }
+        }
+        Ok(())
+    }
+}

--- a/tests/programs/test-one-of/src/lib.rs
+++ b/tests/programs/test-one-of/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![allow(dead_code)]
+
+use quasar_lang::prelude::*;
+
+mod instructions;
+use instructions::*;
+pub mod state;
+
+declare_id!("11111111111111111111111111111113");
+
+#[program]
+mod quasar_test_one_of {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn check_consensus(ctx: Ctx<CheckConsensus>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    #[instruction(discriminator = 1)]
+    pub fn typed_accessor(ctx: Ctx<TypedAccessor>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+}

--- a/tests/programs/test-one-of/src/state.rs
+++ b/tests/programs/test-one-of/src/state.rs
@@ -1,0 +1,52 @@
+use quasar_lang::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Shared trait
+// ---------------------------------------------------------------------------
+
+pub trait Consensus {
+    fn threshold(&self) -> u16;
+}
+
+// ---------------------------------------------------------------------------
+// Variant A: Settings
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 10)]
+pub struct Settings {
+    pub authority: Address,
+    pub threshold: PodU16,
+}
+
+impl Consensus for Settings {
+    fn threshold(&self) -> u16 {
+        self.threshold.into()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variant B: Policy
+// ---------------------------------------------------------------------------
+
+#[account(discriminator = 11)]
+pub struct Policy {
+    pub authority: Address,
+    pub max_amount: PodU64,
+    pub threshold: PodU16,
+}
+
+impl Consensus for Policy {
+    fn threshold(&self) -> u16 {
+        self.threshold.into()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Polymorphic type
+// ---------------------------------------------------------------------------
+
+#[account(one_of, implements(Consensus))]
+pub enum ConsensusAccount {
+    Settings(Settings),
+    Policy(Policy),
+}

--- a/tests/programs/test-raw/Cargo.toml
+++ b/tests/programs/test-raw/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "quasar-test-raw"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true
+
+[features]
+client = []
+debug = []
+alloc = []
+
+[dependencies]
+quasar-lang = { path = "../../../lang" }
+
+[dev-dependencies]

--- a/tests/programs/test-raw/src/lib.rs
+++ b/tests/programs/test-raw/src/lib.rs
@@ -1,0 +1,143 @@
+#![no_std]
+#![allow(dead_code)]
+#![cfg_attr(target_os = "solana", feature(asm_experimental_arch))]
+
+use quasar_lang::prelude::*;
+
+declare_id!("RaW1111111111111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct NormalInit {
+    pub signer: Signer,
+}
+
+#[program]
+mod quasar_test_raw {
+    use super::*;
+
+    /// Normal instruction — verifies framework pipeline still works alongside
+    /// raw.
+    #[instruction(discriminator = 0)]
+    pub fn normal(ctx: Ctx<NormalInit>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.signer;
+        Ok(())
+    }
+
+    /// Raw instruction — reads a u64 from instruction data and writes it to the
+    /// first account's data at offset 8 (past the 8-byte discriminator region).
+    /// Verifies: signer check on account[1], data length validation, direct
+    /// account mutation via AccountView.
+    #[instruction(discriminator = 1, raw)]
+    pub fn raw_write(ctx: Context) -> Result<(), ProgramError> {
+        if ctx.accounts.len() < 2 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        // Manual signer check on the second account.
+        let authority = &ctx.accounts[1];
+        if !authority.is_signer() {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        // Validate instruction data has at least 8 bytes.
+        if ctx.data.len() < 8 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        // Write the u64 from instruction data into account[0] data at offset 8.
+        let target = &mut ctx.accounts[0];
+        let value_bytes: [u8; 8] = ctx.data[..8].try_into().unwrap();
+        unsafe {
+            let data = target.borrow_unchecked_mut();
+            if data.len() < 16 {
+                return Err(ProgramError::AccountDataTooSmall);
+            }
+            core::ptr::copy_nonoverlapping(value_bytes.as_ptr(), data.as_mut_ptr().add(8), 8);
+        }
+
+        Ok(())
+    }
+
+    /// Raw + inline asm — uses sBPF `ldxdw`/`stxdw` to copy a u64 from
+    /// instruction data into account[0] data at a fixed offset.
+    /// Proves inline assembly works end-to-end in a raw handler.
+    ///
+    /// Accounts: [0] writable data account, [1] signer authority
+    /// Data: 8 bytes (u64 little-endian value to write)
+    #[instruction(discriminator = 2, raw)]
+    pub fn raw_asm_write(ctx: Context) -> Result<(), ProgramError> {
+        if ctx.accounts.len() < 2 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        if !ctx.accounts[1].is_signer() {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if ctx.data.len() < 8 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        const WRITE_OFFSET: usize = 8; // past discriminator region
+
+        let dest = ctx.accounts[0].data_mut_ptr();
+        let src = ctx.data.as_ptr();
+
+        // On SBF: use inline asm to load 8 bytes from instruction data
+        // and store them into account data at WRITE_OFFSET.
+        #[cfg(target_os = "solana")]
+        unsafe {
+            core::arch::asm!(
+                "ldxdw r3, [r2+0]",
+                "stxdw [r1+{offset}], r3",
+                in("r1") dest,
+                in("r2") src,
+                offset = const WRITE_OFFSET,
+                out("r3") _,
+            );
+        }
+
+        // On non-SBF (host tests): equivalent in safe Rust.
+        #[cfg(not(target_os = "solana"))]
+        unsafe {
+            core::ptr::copy_nonoverlapping(src, dest.add(WRITE_OFFSET), 8);
+        }
+
+        Ok(())
+    }
+
+    /// callx dispatch test — proves the SVM verifier accepts indirect calls
+    /// through function pointers loaded at runtime. This is the foundation
+    /// for O(1) jump table dispatch of raw instructions.
+    ///
+    /// Uses a 2-entry function pointer table. The discriminator data byte
+    /// selects which function to call: 0 = write 0xAA, 1 = write 0xBB.
+    #[instruction(discriminator = 5, raw)]
+    pub fn callx_dispatch(ctx: Context) -> Result<(), ProgramError> {
+        if ctx.accounts.is_empty() {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        if ctx.data.is_empty() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        let target = &mut ctx.accounts[0];
+        let selector = ctx.data[0] as usize;
+
+        fn write_aa(view: &mut AccountView) {
+            unsafe { *view.borrow_unchecked_mut().get_unchecked_mut(8) = 0xAA };
+        }
+        fn write_bb(view: &mut AccountView) {
+            unsafe { *view.borrow_unchecked_mut().get_unchecked_mut(8) = 0xBB };
+        }
+
+        type Handler = fn(&mut AccountView);
+        let table: [Handler; 2] = [write_aa, write_bb];
+
+        if selector < table.len() {
+            table[selector](target);
+        } else {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(())
+    }
+}

--- a/tests/programs/test-token-cpi/src/instructions/close_token.rs
+++ b/tests/programs/test-token-cpi/src/instructions/close_token.rs
@@ -4,8 +4,8 @@ use {
 };
 
 /// Tests closing a token account via the `close =` attribute.
-/// The macro's epilogue calls `Account::close(dest)` which zeros the account,
-/// transfers lamports, and reassigns to the system program.
+/// The macro's epilogue routes through `AccountExit::close()` which issues
+/// a CPI to the token program's `close_account` instruction.
 #[derive(Accounts)]
 pub struct CloseToken {
     pub authority: Signer,

--- a/tests/suite/Cargo.toml
+++ b/tests/suite/Cargo.toml
@@ -21,6 +21,9 @@ quasar-test-token-cpi = { path = "../programs/test-token-cpi" }
 quasar-test-token-validate = { path = "../programs/test-token-validate" }
 quasar-test-heap = { path = "../programs/test-heap", features = ["client"] }
 quasar-test-token-init = { path = "../programs/test-token-init" }
+quasar-test-one-of = { path = "../programs/test-one-of" }
+quasar-test-migrate = { path = "../programs/test-migrate" }
+quasar-test-raw = { path = "../programs/test-raw" }
 quasar-spl = { path = "../../spl" }
 quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
 mollusk-svm = "0.10.3"

--- a/tests/suite/src/helpers.rs
+++ b/tests/suite/src/helpers.rs
@@ -306,6 +306,11 @@ pub fn svm_heap() -> QuasarSvm {
     QuasarSvm::new().with_program(&quasar_test_heap::ID, &elf)
 }
 
+pub fn svm_raw() -> QuasarSvm {
+    let elf = read_deploy_elf("quasar_test_raw");
+    QuasarSvm::new().with_program(&quasar_test_raw::ID, &elf)
+}
+
 /// Account with custom lamports (for pre-funded init tests).
 pub fn prefunded_account(address: Pubkey, lamports: u64) -> Account {
     Account {

--- a/tests/suite/src/lib.rs
+++ b/tests/suite/src/lib.rs
@@ -97,3 +97,15 @@ mod test_interface_migration;
 // Heap opt-in
 #[cfg(test)]
 mod test_heap;
+
+// Polymorphic accounts (one_of)
+#[cfg(test)]
+mod test_one_of;
+
+// Account migration (migrate)
+#[cfg(test)]
+mod test_migrate;
+
+// Raw instruction escape hatch
+#[cfg(test)]
+mod test_raw;

--- a/tests/suite/src/test_init_interface.rs
+++ b/tests/suite/src/test_init_interface.rs
@@ -189,6 +189,40 @@ fn init_if_needed_token_interface_existing_valid() {
 }
 
 #[test]
+fn init_if_needed_token_interface_t22_existing_valid() {
+    let mut svm = svm_init();
+    let payer = Pubkey::new_unique();
+    let token_key = Pubkey::new_unique();
+    let mint_key = Pubkey::new_unique();
+    let mint_authority = Pubkey::new_unique();
+    let token_program = token_2022_program_id();
+    let system_program = quasar_svm::system_program::ID;
+
+    let instruction: Instruction = InitIfNeededTokenInterfaceInstruction {
+        payer,
+        token_account: token_key,
+        mint: mint_key,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            rich_signer_account(payer),
+            token_account(token_key, mint_key, payer, 100, token_program),
+            mint_account(mint_key, mint_authority, 6, token_program),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "init_if_needed InterfaceAccount<Token> existing T22 should succeed: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
 fn init_if_needed_token_interface_existing_wrong_mint() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
@@ -397,6 +431,39 @@ fn init_if_needed_mint_interface_existing_valid() {
     assert!(
         result.is_ok(),
         "init_if_needed InterfaceAccount<Mint> existing valid should succeed: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
+fn init_if_needed_mint_interface_t22_existing_valid() {
+    let mut svm = svm_init();
+    let payer = Pubkey::new_unique();
+    let mint_key = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let token_program = token_2022_program_id();
+    let system_program = quasar_svm::system_program::ID;
+
+    let instruction: Instruction = InitIfNeededMintInterfaceInstruction {
+        payer,
+        mint: mint_key,
+        mint_authority: authority,
+        token_program,
+        system_program,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            rich_signer_account(payer),
+            mint_account(mint_key, authority, 6, token_program),
+            signer_account(authority),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "init_if_needed InterfaceAccount<Mint> existing T22 should succeed: {:?}",
         result.raw_result
     );
 }

--- a/tests/suite/src/test_migrate.rs
+++ b/tests/suite/src/test_migrate.rs
@@ -1,0 +1,133 @@
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_migrate::cpi::*,
+};
+
+// ---------------------------------------------------------------------------
+// Raw data builders
+// ---------------------------------------------------------------------------
+
+/// ConfigV1: disc=1, authority: Address (32), value: PodU64 (8)
+/// Total = 1 + 32 + 8 = 41 bytes
+const CONFIG_V1_SIZE: usize = 41;
+
+fn build_config_v1_data(authority: Pubkey, value: u64) -> Vec<u8> {
+    let mut data = vec![0u8; CONFIG_V1_SIZE];
+    data[0] = 1; // discriminator
+    data[1..33].copy_from_slice(authority.as_ref());
+    data[33..41].copy_from_slice(&value.to_le_bytes());
+    data
+}
+
+/// ConfigV2: disc=2, authority: Address (32), value: PodU64 (8), extra: PodU32
+/// (4) Total = 1 + 32 + 8 + 4 = 45 bytes
+const CONFIG_V2_SIZE: usize = 45;
+
+// ---------------------------------------------------------------------------
+// SVM factory
+// ---------------------------------------------------------------------------
+
+fn svm_migrate() -> quasar_svm::QuasarSvm {
+    let path = "../../target/deploy/quasar_test_migrate.so";
+    let elf = std::fs::read(path)
+        .unwrap_or_else(|e| panic!("failed to read {path}: {e}. Run `make build-sbf` first."));
+    quasar_svm::QuasarSvm::new().with_program(&quasar_test_migrate::ID, &elf)
+}
+
+fn config_v1_account(address: Pubkey, authority: Pubkey, value: u64) -> quasar_svm::Account {
+    raw_account(
+        address,
+        1_000_000,
+        build_config_v1_data(authority, value),
+        quasar_test_migrate::ID,
+    )
+}
+
+// ============================================================================
+// Happy path: V1 → V2 migration
+// ============================================================================
+
+#[test]
+fn migrate_v1_to_v2() {
+    let mut svm = svm_migrate();
+    let payer = Pubkey::new_unique();
+    let config = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+
+    let ix: Instruction = MigrateConfigInstruction {
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        config,
+        authority,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            rich_signer_account(payer),
+            // system_program is auto-provided by QuasarSvm — no account entry needed
+            config_v1_account(config, authority, 100),
+            signer_account(authority),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "migrate V1→V2 failed: {:?}",
+        result.raw_result
+    );
+
+    // Verify the account was migrated: disc should be 2, size should be V2
+    let migrated = result.account(&config).expect("config account exists");
+    assert_eq!(migrated.data.len(), CONFIG_V2_SIZE, "account resized to V2");
+    assert_eq!(migrated.data[0], 2, "discriminator updated to V2");
+
+    // authority field preserved
+    assert_eq!(
+        &migrated.data[1..33],
+        authority.as_ref(),
+        "authority preserved"
+    );
+    // value field preserved
+    assert_eq!(
+        u64::from_le_bytes(migrated.data[33..41].try_into().unwrap()),
+        100,
+        "value preserved"
+    );
+    // extra field set by migration logic
+    assert_eq!(
+        u32::from_le_bytes(migrated.data[41..45].try_into().unwrap()),
+        42,
+        "extra field set to 42 by migrate()"
+    );
+}
+
+// ============================================================================
+// Error: wrong authority (has_one fails)
+// ============================================================================
+
+#[test]
+fn migrate_wrong_authority_fails() {
+    let mut svm = svm_migrate();
+    let payer = Pubkey::new_unique();
+    let config = Pubkey::new_unique();
+    let authority = Pubkey::new_unique();
+    let wrong_authority = Pubkey::new_unique();
+
+    let ix: Instruction = MigrateConfigInstruction {
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        config,
+        authority: wrong_authority,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            rich_signer_account(payer),
+            config_v1_account(config, authority, 100), // authority != wrong_authority
+            signer_account(wrong_authority),
+        ],
+    );
+    assert!(result.is_err(), "wrong authority should fail");
+}

--- a/tests/suite/src/test_one_of.rs
+++ b/tests/suite/src/test_one_of.rs
@@ -1,0 +1,193 @@
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_one_of::cpi::*,
+};
+
+// ---------------------------------------------------------------------------
+// Raw data builders
+// ---------------------------------------------------------------------------
+
+/// Settings: disc=10, authority: Address (32), threshold: PodU16 (2)
+/// Total = 1 + 32 + 2 = 35 bytes
+const SETTINGS_SIZE: usize = 35;
+
+fn build_settings_data(authority: Pubkey, threshold: u16) -> Vec<u8> {
+    let mut data = vec![0u8; SETTINGS_SIZE];
+    data[0] = 10; // discriminator
+    data[1..33].copy_from_slice(authority.as_ref());
+    data[33..35].copy_from_slice(&threshold.to_le_bytes());
+    data
+}
+
+/// Policy: disc=11, authority: Address (32), max_amount: PodU64 (8), threshold:
+/// PodU16 (2) Total = 1 + 32 + 8 + 2 = 43 bytes
+const POLICY_SIZE: usize = 43;
+
+fn build_policy_data(authority: Pubkey, max_amount: u64, threshold: u16) -> Vec<u8> {
+    let mut data = vec![0u8; POLICY_SIZE];
+    data[0] = 11; // discriminator
+    data[1..33].copy_from_slice(authority.as_ref());
+    data[33..41].copy_from_slice(&max_amount.to_le_bytes());
+    data[41..43].copy_from_slice(&threshold.to_le_bytes());
+    data
+}
+
+// ---------------------------------------------------------------------------
+// SVM factory
+// ---------------------------------------------------------------------------
+
+fn svm_one_of() -> quasar_svm::QuasarSvm {
+    let path = "../../target/deploy/quasar_test_one_of.so";
+    let elf = std::fs::read(path)
+        .unwrap_or_else(|e| panic!("failed to read {path}: {e}. Run `make build-sbf` first."));
+    quasar_svm::QuasarSvm::new().with_program(&quasar_test_one_of::ID, &elf)
+}
+
+fn consensus_account(address: Pubkey, data: Vec<u8>) -> quasar_svm::Account {
+    raw_account(address, 1_000_000, data, quasar_test_one_of::ID)
+}
+
+// ============================================================================
+// Happy path: Settings variant
+// ============================================================================
+
+#[test]
+fn load_settings_via_one_of() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    let data = build_settings_data(signer, 100);
+    let ix: Instruction = CheckConsensusInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[signer_account(signer), consensus_account(target, data)],
+    );
+    assert!(
+        result.is_ok(),
+        "settings via one_of: {:?}",
+        result.raw_result
+    );
+}
+
+// ============================================================================
+// Happy path: Policy variant
+// ============================================================================
+
+#[test]
+fn load_policy_via_one_of() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    let data = build_policy_data(signer, 1_000_000, 200);
+    let ix: Instruction = CheckConsensusInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[signer_account(signer), consensus_account(target, data)],
+    );
+    assert!(result.is_ok(), "policy via one_of: {:?}", result.raw_result);
+}
+
+// ============================================================================
+// Typed accessor via variant()
+// ============================================================================
+
+#[test]
+fn typed_accessor_settings() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    let data = build_settings_data(signer, 50);
+    let ix: Instruction = TypedAccessorInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[signer_account(signer), consensus_account(target, data)],
+    );
+    assert!(
+        result.is_ok(),
+        "typed accessor settings: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
+fn typed_accessor_policy() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    let data = build_policy_data(signer, 500_000, 75);
+    let ix: Instruction = TypedAccessorInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[signer_account(signer), consensus_account(target, data)],
+    );
+    assert!(
+        result.is_ok(),
+        "typed accessor policy: {:?}",
+        result.raw_result
+    );
+}
+
+// ============================================================================
+// Rejection: wrong discriminator
+// ============================================================================
+
+#[test]
+fn rejects_unknown_discriminator() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    // Discriminator 99 matches neither Settings (10) nor Policy (11)
+    let mut data = vec![0u8; SETTINGS_SIZE];
+    data[0] = 99;
+    let ix: Instruction = CheckConsensusInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(
+        &ix,
+        &[signer_account(signer), consensus_account(target, data)],
+    );
+    assert!(
+        result.raw_result.is_err(),
+        "unknown discriminator should be rejected"
+    );
+}
+
+// ============================================================================
+// Rejection: wrong owner
+// ============================================================================
+
+#[test]
+fn rejects_wrong_owner() {
+    let mut svm = svm_one_of();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+    let data = build_settings_data(signer, 100);
+    // Account owned by system program, not our program
+    let bad_account = raw_account(target, 1_000_000, data, Pubkey::default());
+    let ix: Instruction = CheckConsensusInstruction {
+        signer,
+        consensus: target,
+    }
+    .into();
+    let result = svm.process_instruction(&ix, &[signer_account(signer), bad_account]);
+    assert!(result.raw_result.is_err(), "wrong owner should be rejected");
+}

--- a/tests/suite/src/test_raw.rs
+++ b/tests/suite/src/test_raw.rs
@@ -1,0 +1,305 @@
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_raw::cpi::*,
+};
+
+/// Normal instruction via the typed client — proves the framework pipeline
+/// is unaffected by the presence of raw instructions in the same program.
+#[test]
+fn normal_instruction_works_alongside_raw() {
+    let mut svm = svm_raw();
+    let signer = Pubkey::new_unique();
+    let ix: Instruction = NormalInstruction { signer }.into();
+    let result = svm.process_instruction(&ix, &[signer_account(signer)]);
+    assert!(
+        result.is_ok(),
+        "normal instruction should succeed: {:?}",
+        result.raw_result
+    );
+}
+
+/// Raw instruction — manually construct the instruction data (discriminator +
+/// payload). Passes two accounts: a writable data account and a signer.
+/// The raw handler writes a u64 from instruction data into account[0] at offset
+/// 8.
+#[test]
+fn raw_write_succeeds() {
+    let mut svm = svm_raw();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+
+    // Create a data account owned by the program with 32 bytes of data.
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    // Discriminator [1] + u64 payload (42_u64 little-endian).
+    let value: u64 = 42;
+    let mut data = vec![1u8]; // discriminator
+    data.extend_from_slice(&value.to_le_bytes());
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![
+            quasar_svm::AccountMeta {
+                pubkey: target,
+                is_signer: false,
+                is_writable: true,
+            },
+            quasar_svm::AccountMeta {
+                pubkey: signer,
+                is_signer: true,
+                is_writable: false,
+            },
+        ],
+        data,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account, signer_account(signer)]);
+    assert!(
+        result.is_ok(),
+        "raw_write should succeed: {:?}",
+        result.raw_result
+    );
+
+    // Verify the value was written to account data at offset 8.
+    let account_after = svm.get_account(&target).expect("account should exist");
+    let written = u64::from_le_bytes(account_after.data[8..16].try_into().unwrap());
+    assert_eq!(written, 42, "raw handler should write 42 at offset 8");
+}
+
+/// Raw instruction fails when signer check fails — account[1] is not a signer.
+#[test]
+fn raw_write_fails_without_signer() {
+    let mut svm = svm_raw();
+    let not_signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    let mut data = vec![1u8];
+    data.extend_from_slice(&0u64.to_le_bytes());
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![
+            quasar_svm::AccountMeta {
+                pubkey: target,
+                is_signer: false,
+                is_writable: true,
+            },
+            quasar_svm::AccountMeta {
+                pubkey: not_signer,
+                is_signer: false, // NOT a signer
+                is_writable: false,
+            },
+        ],
+        data,
+    };
+
+    let non_signer_account = quasar_svm::Account {
+        address: not_signer,
+        lamports: 1_000_000,
+        data: vec![],
+        owner: quasar_svm::system_program::ID,
+        executable: false,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account, non_signer_account]);
+    assert!(
+        result.raw_result.is_err(),
+        "raw_write should fail without signer"
+    );
+}
+
+/// Raw + inline asm — the handler uses sBPF ldxdw/stxdw to copy a u64
+/// from instruction data into account data at offset 8.
+#[test]
+fn raw_asm_write_succeeds() {
+    let mut svm = svm_raw();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    // Discriminator [2] + u64 payload (0xDEADBEEF_CAFEBABE).
+    let value: u64 = 0xDEAD_BEEF_CAFE_BABE;
+    let mut data = vec![2u8]; // discriminator for raw_asm_write
+    data.extend_from_slice(&value.to_le_bytes());
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![
+            quasar_svm::AccountMeta {
+                pubkey: target,
+                is_signer: false,
+                is_writable: true,
+            },
+            quasar_svm::AccountMeta {
+                pubkey: signer,
+                is_signer: true,
+                is_writable: false,
+            },
+        ],
+        data,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account, signer_account(signer)]);
+    assert!(
+        result.is_ok(),
+        "raw_asm_write should succeed: {:?}",
+        result.raw_result
+    );
+
+    // Verify the asm wrote the value at offset 8.
+    let account_after = svm.get_account(&target).expect("account should exist");
+    let written = u64::from_le_bytes(account_after.data[8..16].try_into().unwrap());
+    assert_eq!(
+        written, 0xDEAD_BEEF_CAFE_BABE,
+        "inline asm should write 0xDEADBEEFCAFEBABE at offset 8"
+    );
+}
+
+/// Raw instruction fails with too-short instruction data.
+#[test]
+fn raw_write_fails_with_short_data() {
+    let mut svm = svm_raw();
+    let signer = Pubkey::new_unique();
+    let target = Pubkey::new_unique();
+
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    // Discriminator [1] + only 4 bytes (needs 8).
+    let data = vec![1u8, 0, 0, 0, 0];
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![
+            quasar_svm::AccountMeta {
+                pubkey: target,
+                is_signer: false,
+                is_writable: true,
+            },
+            quasar_svm::AccountMeta {
+                pubkey: signer,
+                is_signer: true,
+                is_writable: false,
+            },
+        ],
+        data,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account, signer_account(signer)]);
+    assert!(
+        result.raw_result.is_err(),
+        "raw_write should fail with short data"
+    );
+}
+
+// ===========================================================================
+// callx dispatch — proves the SVM accepts indirect function calls via
+// function pointer tables. Foundation for O(1) raw instruction dispatch.
+// ===========================================================================
+
+#[test]
+fn callx_dispatch_selector_0_writes_aa() {
+    let mut svm = svm_raw();
+    let target = Pubkey::new_unique();
+
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    // Discriminator [5] + selector byte 0 → write_aa → 0xAA at offset 8
+    let data = vec![5u8, 0];
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![quasar_svm::AccountMeta {
+            pubkey: target,
+            is_signer: false,
+            is_writable: true,
+        }],
+        data,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account]);
+    assert!(
+        result.is_ok(),
+        "callx dispatch selector 0 should succeed: {:?}",
+        result.raw_result
+    );
+
+    let account_after = svm.get_account(&target).expect("account should exist");
+    assert_eq!(
+        account_after.data[8], 0xAA,
+        "selector 0 should write 0xAA at offset 8"
+    );
+}
+
+#[test]
+fn callx_dispatch_selector_1_writes_bb() {
+    let mut svm = svm_raw();
+    let target = Pubkey::new_unique();
+
+    let target_account = quasar_svm::Account {
+        address: target,
+        lamports: 1_000_000,
+        data: vec![0u8; 32],
+        owner: quasar_test_raw::ID,
+        executable: false,
+    };
+
+    // Discriminator [5] + selector byte 1 → write_bb → 0xBB at offset 8
+    let data = vec![5u8, 1];
+
+    let ix = Instruction {
+        program_id: quasar_test_raw::ID,
+        accounts: vec![quasar_svm::AccountMeta {
+            pubkey: target,
+            is_signer: false,
+            is_writable: true,
+        }],
+        data,
+    };
+
+    let result = svm.process_instruction(&ix, &[target_account]);
+    assert!(
+        result.is_ok(),
+        "callx dispatch selector 1 should succeed: {:?}",
+        result.raw_result
+    );
+
+    let account_after = svm.get_account(&target).expect("account should exist");
+    assert_eq!(
+        account_after.data[8], 0xBB,
+        "selector 1 should write 0xBB at offset 8"
+    );
+}


### PR DESCRIPTION
## Overview

Rewrites the accounts derive macro from a field-shape-based codegen system to a trait-dispatched, phase-ordered architecture. Adds new account types and instruction modes.

## AccountOp trait + phased dispatch

All account lifecycle operations now implement a single `AccountOp<Field>` trait. The derive emits UFCS calls at each phase, gated on const booleans that LLVM eliminates at compile time:

```rust
pub trait AccountOp<Field> {
    const REQUIRES_MUT: bool = false;
    const HAS_BEFORE_LOAD: bool = false;
    const HAS_EXIT: bool = false;

    fn before_load(&self, slot: &mut AccountView, ctx: &OpCtx) -> Result<(), ProgramError> { Ok(()) }
    fn after_load(&self, field: &Field, ctx: &OpCtx) -> Result<(), ProgramError> { Ok(()) }
    fn after_load_mut(&self, field: &mut Field, ctx: &OpCtx) -> Result<(), ProgramError> { Ok(()) }
    fn exit(&self, field: &mut Field, ctx: &OpCtx) -> Result<(), ProgramError> { Ok(()) }
}
```

SPL ops (token validation, close, sweep, realloc) implement this trait. The derive doesn't know what ops do — it just dispatches them.

## Migration\<From, To\>

Zero-copy account wrapper for type-safe on-chain schema migration:

```rust
#[account(migration(payer = payer))]
pub config: Migration<ConfigV1, ConfigV2>,
```

- `source()` provides read access to the old schema before migration
- `finish()` runs in the epilogue: reads source → calls `Migrate::migrate()` → reallocs → writes target disc + data
- Compile-time assertions: same owner, non-overlapping discriminators, target fits sBPF stack

## #[account(one_of)] — polymorphic accounts

Enum-based account dispatch for accounts that can hold multiple types:

```rust
#[account(one_of)]
pub enum ConsensusAccount {
    Settings(Settings),
    Policy(Policy),
}
```

Pairwise discriminator prefix assertions prevent type confusion. Optional `implements(Trait)` generates `Deref<Target = dyn Trait>`.

## #[instruction(raw)] — zero-overhead escape hatch

Bypasses the framework pipeline entirely. Handler receives bare `Context` with no parsing, validation, or epilogue:

```rust
#[instruction(discriminator = 1, raw)]
pub fn raw_write(ctx: Context) -> Result<(), ProgramError> { ... }
```

Enables inline sBPF asm and `callx` jump table dispatch for O(1) instruction routing.

## #[account(custom)] — user-provided validation

Accounts where the framework's owner/discriminator checks don't apply:

```rust
#[account(custom)]
pub struct OraclePrice { pub price: u64, pub confidence: u64 }
```

User implements `check()`. Framework generates the wrapper and zero-copy access.

## SPL ops

Token/Mint init, close, and sweep are now proper `AccountOp` implementations in `spl/src/ops/`. Init params flow through `InitParamsFrom` trait — the derive doesn't know SPL types exist.

## Test coverage

- 7 new test programs (migrate, one-of, raw, custom accounts)
- 14 compile-fail tests
- 67 compile-pass tests
- Runtime tests via mollusk-svm