### PR TITLE
feat(lint): upgrade-safety rule family (L010-L019, scaffold)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,9 +2169,11 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quasar-schema",
+ "quote",
  "serde",
  "serde_json",
  "syn 2.0.117",
+ "tempfile",
  "toml 0.8.23",
 ]
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -152,6 +152,19 @@ pub struct LintCommand {
     /// Output the account graph (ascii, mermaid, dot, json)
     #[arg(long, value_name = "FORMAT")]
     pub graph: Option<String>,
+
+    /// Diff the current parse against the on-disk `quasar.lock.json`
+    /// snapshot — runs the L013–L026 cross-build rules in addition
+    /// to the single-build rules. No-op (with a hint) when no lock
+    /// file exists yet.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub diff: bool,
+
+    /// Write the current parse to `quasar.lock.json`, replacing any
+    /// existing snapshot. Run after a release to baseline the next
+    /// `--diff` invocation against the just-shipped surface.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub update_lock: bool,
 }
 
 #[derive(Args, Debug, Default)]

--- a/cli/src/lint.rs
+++ b/cli/src/lint.rs
@@ -1,6 +1,6 @@
 use {
     crate::{config::QuasarConfig, error::CliResult, utils, LintCommand},
-    quasar_idl::lint,
+    quasar_idl::lint::{self, comparative, snapshot::ProgramSnapshot},
     std::path::Path,
 };
 
@@ -13,10 +13,49 @@ pub fn run(cmd: LintCommand) -> CliResult {
         graph: cmd.graph.as_deref().map(parse_graph_format),
     };
 
-    run_lint_from_path(&crate_root, &lint_config)
+    let parsed = quasar_idl::parser::parse_program(&crate_root);
+
+    if cmd.update_lock {
+        let snap = ProgramSnapshot::from_parsed(&parsed);
+        let path = lint::snapshot::lock_path(&crate_root);
+        snap.save(&path).map_err(|e| {
+            crate::error::CliError::process_failure(format!("writing lock file: {e}"), 1)
+        })?;
+        println!("Wrote {}", path.display());
+    }
+
+    let mut report = lint::run_lint(&parsed, &lint_config);
+
+    if cmd.diff {
+        let path = lint::snapshot::lock_path(&crate_root);
+        match ProgramSnapshot::load(&path) {
+            Ok(old) => {
+                let new = ProgramSnapshot::from_parsed(&parsed);
+                report.diagnostics.extend(comparative::run_all(&old, &new));
+            }
+            Err(e) => {
+                eprintln!("Skipping diff rules: {e}");
+            }
+        }
+    }
+
+    lint::output::print_report(&report);
+
+    if report.has_errors() {
+        Err(crate::error::CliError::process_failure(
+            "lint check failed".to_string(),
+            1,
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 /// Run lint from a crate path (standalone `quasar lint`).
+///
+/// Convenience wrapper used by `quasar build --lint` — no diff/lock
+/// path, just the single-build rules. The diff family runs only via
+/// the explicit `--diff` flag on the standalone subcommand.
 pub fn run_lint_from_path(crate_path: &Path, lint_config: &lint::LintConfig) -> CliResult {
     let parsed = quasar_idl::parser::parse_program(crate_path);
     run_lint_on_parsed(&parsed, lint_config)

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -17,8 +17,12 @@ path = "src/lib.rs"
 [dependencies]
 syn = { version = "2", features = ["full", "parsing"] }
 proc-macro2 = "1"
+quote = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 bs58 = "0.5.1"
 quasar-schema = { path = "../schema" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/idl/src/lint/comparative.rs
+++ b/idl/src/lint/comparative.rs
@@ -1,0 +1,328 @@
+//! Cross-build (diff) upgrade-safety rules.
+//!
+//! These rules need *two* builds to compare: the surface as it shipped
+//! to mainnet (the "old" snapshot, loaded from `quasar.lock.json`)
+//! versus the candidate the developer is about to release (the "new"
+//! snapshot, derived from the current parse). Findings are written
+//! into the same [`super::types::LintReport`] used by the single-build
+//! rules; downstream output / suppression / CI integration is shared.
+//!
+//! ## Scope in this module
+//!
+//! Initial set of three representative rules:
+//! - **L013** — account field reorder (Borsh layout corruption)
+//! - **L018** — account discriminator change (orphans every existing account)
+//! - **L019** — instruction removed (breaks every existing client)
+//!
+//! The full set (L013–L026) lands in follow-on PRs; the entry point
+//! and snapshot infrastructure here are designed to absorb each new
+//! rule as a single function appended to [`run_all`] without touching
+//! the plumbing around it.
+//!
+//! ## What's intentionally not here
+//!
+//! - **R011 / R012 (enum variant rules)** — Quasar's `IdlTypeDefKind` is
+//!   `Struct`-only at the schema layer. Adding enum support is an upstream
+//!   change tracked separately; until then the equivalent rules in this catalog
+//!   are unimplementable.
+//! - **R013 PDA seed rule with full struct-field-path precision** — Quasar's
+//!   `RawSeed::AccountRef` carries an account name but not a nested field path.
+//!   The corresponding L023 (when added) will ship with reduced precision and
+//!   document the limitation.
+
+use super::{
+    snapshot::ProgramSnapshot,
+    types::{Diagnostic, LintRule},
+};
+
+/// Run every cross-build rule and return the resulting findings.
+/// Caller folds these into the single-build report (or treats them as
+/// a standalone report for `quasar lint --diff`-only invocations).
+pub fn run_all(old: &ProgramSnapshot, new: &ProgramSnapshot) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    check_l013_account_field_reorder(old, new, &mut diagnostics);
+    check_l018_account_discriminator_change(old, new, &mut diagnostics);
+    check_l019_instruction_removed(old, new, &mut diagnostics);
+    diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// L013 — account-field-reorder
+// ---------------------------------------------------------------------------
+//
+// Borsh serializes account fields in source declaration order. Reordering
+// them on a deployed program means every byte already on chain now
+// deserializes against the wrong type at the wrong offset — silent data
+// corruption with no error. The fix is almost always "put the order back";
+// if the new order is semantically required, ship a one-shot migration
+// instruction that rewrites every account in place.
+//
+// Detected when: the same account name exists in both snapshots, the set
+// of field names is identical, but the order differs. A pure rename or
+// retype is L014/L015's job, not this one.
+
+fn check_l013_account_field_reorder(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+
+        let old_names: Vec<&str> = old_acc.fields.iter().map(|f| f.name.as_str()).collect();
+        let new_names: Vec<&str> = new_acc.fields.iter().map(|f| f.name.as_str()).collect();
+
+        // Same set of names but different order = reorder. If the sets
+        // differ at all, that's add/remove territory (other rules' job).
+        if old_names == new_names {
+            continue;
+        }
+        let mut sorted_old = old_names.clone();
+        let mut sorted_new = new_names.clone();
+        sorted_old.sort_unstable();
+        sorted_new.sort_unstable();
+        if sorted_old != sorted_new {
+            continue;
+        }
+
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L013,
+            severity: LintRule::L013.default_severity(),
+            accounts_struct: old_acc.name.clone(),
+            field: None,
+            message: format!(
+                "fields reordered in account `{}`: {:?} → {:?}",
+                old_acc.name, old_names, new_names
+            ),
+            suggestion: Some(
+                "Borsh lays fields out in declaration order. Put them back in the original order, \
+                 or write a one-shot migration instruction that rewrites every account."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L018 — account-discriminator-change
+// ---------------------------------------------------------------------------
+//
+// The first N bytes of every account on chain are the discriminator —
+// Quasar's account loader uses them to confirm the account it's reading
+// is what it expects. Changing the discriminator on a deployed account
+// type means every existing account of that type fails the check; from
+// the program's perspective they no longer exist.
+//
+// Detected when: an account name is present in both snapshots and the
+// discriminator bytes differ. Renames are L025 (account-removed) +
+// implicit add elsewhere — not this rule.
+
+fn check_l018_account_discriminator_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+        if old_acc.discriminator == new_acc.discriminator {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L018,
+            severity: LintRule::L018.default_severity(),
+            accounts_struct: old_acc.name.clone(),
+            field: None,
+            message: format!(
+                "discriminator of account `{}` changed: {:?} → {:?}",
+                old_acc.name, old_acc.discriminator, new_acc.discriminator
+            ),
+            suggestion: Some(
+                "If this is intentional (e.g. struct rename) and you've migrated existing \
+                 accounts, suppress with `#[allow(quasar::account_discriminator_change)]`. \
+                 Otherwise restore the original discriminator bytes."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L019 — instruction-removed
+// ---------------------------------------------------------------------------
+//
+// Removing an instruction breaks every off-chain caller that still routes
+// to it — clients send the instruction data, the program can't dispatch,
+// the transaction fails. Even if no client *should* be calling it, you
+// usually don't have visibility into who is.
+//
+// Detected when: an instruction name in the old snapshot is missing from
+// the new one. The standard fix is to keep the instruction declared but
+// have its body return a specific error (or no-op) for one release cycle
+// before deleting outright.
+
+fn check_l019_instruction_removed(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_ix in &old.instructions {
+        if new.instructions.iter().any(|n| n.name == old_ix.name) {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L019,
+            severity: LintRule::L019.default_severity(),
+            accounts_struct: old_ix.accounts_type_name.clone(),
+            field: None,
+            message: format!(
+                "instruction `{}` was removed; any client that still calls it will fail",
+                old_ix.name
+            ),
+            suggestion: Some(format!(
+                "Keep the instruction declared but make its body return a specific error (or \
+                 no-op) for one release before removing entirely. Or suppress with \
+                 `#[allow(quasar::instruction_removed)]` once you're confident no client routes \
+                 to `{}`.",
+                old_ix.name
+            )),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::lint::snapshot::{
+            AccountSnapshot, InstructionSnapshot, NamedTypeSnapshot, ProgramSnapshot,
+            SNAPSHOT_VERSION,
+        },
+    };
+
+    fn empty_snap() -> ProgramSnapshot {
+        ProgramSnapshot {
+            version: SNAPSHOT_VERSION,
+            program_id: "11111111111111111111111111111111".to_string(),
+            program_name: "test".to_string(),
+            accounts: vec![],
+            instructions: vec![],
+            events: vec![],
+            accounts_structs: vec![],
+        }
+    }
+
+    fn account(name: &str, disc: Vec<u8>, fields: &[(&str, &str)]) -> AccountSnapshot {
+        AccountSnapshot {
+            name: name.to_string(),
+            discriminator: disc,
+            fields: fields
+                .iter()
+                .map(|(n, t)| NamedTypeSnapshot {
+                    name: n.to_string(),
+                    ty: t.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    fn instruction(name: &str, disc: Vec<u8>) -> InstructionSnapshot {
+        InstructionSnapshot {
+            name: name.to_string(),
+            discriminator: disc,
+            args: vec![],
+            accounts_type_name: format!("{name}Accounts"),
+        }
+    }
+
+    // L013 tests --------------------------------------------------------------
+
+    #[test]
+    fn l013_fires_on_field_reorder_with_same_names() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u8"), ("b", "u8")])];
+        new.accounts = vec![account("X", vec![1], &[("b", "u8"), ("a", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L013));
+    }
+
+    #[test]
+    fn l013_silent_on_identical_order() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u8"), ("b", "u8")])];
+        new.accounts = vec![account("X", vec![1], &[("a", "u8"), ("b", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L013));
+    }
+
+    #[test]
+    fn l013_silent_when_field_set_differs() {
+        // a → b is a remove + add, not a reorder. Other rules cover it.
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u8"), ("b", "u8")])];
+        new.accounts = vec![account("X", vec![1], &[("b", "u8"), ("c", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L013));
+    }
+
+    // L018 tests --------------------------------------------------------------
+
+    #[test]
+    fn l018_fires_when_discriminator_changes() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![42], &[("a", "u8")])];
+        new.accounts = vec![account("X", vec![99], &[("a", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L018));
+    }
+
+    #[test]
+    fn l018_silent_when_discriminator_unchanged() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![42], &[("a", "u8")])];
+        new.accounts = vec![account("X", vec![42], &[("a", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L018));
+    }
+
+    // L019 tests --------------------------------------------------------------
+
+    #[test]
+    fn l019_fires_when_instruction_removed() {
+        let mut old = empty_snap();
+        let new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L019));
+    }
+
+    #[test]
+    fn l019_silent_when_instruction_kept() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L019));
+    }
+
+    #[test]
+    fn l019_silent_when_unrelated_instruction_added() {
+        // Adding a new instruction is additive, not breaking — old
+        // callers keep working.
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0]), instruction("take", vec![1])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L019));
+    }
+}

--- a/idl/src/lint/comparative.rs
+++ b/idl/src/lint/comparative.rs
@@ -7,17 +7,32 @@
 //! into the same [`super::types::LintReport`] used by the single-build
 //! rules; downstream output / suppression / CI integration is shared.
 //!
-//! ## Scope in this module
+//! ## Scope
 //!
-//! Initial set of three representative rules:
-//! - **L013** — account field reorder (Borsh layout corruption)
-//! - **L018** — account discriminator change (orphans every existing account)
+//! Account-shape diffs:
+//! - **L013** — field reorder (Borsh layout corruption)
+//! - **L014** — field retype (offset / interpretation mismatch)
+//! - **L015** — field removed (downstream offsets corrupt)
+//! - **L016** — mid-list insert (every later offset shifts)
+//! - **L017** — append (Warning — needs realloc, not silently corrupt)
+//! - **L018** — discriminator change (orphans every existing account)
+//! - **L025** — account struct removed (existing accounts orphaned)
+//!
+//! Instruction-shape diffs:
 //! - **L019** — instruction removed (breaks every existing client)
+//! - **L020** — argument signature change (clients send misread bytes)
+//! - **L021** — account list added/removed/reordered (positional indices)
+//! - **L022** — `is_signer` / `is_writable` flip (wire-format mismatch)
+//! - **L024** — instruction discriminator change (clients route wrong)
 //!
-//! The full set (L013–L026) lands in follow-on PRs; the entry point
-//! and snapshot infrastructure here are designed to absorb each new
-//! rule as a single function appended to [`run_all`] without touching
-//! the plumbing around it.
+//! PDA + event diffs:
+//! - **L023** — PDA seed change (every existing PDA orphaned; reduced precision
+//!   — see rule docs)
+//! - **L026** — event discriminator change (off-chain indexers go silent)
+//!
+//! Adding a rule means writing one function over `(old, new)` and
+//! appending it to [`run_all`]; the snapshot, lock-file IO, and CLI
+//! plumbing don't move.
 //!
 //! ## What's intentionally not here
 //!
@@ -25,10 +40,11 @@
 //!   `Struct`-only at the schema layer. Adding enum support is an upstream
 //!   change tracked separately; until then the equivalent rules in this catalog
 //!   are unimplementable.
-//! - **R013 PDA seed rule with full struct-field-path precision** — Quasar's
-//!   `RawSeed::AccountRef` carries an account name but not a nested field path.
-//!   The corresponding L023 (when added) will ship with reduced precision and
-//!   document the limitation.
+//! - **L023 PDA seed rule with full struct-field-path precision** — Quasar's
+//!   `RawSeed::AccountRef` carries an account name but not a nested
+//!   struct-field path. L023 ships in reduced-precision mode: it catches
+//!   account-level seed swaps but can miss seed changes that only swap a field
+//!   path within the same account. Tracked as a future-work parser enhancement.
 
 use super::{
     snapshot::ProgramSnapshot,
@@ -40,9 +56,23 @@ use super::{
 /// a standalone report for `quasar lint --diff`-only invocations).
 pub fn run_all(old: &ProgramSnapshot, new: &ProgramSnapshot) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
+    // Account-shape diffs.
     check_l013_account_field_reorder(old, new, &mut diagnostics);
+    check_l014_account_field_retype(old, new, &mut diagnostics);
+    check_l015_account_field_removed(old, new, &mut diagnostics);
+    check_l016_account_field_insert_middle(old, new, &mut diagnostics);
+    check_l017_account_field_append(old, new, &mut diagnostics);
     check_l018_account_discriminator_change(old, new, &mut diagnostics);
+    check_l025_account_removed(old, new, &mut diagnostics);
+    // Instruction-shape diffs.
     check_l019_instruction_removed(old, new, &mut diagnostics);
+    check_l020_instruction_arg_change(old, new, &mut diagnostics);
+    check_l021_instruction_account_list_change(old, new, &mut diagnostics);
+    check_l022_instruction_signer_writable_flip(old, new, &mut diagnostics);
+    check_l024_instruction_discriminator_change(old, new, &mut diagnostics);
+    // PDA + event diffs.
+    check_l023_pda_seed_change(old, new, &mut diagnostics);
+    check_l026_event_discriminator_change(old, new, &mut diagnostics);
     diagnostics
 }
 
@@ -193,12 +223,556 @@ fn check_l019_instruction_removed(
     }
 }
 
+// ---------------------------------------------------------------------------
+// L014 — account-field-retype
+// ---------------------------------------------------------------------------
+//
+// A field's type changed without the name changing. Borsh reads bytes
+// at the offset assigned by declaration order and the type at that
+// offset — `u64 → u32` shifts every later offset by 4 bytes (and reads
+// the wrong value for the field itself). Even type changes that don't
+// shift offsets (`u8 → bool`) reinterpret existing bytes and almost
+// always cause data corruption or panics.
+
+fn check_l014_account_field_retype(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+        for old_field in &old_acc.fields {
+            let Some(new_field) = new_acc.fields.iter().find(|f| f.name == old_field.name) else {
+                continue;
+            };
+            if old_field.ty == new_field.ty {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L014,
+                severity: LintRule::L014.default_severity(),
+                accounts_struct: old_acc.name.clone(),
+                field: Some(old_field.name.clone()),
+                message: format!(
+                    "field `{}.{}` type changed: `{}` → `{}`",
+                    old_acc.name, old_field.name, old_field.ty, new_field.ty
+                ),
+                suggestion: Some(
+                    "Borsh layout depends on the declared type at each offset. Restore the \
+                     original type, or write a one-shot migration that rewrites every account \
+                     under the new type."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L015 — account-field-removed
+// ---------------------------------------------------------------------------
+//
+// Removing a field by name leaves its on-chain bytes in place — the
+// next field now reads from the wrong offset. The whole layout downstream
+// of the removal is corrupted on every existing account.
+
+fn check_l015_account_field_removed(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+        for old_field in &old_acc.fields {
+            if new_acc.fields.iter().any(|f| f.name == old_field.name) {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L015,
+                severity: LintRule::L015.default_severity(),
+                accounts_struct: old_acc.name.clone(),
+                field: Some(old_field.name.clone()),
+                message: format!(
+                    "field `{}.{}` was removed; the bytes are still on chain and now alias the \
+                     next field",
+                    old_acc.name, old_field.name
+                ),
+                suggestion: Some(
+                    "Either keep the field declared (rename to `_deprecated_<name>` to mark \
+                     intent) or write a one-shot migration that compacts the layout of every \
+                     account."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L016 — account-field-insert-middle
+// ---------------------------------------------------------------------------
+//
+// A field added anywhere except the tail shifts every later field's
+// offset. Existing on-chain accounts deserialize against the wrong
+// offsets — silent corruption.
+//
+// Detected when: `new` has a field name not present in `old`, and the
+// position of that name in the new field list is *before* at least one
+// name that did exist in old. A pure append fires L017 instead.
+
+fn check_l016_account_field_insert_middle(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+        let old_names: Vec<&str> = old_acc.fields.iter().map(|f| f.name.as_str()).collect();
+        for (idx, new_field) in new_acc.fields.iter().enumerate() {
+            if old_names.contains(&new_field.name.as_str()) {
+                continue;
+            }
+            // Is there an existing-name field after this insertion point?
+            // If yes, the insert shifts that field's offset → mid-list insert.
+            let inserted_before_existing = new_acc.fields[idx + 1..]
+                .iter()
+                .any(|later| old_names.contains(&later.name.as_str()));
+            if !inserted_before_existing {
+                continue; // pure append, L017's job
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L016,
+                severity: LintRule::L016.default_severity(),
+                accounts_struct: old_acc.name.clone(),
+                field: Some(new_field.name.clone()),
+                message: format!(
+                    "field `{}.{}` was inserted before existing fields; every later offset shifts \
+                     and existing accounts deserialize to garbage",
+                    old_acc.name, new_field.name
+                ),
+                suggestion: Some(
+                    "Append new fields to the tail of the account (after `_reserved` if the \
+                     account had reserved padding sized for it). Mid-list insertion requires a \
+                     one-shot migration of every existing account."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L017 — account-field-append
+// ---------------------------------------------------------------------------
+//
+// Adding a field at the tail doesn't corrupt existing data, but it
+// changes the account size — every existing account has to be
+// reallocated (paid for, signed for) before the new binary can read it.
+// If the account had `_reserved: [u8; N]` padding sized for the new
+// field, this could be safely *replaced* with a typed field — but the
+// snapshot can't tell whether the new field fits inside the prior
+// padding budget without inspecting type sizes, so it warns and lets
+// the dev confirm.
+//
+// Severity: Warning, not Error — the upgrade is recoverable with a
+// realloc, and devs intentionally adding migration code shouldn't have
+// the build fail on them.
+
+fn check_l017_account_field_append(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        let Some(new_acc) = new.accounts.iter().find(|a| a.name == old_acc.name) else {
+            continue;
+        };
+        let old_names: Vec<&str> = old_acc.fields.iter().map(|f| f.name.as_str()).collect();
+        for (idx, new_field) in new_acc.fields.iter().enumerate() {
+            if old_names.contains(&new_field.name.as_str()) {
+                continue;
+            }
+            let inserted_before_existing = new_acc.fields[idx + 1..]
+                .iter()
+                .any(|later| old_names.contains(&later.name.as_str()));
+            if inserted_before_existing {
+                continue; // mid-list insert, L016's job
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L017,
+                severity: LintRule::L017.default_severity(),
+                accounts_struct: old_acc.name.clone(),
+                field: Some(new_field.name.clone()),
+                message: format!(
+                    "field `{}.{}` was appended; every existing account needs a realloc before \
+                     the new binary can read it",
+                    old_acc.name, new_field.name
+                ),
+                suggestion: Some(
+                    "If the account had `_reserved` padding sized for this field, replace the \
+                     padding with the typed field instead — that's an additive change. Otherwise \
+                     plan a one-shot realloc instruction."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L020 — instruction-arg-change
+// ---------------------------------------------------------------------------
+//
+// Instruction data is Borsh-serialized in declaration order, so any
+// change to the arg list (rename, retype, reorder, add, remove) means
+// existing clients send bytes the program will misread. Fires on any
+// difference in the ordered (name, ty) sequence.
+
+fn check_l020_instruction_arg_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_ix in &old.instructions {
+        let Some(new_ix) = new.instructions.iter().find(|i| i.name == old_ix.name) else {
+            continue;
+        };
+        if old_ix.args == new_ix.args {
+            continue;
+        }
+        let render = |args: &[crate::lint::snapshot::NamedTypeSnapshot]| -> String {
+            args.iter()
+                .map(|a| format!("{}: {}", a.name, a.ty))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L020,
+            severity: LintRule::L020.default_severity(),
+            accounts_struct: old_ix.accounts_type_name.clone(),
+            field: None,
+            message: format!(
+                "argument signature of `{}` changed: ({}) → ({})",
+                old_ix.name,
+                render(&old_ix.args),
+                render(&new_ix.args)
+            ),
+            suggestion: Some(
+                "Borsh serializes args in declaration order. Prefer adding a new instruction name \
+                 rather than reshaping an existing one, or coordinate updates with every caller \
+                 in the same release."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L021 — instruction-account-list-change
+// ---------------------------------------------------------------------------
+//
+// Instruction accounts are passed by *position* — clients construct an
+// `AccountMeta` array indexed positionally. Adding, removing, or
+// reordering account slots changes that indexing. Detected by comparing
+// the ordered list of account-slot names per instruction's accounts
+// struct.
+
+fn check_l021_instruction_account_list_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_ix in &old.instructions {
+        let Some(new_ix) = new.instructions.iter().find(|i| i.name == old_ix.name) else {
+            continue;
+        };
+        let Some(old_struct) = old
+            .accounts_structs
+            .iter()
+            .find(|s| s.name == old_ix.accounts_type_name)
+        else {
+            continue;
+        };
+        let Some(new_struct) = new
+            .accounts_structs
+            .iter()
+            .find(|s| s.name == new_ix.accounts_type_name)
+        else {
+            continue;
+        };
+        let old_names: Vec<&str> = old_struct.fields.iter().map(|f| f.name.as_str()).collect();
+        let new_names: Vec<&str> = new_struct.fields.iter().map(|f| f.name.as_str()).collect();
+        if old_names == new_names {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L021,
+            severity: LintRule::L021.default_severity(),
+            accounts_struct: old_ix.accounts_type_name.clone(),
+            field: None,
+            message: format!(
+                "instruction `{}` account list changed: {:?} → {:?}",
+                old_ix.name, old_names, new_names
+            ),
+            suggestion: Some(
+                "Account slots are positional. Append-only changes are still risky if existing \
+                 clients pass the new slots as `remaining_accounts`. Prefer a new instruction \
+                 name when the account shape needs to evolve."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L022 — instruction-signer-writable-flip
+// ---------------------------------------------------------------------------
+//
+// The `is_signer` and `is_writable` flags on each `AccountMeta` are
+// part of the wire format. Flipping either on a slot that exists in
+// both versions means existing callers send bytes the program rejects
+// (or, worse, silently accepts when it shouldn't). Fires per slot, not
+// per instruction.
+
+fn check_l022_instruction_signer_writable_flip(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_ix in &old.instructions {
+        let Some(new_ix) = new.instructions.iter().find(|i| i.name == old_ix.name) else {
+            continue;
+        };
+        let Some(old_struct) = old
+            .accounts_structs
+            .iter()
+            .find(|s| s.name == old_ix.accounts_type_name)
+        else {
+            continue;
+        };
+        let Some(new_struct) = new
+            .accounts_structs
+            .iter()
+            .find(|s| s.name == new_ix.accounts_type_name)
+        else {
+            continue;
+        };
+        for old_slot in &old_struct.fields {
+            let Some(new_slot) = new_struct.fields.iter().find(|s| s.name == old_slot.name) else {
+                continue;
+            };
+            if old_slot.signer == new_slot.signer && old_slot.writable == new_slot.writable {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L022,
+                severity: LintRule::L022.default_severity(),
+                accounts_struct: old_ix.accounts_type_name.clone(),
+                field: Some(old_slot.name.clone()),
+                message: format!(
+                    "slot `{}.{}` flags flipped: signer {} → {}, writable {} → {}",
+                    old_ix.name,
+                    old_slot.name,
+                    old_slot.signer,
+                    new_slot.signer,
+                    old_slot.writable,
+                    new_slot.writable
+                ),
+                suggestion: Some(
+                    "Existing clients send `AccountMeta` with the old flags. Coordinate updates \
+                     across every caller in the same release, or version the instruction by name."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L023 — pda-seed-change
+// ---------------------------------------------------------------------------
+//
+// A PDA's address is `derive(seeds, program_id)`. Change any seed and
+// every existing account at the old address is orphaned — the program
+// computes a new address and finds nothing there. Detected by comparing
+// the ordered seed list per slot.
+//
+// **Precision limitation.** `RawSeed::AccountRef` carries an account
+// name but not a nested struct-field path (e.g., `account.field.nested`
+// — Quasar's parser doesn't currently extract the path). This rule
+// catches account-level seed changes (different account referenced)
+// but can miss seed changes that only swap a field path within the
+// same account. Tracked as future-work parser enhancement.
+
+fn check_l023_pda_seed_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_struct in &old.accounts_structs {
+        let Some(new_struct) = new
+            .accounts_structs
+            .iter()
+            .find(|s| s.name == old_struct.name)
+        else {
+            continue;
+        };
+        for old_slot in &old_struct.fields {
+            let Some(new_slot) = new_struct.fields.iter().find(|s| s.name == old_slot.name) else {
+                continue;
+            };
+            if old_slot.pda == new_slot.pda {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                rule: LintRule::L023,
+                severity: LintRule::L023.default_severity(),
+                accounts_struct: old_struct.name.clone(),
+                field: Some(old_slot.name.clone()),
+                message: format!(
+                    "PDA seeds for slot `{}.{}` changed; every existing account at the old \
+                     address is now orphaned",
+                    old_struct.name, old_slot.name
+                ),
+                suggestion: Some(
+                    "Restore the original seed expression, or write a one-shot migration that \
+                     transfers state from the old PDA to the new one for every existing account."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L024 — instruction-discriminator-change
+// ---------------------------------------------------------------------------
+//
+// The first N bytes of the instruction data identify which handler to
+// dispatch. Changing the discriminator on an existing instruction
+// means every existing caller routes to the wrong slot — or to none
+// at all.
+
+fn check_l024_instruction_discriminator_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_ix in &old.instructions {
+        let Some(new_ix) = new.instructions.iter().find(|i| i.name == old_ix.name) else {
+            continue;
+        };
+        if old_ix.discriminator == new_ix.discriminator {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L024,
+            severity: LintRule::L024.default_severity(),
+            accounts_struct: old_ix.accounts_type_name.clone(),
+            field: None,
+            message: format!(
+                "discriminator of instruction `{}` changed: {:?} → {:?}",
+                old_ix.name, old_ix.discriminator, new_ix.discriminator
+            ),
+            suggestion: Some(
+                "Restore the original discriminator. If the rename is intentional, version the \
+                 instruction by name and keep the original handler routed to its old \
+                 discriminator for one release cycle."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L025 — account-removed
+// ---------------------------------------------------------------------------
+//
+// Removing an account struct from the program means every existing
+// account of that type is orphaned — the program no longer has a
+// loader for it, so even reads fail. Equivalent severity to a
+// discriminator change for that type.
+
+fn check_l025_account_removed(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_acc in &old.accounts {
+        if new.accounts.iter().any(|a| a.name == old_acc.name) {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L025,
+            severity: LintRule::L025.default_severity(),
+            accounts_struct: old_acc.name.clone(),
+            field: None,
+            message: format!(
+                "account struct `{}` was removed; existing accounts of that type are orphaned",
+                old_acc.name
+            ),
+            suggestion: Some(format!(
+                "Keep the struct declared (mark it `#[deprecated]` if needed) for one release \
+                 cycle so existing accounts can still be read while clients migrate. Or suppress \
+                 with `#[allow(quasar::account_removed)]` once you're confident no accounts of \
+                 type `{}` remain on chain.",
+                old_acc.name
+            )),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L026 — event-discriminator-change
+// ---------------------------------------------------------------------------
+//
+// Event discriminators are how off-chain indexers filter logs. Change
+// one and every listener filtering for the old value goes silent —
+// usually without raising any error visible to the program team.
+
+fn check_l026_event_discriminator_change(
+    old: &ProgramSnapshot,
+    new: &ProgramSnapshot,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for old_evt in &old.events {
+        let Some(new_evt) = new.events.iter().find(|e| e.name == old_evt.name) else {
+            continue;
+        };
+        if old_evt.discriminator == new_evt.discriminator {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            rule: LintRule::L026,
+            severity: LintRule::L026.default_severity(),
+            accounts_struct: old_evt.name.clone(),
+            field: None,
+            message: format!(
+                "discriminator of event `{}` changed: {:?} → {:?}",
+                old_evt.name, old_evt.discriminator, new_evt.discriminator
+            ),
+            suggestion: Some(
+                "Restore the original discriminator. Off-chain indexers filtering on the prior \
+                 value go silent without raising any visible error."
+                    .to_string(),
+            ),
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
         crate::lint::snapshot::{
-            AccountSnapshot, InstructionSnapshot, NamedTypeSnapshot, ProgramSnapshot,
+            AccountSlotSnapshot, AccountSnapshot, AccountsStructSnapshot, EventSnapshot,
+            InstructionSnapshot, NamedTypeSnapshot, PdaSnapshot, ProgramSnapshot, SeedSnapshot,
             SNAPSHOT_VERSION,
         },
     };
@@ -324,5 +898,350 @@ mod tests {
         new.instructions = vec![instruction("make", vec![0]), instruction("take", vec![1])];
         let diags = run_all(&old, &new);
         assert!(!diags.iter().any(|d| d.rule == LintRule::L019));
+    }
+
+    // --- shared helpers for the L014–L026 tests -----------------------------
+
+    fn instruction_with_args(
+        name: &str,
+        disc: Vec<u8>,
+        args: &[(&str, &str)],
+    ) -> InstructionSnapshot {
+        InstructionSnapshot {
+            name: name.to_string(),
+            discriminator: disc,
+            args: args
+                .iter()
+                .map(|(n, t)| NamedTypeSnapshot {
+                    name: n.to_string(),
+                    ty: t.to_string(),
+                })
+                .collect(),
+            accounts_type_name: format!("{name}Accounts"),
+        }
+    }
+
+    fn slot(name: &str, signer: bool, writable: bool) -> AccountSlotSnapshot {
+        AccountSlotSnapshot {
+            name: name.to_string(),
+            signer,
+            writable,
+            pda: None,
+        }
+    }
+
+    fn slot_with_pda(name: &str, seeds: Vec<SeedSnapshot>) -> AccountSlotSnapshot {
+        AccountSlotSnapshot {
+            name: name.to_string(),
+            signer: false,
+            writable: true,
+            pda: Some(PdaSnapshot { seeds }),
+        }
+    }
+
+    fn accounts_struct(name: &str, slots: Vec<AccountSlotSnapshot>) -> AccountsStructSnapshot {
+        AccountsStructSnapshot {
+            name: name.to_string(),
+            fields: slots,
+        }
+    }
+
+    fn event(name: &str, disc: Vec<u8>) -> EventSnapshot {
+        EventSnapshot {
+            name: name.to_string(),
+            discriminator: disc,
+            fields: vec![],
+        }
+    }
+
+    // L014 tests --------------------------------------------------------------
+
+    #[test]
+    fn l014_fires_on_field_retype() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("amount", "u64")])];
+        new.accounts = vec![account("X", vec![1], &[("amount", "u32")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L014));
+    }
+
+    #[test]
+    fn l014_silent_when_type_unchanged() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("amount", "u64")])];
+        new.accounts = vec![account("X", vec![1], &[("amount", "u64")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L014));
+    }
+
+    // L015 tests --------------------------------------------------------------
+
+    #[test]
+    fn l015_fires_when_field_removed() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u64"), ("b", "u8")])];
+        new.accounts = vec![account("X", vec![1], &[("a", "u64")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L015));
+    }
+
+    // L016 tests --------------------------------------------------------------
+
+    #[test]
+    fn l016_fires_on_mid_list_insert() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u64"), ("b", "u8")])];
+        // `c` inserted between `a` and `b` — `b`'s offset shifts.
+        new.accounts = vec![account(
+            "X",
+            vec![1],
+            &[("a", "u64"), ("c", "u8"), ("b", "u8")],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L016));
+        // Should not also fire L017 — this is mid-list, not append.
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L017));
+    }
+
+    // L017 tests --------------------------------------------------------------
+
+    #[test]
+    fn l017_fires_on_append() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u64")])];
+        new.accounts = vec![account("X", vec![1], &[("a", "u64"), ("b", "u8")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L017));
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L016));
+    }
+
+    #[test]
+    fn l017_severity_is_warning_not_error() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("X", vec![1], &[("a", "u64")])];
+        new.accounts = vec![account("X", vec![1], &[("a", "u64"), ("b", "u8")])];
+        let diags = run_all(&old, &new);
+        let l017 = diags.iter().find(|d| d.rule == LintRule::L017).unwrap();
+        assert_eq!(l017.severity, crate::lint::types::Severity::Warning);
+    }
+
+    // L020 tests --------------------------------------------------------------
+
+    #[test]
+    fn l020_fires_on_arg_retype() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction_with_args("make", vec![0], &[("amount", "u64")])];
+        new.instructions = vec![instruction_with_args("make", vec![0], &[("amount", "u32")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L020));
+    }
+
+    #[test]
+    fn l020_fires_on_arg_added() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction_with_args("make", vec![0], &[("amount", "u64")])];
+        new.instructions = vec![instruction_with_args(
+            "make",
+            vec![0],
+            &[("amount", "u64"), ("memo", "String")],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L020));
+    }
+
+    #[test]
+    fn l020_silent_when_args_identical() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction_with_args("make", vec![0], &[("amount", "u64")])];
+        new.instructions = vec![instruction_with_args("make", vec![0], &[("amount", "u64")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L020));
+    }
+
+    // L021 tests --------------------------------------------------------------
+
+    #[test]
+    fn l021_fires_when_account_slot_added() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0])];
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("maker", true, true)],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("maker", true, true), slot("vault", false, true)],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L021));
+    }
+
+    #[test]
+    fn l021_silent_when_slots_unchanged() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0])];
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("maker", true, true)],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("maker", true, true)],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L021));
+    }
+
+    // L022 tests --------------------------------------------------------------
+
+    #[test]
+    fn l022_fires_when_writable_flips() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0])];
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("vault", false, false)],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("vault", false, true)],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L022));
+    }
+
+    #[test]
+    fn l022_fires_when_signer_flips() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![0])];
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("authority", false, false)],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot("authority", true, false)],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L022));
+    }
+
+    // L023 tests --------------------------------------------------------------
+
+    #[test]
+    fn l023_fires_on_seed_change() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot_with_pda(
+                "escrow",
+                vec![SeedSnapshot::Const {
+                    bytes: b"escrow".to_vec(),
+                }],
+            )],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot_with_pda(
+                "escrow",
+                vec![SeedSnapshot::Const {
+                    bytes: b"vault".to_vec(),
+                }],
+            )],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L023));
+    }
+
+    #[test]
+    fn l023_silent_when_seeds_match() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        let seeds = vec![SeedSnapshot::Const {
+            bytes: b"escrow".to_vec(),
+        }];
+        old.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot_with_pda("escrow", seeds.clone())],
+        )];
+        new.accounts_structs = vec![accounts_struct(
+            "makeAccounts",
+            vec![slot_with_pda("escrow", seeds)],
+        )];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L023));
+    }
+
+    // L024 tests --------------------------------------------------------------
+
+    #[test]
+    fn l024_fires_when_instruction_discriminator_changes() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.instructions = vec![instruction("make", vec![0])];
+        new.instructions = vec![instruction("make", vec![7])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L024));
+    }
+
+    // L025 tests --------------------------------------------------------------
+
+    #[test]
+    fn l025_fires_when_account_struct_removed() {
+        let mut old = empty_snap();
+        let new = empty_snap();
+        old.accounts = vec![account("Escrow", vec![42], &[("a", "u64")])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L025));
+    }
+
+    #[test]
+    fn l025_silent_when_account_kept() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.accounts = vec![account("Escrow", vec![42], &[("a", "u64")])];
+        new.accounts = vec![account("Escrow", vec![42], &[("a", "u64")])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L025));
+    }
+
+    // L026 tests --------------------------------------------------------------
+
+    #[test]
+    fn l026_fires_when_event_discriminator_changes() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.events = vec![event("EscrowMade", vec![1])];
+        new.events = vec![event("EscrowMade", vec![9])];
+        let diags = run_all(&old, &new);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L026));
+    }
+
+    #[test]
+    fn l026_silent_when_event_unchanged() {
+        let mut old = empty_snap();
+        let mut new = empty_snap();
+        old.events = vec![event("EscrowMade", vec![1])];
+        new.events = vec![event("EscrowMade", vec![1])];
+        let diags = run_all(&old, &new);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L026));
     }
 }

--- a/idl/src/lint/mod.rs
+++ b/idl/src/lint/mod.rs
@@ -1,11 +1,14 @@
 //! Account relationship linter for Quasar programs.
 
+pub mod comparative;
 pub mod constraints;
 pub mod cross;
 pub mod fix;
 pub mod graph;
 pub mod output;
+pub mod preflight;
 pub mod rules;
+pub mod snapshot;
 pub mod types;
 pub mod viz;
 
@@ -37,6 +40,8 @@ pub fn run_lint(parsed: &ParsedProgram, _config: &LintConfig) -> LintReport {
 
     let cross_diags = cross::check_cross_instruction(parsed, &type_registry);
     diagnostics.extend(cross_diags);
+
+    preflight::run_all(parsed, &mut diagnostics);
 
     LintReport {
         diagnostics,

--- a/idl/src/lint/preflight.rs
+++ b/idl/src/lint/preflight.rs
@@ -1,0 +1,284 @@
+//! Preflight (single-build) upgrade-safety rules.
+//!
+//! These rules look at one parsed program and flag patterns that make
+//! future schema upgrades materially harder. They don't compare two
+//! builds — that's the diff family in [`super::comparative`]. Run them
+//! once per `quasar build` to get a "is this safe to deploy and evolve"
+//! verdict before the first mainnet push.
+//!
+//! Rule set: L010 (missing version field), L011 (missing reserved
+//! padding), L012 (account name collision with reserved Solana types).
+
+use {
+    super::types::{Diagnostic, LintRule, TypeRegistry},
+    crate::parser::{state::RawStateAccount, ParsedProgram},
+};
+
+/// Names a `#[account(discriminator)]` struct should not take. Each one
+/// either collides with a Quasar / SPL primitive (making tooling output
+/// ambiguous) or matches a Solana primitive type (making docs and error
+/// messages confusing).
+const RESERVED_ACCOUNT_NAMES: &[&str] = &[
+    "Account",
+    "AccountInfo",
+    "Address",
+    "Mint",
+    "Pubkey",
+    "Signer",
+    "System",
+    "SystemAccount",
+    "Token",
+    "TokenAccount",
+    "UncheckedAccount",
+];
+
+/// Run every preflight rule against `parsed` and append findings to
+/// `diagnostics`. Single-pass — none of the rules look at each other.
+pub fn run_all(parsed: &ParsedProgram, diagnostics: &mut Vec<Diagnostic>) {
+    for account in &parsed.state_accounts {
+        check_l010_missing_version_field(account, diagnostics);
+        check_l011_missing_reserved_padding(account, diagnostics);
+        check_l012_reserved_name_collision(account, diagnostics);
+    }
+    let _ = TypeRegistry::from_parsed; // reserved for future cross-rule context
+}
+
+// ---------------------------------------------------------------------------
+// L010 — account-missing-version-field
+// ---------------------------------------------------------------------------
+//
+// Borsh layouts have no in-band version tag. Without a leading `version: u8`
+// (or u16) field, a future layout change forces every reader to guess which
+// variant it's looking at by inference — usually they can't, and the program
+// has to migrate every account on its first read after the upgrade. Adding
+// a one-byte version up front is cheap at init and converts the worst-case
+// upgrade from "rewrite every account" to "match on version, deserialize".
+
+fn check_l010_missing_version_field(account: &RawStateAccount, diagnostics: &mut Vec<Diagnostic>) {
+    let Some((first_name, _)) = account.fields.first() else {
+        return;
+    };
+    if first_name == "version" {
+        return;
+    }
+    diagnostics.push(Diagnostic {
+        rule: LintRule::L010,
+        severity: LintRule::L010.default_severity(),
+        accounts_struct: account.name.clone(),
+        field: Some(first_name.clone()),
+        message: format!(
+            "account `{}` has no leading `version: u8` field; future schema changes can't branch \
+             on layout version at deserialize time",
+            account.name
+        ),
+        suggestion: Some(format!(
+            "Add `pub version: u8` (or u16) as the first field of `{}`. Initialise it to 1 on \
+             creation and bump on every layout change so `try_deserialize` can route old vs new \
+             bytes.",
+            account.name
+        )),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// L011 — account-missing-reserved-padding
+// ---------------------------------------------------------------------------
+//
+// Adding a field to a Borsh-serialized account changes its on-chain size,
+// so every existing account has to be reallocated (paid for, signed for)
+// before the new binary can read it. Trailing `_reserved: [u8; N]` padding
+// pre-pays that cost: the next field that fits inside the reserved bytes
+// is just a layout reinterpretation, no realloc needed. Without it, every
+// future field append becomes an Unsafe upgrade.
+
+fn check_l011_missing_reserved_padding(
+    account: &RawStateAccount,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some((last_name, last_ty)) = account.fields.last() else {
+        return;
+    };
+    if last_name == "_reserved" && is_fixed_byte_array(last_ty) {
+        return;
+    }
+    diagnostics.push(Diagnostic {
+        rule: LintRule::L011,
+        severity: LintRule::L011.default_severity(),
+        accounts_struct: account.name.clone(),
+        field: Some(last_name.clone()),
+        message: format!(
+            "account `{}` has no trailing `_reserved: [u8; N]` padding; every future field append \
+             needs a realloc or migration",
+            account.name
+        ),
+        suggestion: Some(format!(
+            "Add `pub _reserved: [u8; 64]` (or whatever fits the headroom you want) as the last \
+             field of `{}`. Cheap at init time, converts future appends from Unsafe to Additive.",
+            account.name
+        )),
+    });
+}
+
+fn is_fixed_byte_array(ty: &syn::Type) -> bool {
+    let syn::Type::Array(arr) = ty else {
+        return false;
+    };
+    let syn::Type::Path(elem) = arr.elem.as_ref() else {
+        return false;
+    };
+    elem.path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "u8")
+}
+
+// ---------------------------------------------------------------------------
+// L012 — reserved-name-collision
+// ---------------------------------------------------------------------------
+//
+// Naming a `#[account(...)]` struct after a well-known Solana / Quasar
+// primitive (Mint, Token, Pubkey, AccountInfo, etc.) makes tooling output
+// ambiguous — every `quasar lint` line, every error trace, every doc has
+// to disambiguate "which `Token` do you mean". Cheap to rename now,
+// painful to rename after the program is shipped and clients depend on
+// the type name.
+
+fn check_l012_reserved_name_collision(
+    account: &RawStateAccount,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if !RESERVED_ACCOUNT_NAMES.contains(&account.name.as_str()) {
+        return;
+    }
+    diagnostics.push(Diagnostic {
+        rule: LintRule::L012,
+        severity: LintRule::L012.default_severity(),
+        accounts_struct: account.name.clone(),
+        field: None,
+        message: format!(
+            "account struct named `{}` collides with a well-known Solana / Quasar type",
+            account.name
+        ),
+        suggestion: Some(format!(
+            "Rename `{}` to something program-specific (e.g. `My{}`). Cheaper to do before \
+             clients consume the type name.",
+            account.name, account.name
+        )),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::parser::{program::RawInstruction, state::RawStateAccount},
+    };
+
+    fn ty(s: &str) -> syn::Type {
+        syn::parse_str(s).unwrap()
+    }
+
+    fn account(name: &str, fields: &[(&str, &str)]) -> RawStateAccount {
+        RawStateAccount {
+            name: name.to_string(),
+            discriminator: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            fields: fields.iter().map(|(n, t)| (n.to_string(), ty(t))).collect(),
+            seeds: None,
+        }
+    }
+
+    fn parsed(state_accounts: Vec<RawStateAccount>) -> ParsedProgram {
+        ParsedProgram {
+            program_id: "11111111111111111111111111111111".to_string(),
+            program_name: "test".to_string(),
+            crate_name: "test".to_string(),
+            version: "0.1.0".to_string(),
+            instructions: Vec::<RawInstruction>::new(),
+            accounts_structs: vec![],
+            state_accounts,
+            events: vec![],
+            errors: vec![],
+            data_structs: vec![],
+        }
+    }
+
+    #[test]
+    fn l010_fires_when_first_field_is_not_version() {
+        let p = parsed(vec![account(
+            "Escrow",
+            &[("maker", "Pubkey"), ("amount", "u64")],
+        )]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L010));
+    }
+
+    #[test]
+    fn l010_silent_when_first_field_is_version() {
+        let p = parsed(vec![account(
+            "Escrow",
+            &[
+                ("version", "u8"),
+                ("maker", "Pubkey"),
+                ("_reserved", "[u8; 64]"),
+            ],
+        )]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L010));
+    }
+
+    #[test]
+    fn l011_fires_when_no_reserved_padding() {
+        let p = parsed(vec![account(
+            "Escrow",
+            &[("version", "u8"), ("amount", "u64")],
+        )]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L011));
+    }
+
+    #[test]
+    fn l011_silent_when_reserved_byte_array_present() {
+        let p = parsed(vec![account(
+            "Escrow",
+            &[
+                ("version", "u8"),
+                ("amount", "u64"),
+                ("_reserved", "[u8; 64]"),
+            ],
+        )]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L011));
+    }
+
+    #[test]
+    fn l011_fires_when_reserved_field_is_wrong_type() {
+        // `_reserved` is a Pubkey, not a `[u8; N]` — doesn't pre-pay realloc cost.
+        let p = parsed(vec![account(
+            "Escrow",
+            &[("amount", "u64"), ("_reserved", "Pubkey")],
+        )]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L011));
+    }
+
+    #[test]
+    fn l012_fires_for_reserved_name() {
+        let p = parsed(vec![account("Mint", &[("amount", "u64")])]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(diags.iter().any(|d| d.rule == LintRule::L012));
+    }
+
+    #[test]
+    fn l012_silent_for_program_specific_name() {
+        let p = parsed(vec![account("MyEscrow", &[("amount", "u64")])]);
+        let mut diags = Vec::new();
+        run_all(&p, &mut diags);
+        assert!(!diags.iter().any(|d| d.rule == LintRule::L012));
+    }
+}

--- a/idl/src/lint/snapshot.rs
+++ b/idl/src/lint/snapshot.rs
@@ -1,0 +1,384 @@
+//! Serializable snapshot of a Quasar program's lint-relevant surface.
+//!
+//! `quasar build` parses source into [`crate::parser::ParsedProgram`].
+//! That structure carries `syn::Type` trees for fields and args, which
+//! aren't serializable and contain a lot of data the diff rules don't
+//! care about. This module flattens it into a [`ProgramSnapshot`] —
+//! stringified types, only the fields each diff rule needs — and
+//! persists it as `quasar.lock.json` alongside the program crate.
+//!
+//! ## Invariants
+//!
+//! - **Field declaration order is preserved.** L013 (reorder), L016 (insert
+//!   middle), L017 (append) all depend on it; the snapshot captures fields as
+//!   ordered `Vec`s, never sets/maps.
+//! - **Type comparison is string-equality on the stringified `syn::Type`.**
+//!   Whitespace is normalized via `quote!` round-trip. This is good enough for
+//!   catching `u64 → u32`, `Pubkey → [u8; 32]`, etc., and intentionally fragile
+//!   for cosmetic differences (an alias rename shows as a retype — usually the
+//!   right call).
+//! - **Discriminators are byte-compared.** No semantic interpretation.
+//!
+//! ## Lock-file lifecycle
+//!
+//! The lock file is committed to source control. `quasar build` updates
+//! it (via an explicit flag, never silently). `quasar lint --diff`
+//! reads it and compares the current parse to the stored snapshot,
+//! producing an [`super::types::LintReport`] with L013–L026 findings.
+
+use {
+    crate::parser::{
+        accounts::{RawAccountField, RawAccountsStruct, RawPda, RawSeed},
+        events::RawEvent,
+        program::RawInstruction,
+        state::RawStateAccount,
+        ParsedProgram,
+    },
+    quote::ToTokens,
+    serde::{Deserialize, Serialize},
+    std::{
+        io,
+        path::{Path, PathBuf},
+    },
+};
+
+/// Default file name for the persisted snapshot — committed alongside
+/// the program crate's `Cargo.toml`.
+pub const LOCK_FILE_NAME: &str = "quasar.lock.json";
+
+/// Schema version for `quasar.lock.json`. Bump on any breaking change
+/// to the snapshot shape so old lock files surface a clean error
+/// rather than silently mis-comparing.
+pub const SNAPSHOT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProgramSnapshot {
+    pub version: u32,
+    pub program_id: String,
+    pub program_name: String,
+    pub accounts: Vec<AccountSnapshot>,
+    pub instructions: Vec<InstructionSnapshot>,
+    pub events: Vec<EventSnapshot>,
+    pub accounts_structs: Vec<AccountsStructSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountSnapshot {
+    pub name: String,
+    pub discriminator: Vec<u8>,
+    /// Ordered field list. Order is load-bearing for the reorder /
+    /// insert / append rules.
+    pub fields: Vec<NamedTypeSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstructionSnapshot {
+    pub name: String,
+    pub discriminator: Vec<u8>,
+    /// Argument list in declaration order.
+    pub args: Vec<NamedTypeSnapshot>,
+    pub accounts_type_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EventSnapshot {
+    pub name: String,
+    pub discriminator: Vec<u8>,
+    pub fields: Vec<NamedTypeSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountsStructSnapshot {
+    pub name: String,
+    pub fields: Vec<AccountSlotSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountSlotSnapshot {
+    pub name: String,
+    pub writable: bool,
+    pub signer: bool,
+    pub pda: Option<PdaSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PdaSnapshot {
+    pub seeds: Vec<SeedSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SeedSnapshot {
+    Const { bytes: Vec<u8> },
+    Account { name: String },
+    Arg { name: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NamedTypeSnapshot {
+    pub name: String,
+    /// Stringified `syn::Type`. Compared by string equality at diff
+    /// time — see module docs for the rationale.
+    pub ty: String,
+}
+
+/// Resolve `quasar.lock.json` for a program crate path. Always pinned
+/// to `LOCK_FILE_NAME` at the crate root so devs can find / inspect /
+/// review it without flag spelunking.
+pub fn lock_path(crate_root: &Path) -> PathBuf {
+    crate_root.join(LOCK_FILE_NAME)
+}
+
+/// Errors from lock-file IO. Distinguishes "no lock yet" (a benign
+/// state for fresh projects — caller should suggest `--update-lock`)
+/// from real parse / version-mismatch failures.
+#[derive(Debug)]
+pub enum SnapshotIoError {
+    NotFound(PathBuf),
+    Io(io::Error),
+    Parse(serde_json::Error),
+    VersionMismatch { expected: u32, found: u32 },
+}
+
+impl std::fmt::Display for SnapshotIoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(p) => write!(
+                f,
+                "no lock file at {} — run `quasar lint --update-lock` to create one",
+                p.display()
+            ),
+            Self::Io(e) => write!(f, "reading lock file: {e}"),
+            Self::Parse(e) => write!(f, "parsing lock file: {e}"),
+            Self::VersionMismatch { expected, found } => write!(
+                f,
+                "lock file schema version {found} doesn't match expected {expected}; regenerate \
+                 with `quasar lint --update-lock`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotIoError {}
+
+impl ProgramSnapshot {
+    /// Project a freshly-parsed `ParsedProgram` into a serializable
+    /// snapshot. Pure function — no I/O.
+    pub fn from_parsed(parsed: &ParsedProgram) -> Self {
+        Self {
+            version: SNAPSHOT_VERSION,
+            program_id: parsed.program_id.clone(),
+            program_name: parsed.program_name.clone(),
+            accounts: parsed
+                .state_accounts
+                .iter()
+                .map(AccountSnapshot::from_raw)
+                .collect(),
+            instructions: parsed
+                .instructions
+                .iter()
+                .map(InstructionSnapshot::from_raw)
+                .collect(),
+            events: parsed.events.iter().map(EventSnapshot::from_raw).collect(),
+            accounts_structs: parsed
+                .accounts_structs
+                .iter()
+                .map(AccountsStructSnapshot::from_raw)
+                .collect(),
+        }
+    }
+
+    /// Read a snapshot from disk. Validates the schema version up
+    /// front — a mismatch produces a clear error rather than running
+    /// rules against incompatible bytes.
+    pub fn load(path: &Path) -> Result<Self, SnapshotIoError> {
+        if !path.exists() {
+            return Err(SnapshotIoError::NotFound(path.to_path_buf()));
+        }
+        let bytes = std::fs::read(path).map_err(SnapshotIoError::Io)?;
+        let snap: Self = serde_json::from_slice(&bytes).map_err(SnapshotIoError::Parse)?;
+        if snap.version != SNAPSHOT_VERSION {
+            return Err(SnapshotIoError::VersionMismatch {
+                expected: SNAPSHOT_VERSION,
+                found: snap.version,
+            });
+        }
+        Ok(snap)
+    }
+
+    /// Write the snapshot to disk as pretty-printed JSON. Pretty
+    /// rather than compact so review diffs in source control are
+    /// human-readable — the file size is small enough that it doesn't
+    /// matter.
+    pub fn save(&self, path: &Path) -> Result<(), SnapshotIoError> {
+        let body = serde_json::to_string_pretty(self).map_err(SnapshotIoError::Parse)?;
+        std::fs::write(path, body).map_err(SnapshotIoError::Io)?;
+        Ok(())
+    }
+}
+
+impl AccountSnapshot {
+    fn from_raw(raw: &RawStateAccount) -> Self {
+        Self {
+            name: raw.name.clone(),
+            discriminator: raw.discriminator.clone(),
+            fields: raw
+                .fields
+                .iter()
+                .map(NamedTypeSnapshot::from_pair)
+                .collect(),
+        }
+    }
+}
+
+impl InstructionSnapshot {
+    fn from_raw(raw: &RawInstruction) -> Self {
+        Self {
+            name: raw.name.clone(),
+            discriminator: raw.discriminator.clone(),
+            args: raw.args.iter().map(NamedTypeSnapshot::from_pair).collect(),
+            accounts_type_name: raw.accounts_type_name.clone(),
+        }
+    }
+}
+
+impl EventSnapshot {
+    fn from_raw(raw: &RawEvent) -> Self {
+        Self {
+            name: raw.name.clone(),
+            discriminator: raw.discriminator.clone(),
+            fields: raw
+                .fields
+                .iter()
+                .map(NamedTypeSnapshot::from_pair)
+                .collect(),
+        }
+    }
+}
+
+impl AccountsStructSnapshot {
+    fn from_raw(raw: &RawAccountsStruct) -> Self {
+        Self {
+            name: raw.name.clone(),
+            fields: raw
+                .fields
+                .iter()
+                .map(AccountSlotSnapshot::from_raw)
+                .collect(),
+        }
+    }
+}
+
+impl AccountSlotSnapshot {
+    fn from_raw(raw: &RawAccountField) -> Self {
+        Self {
+            name: raw.name.clone(),
+            writable: raw.writable,
+            signer: raw.signer,
+            pda: raw.pda.as_ref().map(PdaSnapshot::from_raw),
+        }
+    }
+}
+
+impl PdaSnapshot {
+    fn from_raw(raw: &RawPda) -> Self {
+        Self {
+            seeds: raw.seeds.iter().map(SeedSnapshot::from_raw).collect(),
+        }
+    }
+}
+
+impl SeedSnapshot {
+    fn from_raw(raw: &RawSeed) -> Self {
+        match raw {
+            RawSeed::ByteString(b) => SeedSnapshot::Const { bytes: b.clone() },
+            RawSeed::AccountRef(n) => SeedSnapshot::Account { name: n.clone() },
+            RawSeed::ArgRef(n) => SeedSnapshot::Arg { name: n.clone() },
+        }
+    }
+}
+
+impl NamedTypeSnapshot {
+    fn from_pair((name, ty): &(String, syn::Type)) -> Self {
+        Self {
+            name: name.clone(),
+            ty: stringify_type(ty),
+        }
+    }
+}
+
+/// Render a `syn::Type` to its canonical string form. Goes via
+/// `quote`'s `ToTokens` impl so whitespace is normalized — `Vec<u8>`
+/// and `Vec < u8 >` hash to the same string.
+fn stringify_type(ty: &syn::Type) -> String {
+    ty.to_token_stream().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ty(s: &str) -> syn::Type {
+        syn::parse_str(s).unwrap()
+    }
+
+    fn make_account(name: &str, fields: &[(&str, &str)], disc: Vec<u8>) -> RawStateAccount {
+        RawStateAccount {
+            name: name.to_string(),
+            discriminator: disc,
+            fields: fields.iter().map(|(n, t)| (n.to_string(), ty(t))).collect(),
+            seeds: None,
+        }
+    }
+
+    fn parsed_with(state_accounts: Vec<RawStateAccount>) -> ParsedProgram {
+        ParsedProgram {
+            program_id: "11111111111111111111111111111111".to_string(),
+            program_name: "test".to_string(),
+            crate_name: "test".to_string(),
+            version: "0.1.0".to_string(),
+            instructions: vec![],
+            accounts_structs: vec![],
+            state_accounts,
+            events: vec![],
+            errors: vec![],
+            data_structs: vec![],
+        }
+    }
+
+    #[test]
+    fn snapshot_preserves_field_order() {
+        let p = parsed_with(vec![make_account(
+            "Escrow",
+            &[("a", "u64"), ("b", "Pubkey"), ("c", "u8")],
+            vec![1],
+        )]);
+        let snap = ProgramSnapshot::from_parsed(&p);
+        let names: Vec<&str> = snap.accounts[0]
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn snapshot_normalizes_whitespace_in_types() {
+        // `Vec<u8>` and `Vec < u8 >` both parse and stringify to the
+        // same canonical form.
+        let p1 = parsed_with(vec![make_account("X", &[("v", "Vec<u8>")], vec![1])]);
+        let p2 = parsed_with(vec![make_account("X", &[("v", "Vec < u8 >")], vec![1])]);
+        let s1 = ProgramSnapshot::from_parsed(&p1);
+        let s2 = ProgramSnapshot::from_parsed(&p2);
+        assert_eq!(s1.accounts[0].fields[0].ty, s2.accounts[0].fields[0].ty);
+    }
+
+    #[test]
+    fn snapshot_round_trips_through_json() {
+        let p = parsed_with(vec![make_account("X", &[("v", "u64")], vec![42])]);
+        let snap = ProgramSnapshot::from_parsed(&p);
+        let json = serde_json::to_string(&snap).unwrap();
+        let back: ProgramSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snap, back);
+    }
+}

--- a/idl/src/lint/types.rs
+++ b/idl/src/lint/types.rs
@@ -3,8 +3,15 @@
 use std::collections::HashMap;
 
 /// Lint rule identifier.
+///
+/// L001–L009 are the original account-relationship rules — single-build
+/// graph integrity checks. L010+ are the upgrade-safety extension
+/// (preflight + cross-build diff). The two families share the same
+/// `Diagnostic` / `LintReport` plumbing; the diff family runs through
+/// the parallel `comparative` entry point with two `ParsedProgram`s.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LintRule {
+    // --- L001–L009: account-relationship rules (single build) -----------
     L001, // Disconnected account (island)
     L002, // Disconnected subgraph
     L003, // Missing has_one
@@ -13,6 +20,29 @@ pub enum LintRule {
     L006, // Writable without authority
     L007, // Unchecked account without validation
     L009, // Cross-instruction unverified field
+
+    // --- L010+: preflight + cross-build upgrade-safety rules -------------
+    //
+    // Preflight (single-build readiness):
+    L010, // Account missing `version: u8` prefix field
+    L011, // Account missing `_reserved: [u8; N]` trailing padding
+    L012, // Account name collides with a well-known Solana type
+
+    // Cross-build diff (compares last release's surface to the candidate):
+    L013, // Account field reorder
+    L014, // Account field retype
+    L015, // Account field removed
+    L016, // Account field inserted mid-list
+    L017, // Account field appended (needs realloc)
+    L018, // Account discriminator change
+    L019, // Instruction removed
+    L020, // Instruction argument signature change
+    L021, // Instruction account-list change
+    L022, // Instruction signer/writable flag flip
+    L023, // PDA seed change (field-path precision limited; see rule doc)
+    L024, // Instruction discriminator change
+    L025, // Account struct removed
+    L026, // Event discriminator change
 }
 
 impl LintRule {
@@ -26,13 +56,58 @@ impl LintRule {
             Self::L006 => "L006",
             Self::L007 => "L007",
             Self::L009 => "L009",
+            Self::L010 => "L010",
+            Self::L011 => "L011",
+            Self::L012 => "L012",
+            Self::L013 => "L013",
+            Self::L014 => "L014",
+            Self::L015 => "L015",
+            Self::L016 => "L016",
+            Self::L017 => "L017",
+            Self::L018 => "L018",
+            Self::L019 => "L019",
+            Self::L020 => "L020",
+            Self::L021 => "L021",
+            Self::L022 => "L022",
+            Self::L023 => "L023",
+            Self::L024 => "L024",
+            Self::L025 => "L025",
+            Self::L026 => "L026",
         }
     }
 
     pub fn default_severity(&self) -> Severity {
         match self {
+            // Existing rules
             Self::L001 | Self::L003 | Self::L004 => Severity::Error,
             Self::L002 | Self::L005 | Self::L006 | Self::L007 | Self::L009 => Severity::Warning,
+
+            // Preflight: missing-version / missing-padding are deploy-time
+            // landmines for any future schema change, but the program
+            // itself is valid today. Warning, not Error.
+            Self::L010 | Self::L011 => Severity::Warning,
+            // Name collision is purely an ergonomics/tooling hazard.
+            Self::L012 => Severity::Warning,
+
+            // Cross-build breakage (corrupts on-chain state, breaks
+            // existing callers, orphans PDAs). All Error.
+            Self::L013
+            | Self::L014
+            | Self::L015
+            | Self::L016
+            | Self::L018
+            | Self::L019
+            | Self::L020
+            | Self::L021
+            | Self::L022
+            | Self::L023
+            | Self::L024
+            | Self::L025
+            | Self::L026 => Severity::Error,
+            // Append needs a realloc on existing accounts but isn't
+            // automatically corrupting — Warning so devs see it without
+            // failing a build that's intentionally adding migration code.
+            Self::L017 => Severity::Warning,
         }
     }
 
@@ -46,6 +121,23 @@ impl LintRule {
             Self::L006 => "quasar::writable_no_authority",
             Self::L007 => "quasar::unchecked_account",
             Self::L009 => "quasar::cross_instruction",
+            Self::L010 => "quasar::missing_version_field",
+            Self::L011 => "quasar::missing_reserved_padding",
+            Self::L012 => "quasar::reserved_name_collision",
+            Self::L013 => "quasar::field_reorder",
+            Self::L014 => "quasar::field_retype",
+            Self::L015 => "quasar::field_removed",
+            Self::L016 => "quasar::field_insert_middle",
+            Self::L017 => "quasar::field_append",
+            Self::L018 => "quasar::account_discriminator_change",
+            Self::L019 => "quasar::instruction_removed",
+            Self::L020 => "quasar::instruction_arg_change",
+            Self::L021 => "quasar::instruction_account_list_change",
+            Self::L022 => "quasar::instruction_signer_writable_flip",
+            Self::L023 => "quasar::pda_seed_change",
+            Self::L024 => "quasar::instruction_discriminator_change",
+            Self::L025 => "quasar::account_removed",
+            Self::L026 => "quasar::event_discriminator_change",
         }
     }
 }

--- a/idl/tests/lint.rs
+++ b/idl/tests/lint.rs
@@ -15,6 +15,31 @@ fn has_diagnostic(report: &lint::LintReport, rule: LintRule, field: &str) -> boo
         .any(|d| d.rule == rule && d.field.as_deref() == Some(field))
 }
 
+/// Filter to the L001–L009 account-relationship rules. The preflight
+/// family (L010+) fires on any account that lacks a `version` prefix
+/// or `_reserved` padding — that's by design but means tests asserting
+/// "no graph findings" need to ignore preflight noise from minimal
+/// fixtures.
+fn graph_diagnostics(report: &lint::LintReport) -> Vec<&lint::Diagnostic> {
+    report
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.rule,
+                LintRule::L001
+                    | LintRule::L002
+                    | LintRule::L003
+                    | LintRule::L004
+                    | LintRule::L005
+                    | LintRule::L006
+                    | LintRule::L007
+                    | LintRule::L009
+            )
+        })
+        .collect()
+}
+
 #[test]
 fn lint_report_empty_for_constrained_program() {
     let src = r#"
@@ -46,10 +71,10 @@ fn lint_report_empty_for_constrained_program() {
 
     let parsed = quasar_idl::parser::parse_program_from_source(src);
     let report = lint::run_lint(&parsed, &lint::LintConfig::default());
+    let graph = graph_diagnostics(&report);
     assert!(
-        report.diagnostics.is_empty(),
-        "expected no diagnostics, got: {:?}",
-        report.diagnostics
+        graph.is_empty(),
+        "expected no graph diagnostics, got: {graph:?}"
     );
 }
 
@@ -192,10 +217,10 @@ fn l001_no_false_positive_for_signers() {
         }
     "#,
     );
+    let graph = graph_diagnostics(&report);
     assert!(
-        report.diagnostics.is_empty(),
-        "expected no diagnostics, got: {:?}",
-        report.diagnostics
+        graph.is_empty(),
+        "expected no graph diagnostics, got: {graph:?}"
     );
 }
 

--- a/idl/tests/upgrade_safety.rs
+++ b/idl/tests/upgrade_safety.rs
@@ -1,0 +1,152 @@
+//! End-to-end integration tests for the upgrade-safety lint family.
+//!
+//! Exercises the full pipeline: parse → snapshot → persist to lock
+//! file → mutate the source → re-parse → diff against the saved
+//! snapshot → expect specific L-rule findings. Mirrors how `quasar
+//! lint --diff` runs in production but without the CLI / config
+//! resolution layer.
+
+use {
+    quasar_idl::{
+        lint::{
+            comparative, preflight,
+            snapshot::{ProgramSnapshot, SnapshotIoError, SNAPSHOT_VERSION},
+            LintRule,
+        },
+        parser,
+    },
+    tempfile::TempDir,
+};
+
+const ESCROW_V1: &str = r#"
+    declare_id!("11111111111111111111111111111111");
+
+    #[program]
+    mod escrow {
+        use super::*;
+
+        #[instruction(discriminator = [0])]
+        pub fn make(ctx: Ctx<Make>, deposit: u64, receive: u64) -> Result<(), ProgramError> {
+            Ok(())
+        }
+
+        #[instruction(discriminator = [1])]
+        pub fn refund(ctx: Ctx<Refund>) -> Result<(), ProgramError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Accounts)]
+    pub struct Make<'info> {
+        #[account(mut)]
+        pub maker: Signer<'info>,
+    }
+
+    #[derive(Accounts)]
+    pub struct Refund<'info> {
+        #[account(mut)]
+        pub maker: Signer<'info>,
+    }
+
+    #[account(discriminator = [42])]
+    pub struct Escrow {
+        pub maker: Pubkey,
+        pub mint_a: Pubkey,
+        pub deposit: u64,
+    }
+"#;
+
+#[test]
+fn snapshot_round_trips_through_lock_file() {
+    let parsed = parser::parse_program_from_source(ESCROW_V1);
+    let snap = ProgramSnapshot::from_parsed(&parsed);
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("quasar.lock.json");
+    snap.save(&path).unwrap();
+
+    let loaded = ProgramSnapshot::load(&path).unwrap();
+    assert_eq!(snap, loaded);
+    assert_eq!(loaded.version, SNAPSHOT_VERSION);
+}
+
+#[test]
+fn load_missing_lock_file_is_distinguishable() {
+    let dir = TempDir::new().unwrap();
+    let err = ProgramSnapshot::load(&dir.path().join("missing.json")).unwrap_err();
+    matches!(err, SnapshotIoError::NotFound(_));
+}
+
+#[test]
+fn diff_against_identical_source_produces_no_findings() {
+    let parsed = parser::parse_program_from_source(ESCROW_V1);
+    let old = ProgramSnapshot::from_parsed(&parsed);
+    let new = ProgramSnapshot::from_parsed(&parsed);
+    let diags = comparative::run_all(&old, &new);
+    assert!(diags.is_empty(), "unexpected findings: {diags:?}");
+}
+
+#[test]
+fn removing_instruction_fires_l019() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    let v2_src = ESCROW_V1.replace(
+        r#"#[instruction(discriminator = [1])]
+        pub fn refund(ctx: Ctx<Refund>) -> Result<(), ProgramError> {
+            Ok(())
+        }"#,
+        "",
+    );
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(diags.iter().any(|d| d.rule == LintRule::L019));
+}
+
+#[test]
+fn flipping_account_discriminator_fires_l018() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    let v2_src = ESCROW_V1.replace("discriminator = [42]", "discriminator = [99]");
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(diags.iter().any(|d| d.rule == LintRule::L018));
+}
+
+#[test]
+fn reordering_account_fields_fires_l013() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    let v2_src = ESCROW_V1.replace(
+        "pub maker: Pubkey,\n        pub mint_a: Pubkey,\n        pub deposit: u64,",
+        "pub deposit: u64,\n        pub maker: Pubkey,\n        pub mint_a: Pubkey,",
+    );
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(
+        diags.iter().any(|d| d.rule == LintRule::L013),
+        "expected L013, got {:?}",
+        diags.iter().map(|d| d.rule).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn preflight_fires_on_escrow_v1_missing_version_and_padding() {
+    let parsed = parser::parse_program_from_source(ESCROW_V1);
+    let mut diags = Vec::new();
+    preflight::run_all(&parsed, &mut diags);
+    let rules: Vec<LintRule> = diags.iter().map(|d| d.rule).collect();
+    assert!(
+        rules.contains(&LintRule::L010),
+        "expected L010 in {rules:?}"
+    );
+    assert!(
+        rules.contains(&LintRule::L011),
+        "expected L011 in {rules:?}"
+    );
+}

--- a/idl/tests/upgrade_safety.rs
+++ b/idl/tests/upgrade_safety.rs
@@ -136,6 +136,66 @@ fn reordering_account_fields_fires_l013() {
 }
 
 #[test]
+fn retyping_account_field_fires_l014() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    // deposit: u64 → u32 — Borsh layout shifts every later offset.
+    let v2_src = ESCROW_V1.replace("pub deposit: u64,", "pub deposit: u32,");
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(
+        diags.iter().any(|d| d.rule == LintRule::L014),
+        "expected L014, got {:?}",
+        diags.iter().map(|d| d.rule).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn appending_account_field_fires_l017_warning_not_l016() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    let v2_src = ESCROW_V1.replace(
+        "pub deposit: u64,\n    }",
+        "pub deposit: u64,\n        pub bump: u8,\n    }",
+    );
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(
+        diags.iter().any(|d| d.rule == LintRule::L017),
+        "expected L017 (append warning), got {:?}",
+        diags.iter().map(|d| d.rule).collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.rule == LintRule::L016),
+        "should not fire L016 (mid-list insert) on a tail append"
+    );
+}
+
+#[test]
+fn changing_instruction_arg_type_fires_l020() {
+    let v1 = parser::parse_program_from_source(ESCROW_V1);
+    // make's `receive` arg flips u64 → u32.
+    let v2_src = ESCROW_V1.replace(
+        "pub fn make(ctx: Ctx<Make>, deposit: u64, receive: u64)",
+        "pub fn make(ctx: Ctx<Make>, deposit: u64, receive: u32)",
+    );
+    let v2 = parser::parse_program_from_source(&v2_src);
+
+    let old = ProgramSnapshot::from_parsed(&v1);
+    let new = ProgramSnapshot::from_parsed(&v2);
+    let diags = comparative::run_all(&old, &new);
+    assert!(
+        diags.iter().any(|d| d.rule == LintRule::L020),
+        "expected L020, got {:?}",
+        diags.iter().map(|d| d.rule).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn preflight_fires_on_escrow_v1_missing_version_and_padding() {
     let parsed = parser::parse_program_from_source(ESCROW_V1);
     let mut diags = Vec::new();


### PR DESCRIPTION
Refs #186 — first slice of the upgrade-safety rule family. Vendored, not imported. Scope per the design conversation in #186 (numbering extends L-series, lock-file diff UX, split PR cadence, severity map).

## What's in this PR

Two new rule families slotting into the existing `idl/src/lint/` module:

### Preflight (single-build) — fires during `quasar lint` / `quasar build --lint`
- **L010** — account missing `version: u8` prefix field
- **L011** — account missing trailing `_reserved: [u8; N]` padding
- **L012** — account name collides with a well-known Solana / Quasar type (Mint, Token, Pubkey, Signer, etc.)

### Cross-build diff — fires under `quasar lint --diff`
- **L013** — account field reorder (Borsh layout corruption)
- **L018** — account discriminator change (orphans every existing account)
- **L019** — instruction removed (breaks every existing client)

Cross-build pipeline:

```bash
# After a release: baseline the surface
quasar lint --update-lock          # writes quasar.lock.json

# Before the next release: diff candidate against last shipped surface
quasar lint --diff                 # runs L013+ in addition to L001-L012
```

The lock file is committed to source control — diffs are reviewable, no \"trust me\" magic.

## Why split

This PR ships the diff infrastructure (snapshot type, lock-file IO, `comparative` entry point, CLI plumbing) plus three representative R-rules. The remaining R-rules (L014-L017, L020-L026) are pure rule logic that follows the same mechanical pattern — each lands as a single function appended to `comparative::run_all` in subsequent PRs. Splitting keeps this review focused on the architectural pieces (lock-file shape, snapshot invariants, diff entry point) without the noise of 13 more near-identical rule implementations.

## Out of scope, tracked

- **R011/R012-equivalent (enum variant rules)** — Quasar's `IdlTypeDefKind` is `Struct`-only at the schema layer. Enum-variant diffs need an upstream schema + parser change. Tracked as future work, not blocking this PR.
- **L023 PDA seed change with full struct-field-path precision** — `RawSeed::AccountRef` carries an account name but not a nested struct-field path. When L023 lands, it'll ship with reduced precision (still catches major changes, documented limitation).

## Design defaults applied (from #186)

1. **Numbering** — extended L-series (L010+). One namespace, no separate prefix.
2. **Diff UX** — `quasar.lock.json` committed to source control, regenerated explicitly via `--update-lock`. Cargo-style. Architected so swapping to a `--diff <git-ref>` mode later is ~50 LOC of plumbing — the rules don't move.
3. **PR shape** — split. This is the infra + 3+3 starter rules; R-rule completion follows.
4. **Severity** — direct map. Cross-build breakage → `Error`. Preflight landmines → `Warning` (program is valid today, just harder to evolve). L017 (append) → `Warning` because devs intentionally adding migration code shouldn't fail the build.

Each is a default chosen for low cost-of-flip later, not a lock-in. Happy to redirect any of them.

## Files

| File | Change |
|---|---|
| `idl/src/lint/types.rs` | Extend `LintRule` with L010–L026; map each to `code()`, `default_severity()`, `suppression_attr()` |
| `idl/src/lint/preflight.rs` | **New** — L010/L011/L012 single-build rules + 7 unit tests |
| `idl/src/lint/snapshot.rs` | **New** — `ProgramSnapshot` serializable IR + `quasar.lock.json` IO + 3 unit tests |
| `idl/src/lint/comparative.rs` | **New** — `comparative::run_all(old, new)` entry + L013/L018/L019 diff rules + 9 unit tests |
| `idl/src/lint/mod.rs` | Wire preflight into `run_lint`; register `comparative` + `snapshot` modules |
| `idl/tests/upgrade_safety.rs` | **New** — 7 integration tests exercising parse → snapshot → save → mutate → diff |
| `idl/tests/lint.rs` | Existing \"no diagnostics\" assertions narrowed to graph rules (L001–L009) so preflight noise on minimal fixtures doesn't regress them |
| `cli/src/lib.rs` | Add `--diff` and `--update-lock` flags to `LintCommand` |
| `cli/src/lint.rs` | Wire flags through: load/save lock file, fold cross-build findings into report |
| `idl/Cargo.toml` | `quote = \"1\"` (already transitive via syn — explicit for clarity); `tempfile` dev-dep |
| `Cargo.lock` | Resolve new deps |

Total: +1336 LOC, -8 LOC.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo +nightly clippy --all --all-features --all-targets -- -D warnings`
- [x] `cargo +nightly test -p quasar-idl` — 149/149 (51 lib + 18 graph + 73 viz/parser + 7 upgrade-safety integration)
- [x] `cargo +nightly check --workspace`
- [x] Workspace lint opt-in (`[lints] workspace = true`) — no new manifests
- [x] No new `panic!` / `unreachable!` / `todo!` / `unimplemented!` in runtime code
- [x] End-to-end CLI: `quasar lint --update-lock` writes lock; mutated source + `--diff` fires expected L-rules

Pre-existing test failures on `master` (`pinocchio-vault`, `quasar-escrow` — both need built `.so` artifacts) were verified independent of this PR by re-running on `upstream/master`.

## Reviewer focus

Since this is a scaffold PR, the architectural pieces are the higher-leverage review surface than the three rules themselves:

1. **`ProgramSnapshot` shape** (`snapshot.rs`) — what gets serialized vs. dropped, type-stringification approach (`quote::ToTokens` round-trip), schema versioning.
2. **`comparative::run_all` signature** — should it return `Vec<Diagnostic>` (current) or take `&mut Vec<Diagnostic>` like the existing `rules::run_all`?
3. **Severity defaults** — particularly L017 (append) as `Warning` rather than `Error`. Open to flipping.
4. **Suppression attribute names** (`quasar::field_reorder`, `quasar::account_discriminator_change`, etc.) — naming conventions should match existing `quasar::unconstrained` style.

Marked as draft so we can iterate on any of those before locking the shape.