### PR TITLE
fix: unify SPL wrappers, migrate lint attrs, IDL completeness

### DIFF
--- a/derive/src/accounts/resolve/lower.rs
+++ b/derive/src/accounts/resolve/lower.rs
@@ -121,6 +121,7 @@ fn lower_directives(sem: &mut FieldSemantics, directives: Vec<Directive>) -> syn
             Directive::Realloc(expr) => {
                 sem.realloc = Some(expr);
             }
+            Directive::Allow(_) => { /* lint-only, ignored by derive */ }
             Directive::Group(group) => {
                 groups.push(group);
             }

--- a/derive/src/accounts/syntax/attrs.rs
+++ b/derive/src/accounts/syntax/attrs.rs
@@ -1,13 +1,14 @@
 //! V3 directive parser for `#[account(...)]` attributes.
 //!
 //! Grammar:
-//!   directive ::= bare_flag | init | key_value | group | check
+//!   directive ::= bare_flag | init | key_value | group | check | allow
 //!   bare_flag ::= 'mut' | 'dup'
 //!   init      ::= 'init' | 'init' '(' 'idempotent' ')'
 //!   key_value ::= 'payer' '=' ident | 'address' '=' expr | 'realloc' '=' expr
 //!   group     ::= path '(' args ')'
 //!   check     ::= 'has_one' '(' ident_list ')' | 'constraints' '(' expr_list
-//! ')'   args      ::= (ident '=' expr),*
+//! ')'   allow     ::= 'allow' '(' ident_list ')'
+//!   args      ::= (ident '=' expr),*
 //!
 //! Phase placement is NOT part of the user syntax. No `pre(...)` or
 //! `exit(...)`. The lowering layer decides which phases each op participates
@@ -23,10 +24,16 @@ use {
 
 pub(crate) enum Directive {
     Bare(Ident),
-    Init { idempotent: bool },
+    Init {
+        idempotent: bool,
+    },
     Payer(Ident),
     Address(syn::Expr, Option<syn::Expr>),
     Realloc(syn::Expr),
+    /// `allow(unconstrained, ...)` — lint suppression, consumed by the linter
+    /// only. The derive macro ignores these during lowering.
+    #[allow(dead_code)]
+    Allow(Vec<Ident>),
     Group(GroupDirective),
     Check(UserCheck),
 }
@@ -112,6 +119,14 @@ impl Parse for ParsedDirective {
                     };
                     return Ok(ParsedDirective {
                         inner: Directive::Init { idempotent },
+                    });
+                }
+
+                // Lint suppressions: allow(unconstrained, ...)
+                "allow" => {
+                    let idents = parse_ident_list(&content)?;
+                    return Ok(ParsedDirective {
+                        inner: Directive::Allow(idents),
                     });
                 }
 

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -122,8 +122,11 @@ fn describe_accounts(
                 name: sem.core.ident.to_string(),
                 writable: sem.is_writable(),
                 signer: is_signer || client_requires_signer(sem),
+                optional: sem.core.optional,
+                docs: vec![],
                 pda: None, // PDA info now opaque via AddressVerify
                 address: known_address(ty, is_program, is_sysvar).map(str::to_owned),
+                relations: vec![],
                 migration: None,
             }
         })

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -453,6 +453,15 @@ fn pod_alias_type(ty: &Type, accept_pod_aliases: bool) -> Option<proc_macro2::To
                 if accept_pod_aliases {
                     return Some(quote! { quasar_lang::pod::PodVec });
                 }
+            } else if seg.ident == "Option" {
+                // Recursively unwrap Option<T> and apply pod alias to inner type.
+                if let PathArguments::AngleBracketed(ab) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = ab.args.first() {
+                        if let Some(inner_pod) = pod_alias_type(inner, accept_pod_aliases) {
+                            return Some(quote! { Option<#inner_pod> });
+                        }
+                    }
+                }
             }
         }
     }

--- a/idl/src/lint/constraints.rs
+++ b/idl/src/lint/constraints.rs
@@ -95,26 +95,12 @@ pub fn classify_field_type(ty: &syn::Type) -> (FieldClass, Option<String>) {
     }
 }
 
-/// Parse all `#[account(...)]` and `#[allow(quasar::*)]` attributes on a field.
+/// Parse all `#[account(...)]` attributes on a field, including
+/// `allow(...)` lint suppressions within the `#[account(...)]` block.
 pub fn parse_field_constraints(attrs: &[syn::Attribute]) -> FieldConstraints {
     let mut c = FieldConstraints::default();
 
     for attr in attrs {
-        // Parse #[allow(quasar::...)] suppressions
-        if attr.path().is_ident("allow") {
-            if let Ok(list) = attr.meta.require_list() {
-                let tokens_str = list.tokens.to_string();
-                for part in tokens_str.split(',') {
-                    // Normalize spaces around `::` that syn inserts
-                    let normalized: String = part.split_whitespace().collect::<Vec<_>>().join("");
-                    if normalized.starts_with("quasar::") {
-                        c.suppressions.push(normalized);
-                    }
-                }
-            }
-            continue;
-        }
-
         if !attr.path().is_ident("account") {
             continue;
         }
@@ -158,6 +144,19 @@ pub fn parse_field_constraints(attrs: &[syn::Attribute]) -> FieldConstraints {
                 c.seeds_account_refs.extend(refs);
             } else if d.starts_with("constraint") {
                 c.has_constraint = true;
+            } else if d.starts_with("allow") {
+                // Parse allow(unconstrained, ...) within #[account(...)]
+                if let Some(paren_start) = d.find('(') {
+                    if let Some(paren_end) = d.rfind(')') {
+                        let inner = &d[paren_start + 1..paren_end];
+                        for name in inner.split(',') {
+                            let name = name.trim();
+                            if !name.is_empty() {
+                                c.suppressions.push(name.to_string());
+                            }
+                        }
+                    }
+                }
             } else if d.starts_with("close") {
                 c.has_close = true;
             } else if d.starts_with("payer") {
@@ -503,10 +502,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_allow_suppression() {
+    fn parse_allow_suppression_in_account_attr() {
         let code = r#"
             pub struct Foo {
-                #[allow(quasar::unconstrained)]
+                #[account(mut, allow(unconstrained))]
                 pub x: u32,
             }
         "#;
@@ -516,11 +515,11 @@ mod tests {
                 let field = &fields.named[0];
                 let c = parse_field_constraints(&field.attrs);
                 assert!(
-                    c.suppressions
-                        .contains(&"quasar::unconstrained".to_string()),
-                    "expected quasar::unconstrained suppression, got: {:?}",
+                    c.suppressions.contains(&"unconstrained".to_string()),
+                    "expected unconstrained suppression from account attr, got: {:?}",
                     c.suppressions
                 );
+                assert!(c.is_mut, "mut directive should also be parsed");
             }
         }
     }

--- a/idl/src/lint/output.rs
+++ b/idl/src/lint/output.rs
@@ -99,7 +99,10 @@ fn print_diagnostics(report: &LintReport) {
             println!("    \u{2192} {}", suggestion);
         }
 
-        println!("    Suppress: #[allow({})]\n", diag.rule.suppression_attr());
+        println!(
+            "    Suppress: #[account(allow({}))]\n",
+            diag.rule.suppression_attr()
+        );
     }
 }
 

--- a/idl/src/lint/types.rs
+++ b/idl/src/lint/types.rs
@@ -38,14 +38,14 @@ impl LintRule {
 
     pub fn suppression_attr(&self) -> &'static str {
         match self {
-            Self::L001 => "quasar::unconstrained",
-            Self::L002 => "quasar::disconnected_graph",
-            Self::L003 => "quasar::missing_has_one",
-            Self::L004 => "quasar::unvalidated_mint",
-            Self::L005 => "quasar::unvalidated_authority",
-            Self::L006 => "quasar::writable_no_authority",
-            Self::L007 => "quasar::unchecked_account",
-            Self::L009 => "quasar::cross_instruction",
+            Self::L001 => "unconstrained",
+            Self::L002 => "disconnected_graph",
+            Self::L003 => "missing_has_one",
+            Self::L004 => "unvalidated_mint",
+            Self::L005 => "unvalidated_authority",
+            Self::L006 => "writable_no_authority",
+            Self::L007 => "unchecked_account",
+            Self::L009 => "cross_instruction",
         }
     }
 }

--- a/idl/src/parser/accounts.rs
+++ b/idl/src/parser/accounts.rs
@@ -21,6 +21,8 @@ pub struct RawAccountField {
     pub name: String,
     pub writable: bool,
     pub signer: bool,
+    pub optional: bool,
+    pub docs: Vec<String>,
     pub pda: Option<RawPda>,
     pub address: Option<String>,
     pub field_class: FieldClass,
@@ -138,6 +140,31 @@ fn parse_account_field(field: &syn::Field, parent: &syn::ItemStruct) -> RawAccou
         || has_writable_directive(&field.attrs)
         || migration.is_some();
 
+    // Detect Option<T> wrapping
+    let optional = helpers::type_base_name(&field.ty).as_deref() == Some("Option");
+
+    // Extract /// doc comments
+    let docs: Vec<String> = field
+        .attrs
+        .iter()
+        .filter(|a| a.path().is_ident("doc"))
+        .filter_map(|a| match &a.meta {
+            syn::Meta::NameValue(nv) => {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = &nv.value
+                {
+                    Some(s.value().trim().to_string())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+
     // Collect sibling field names for seed reference detection
     let sibling_names: Vec<String> = match &parent.fields {
         Fields::Named(named) => named
@@ -160,6 +187,8 @@ fn parse_account_field(field: &syn::Field, parent: &syn::ItemStruct) -> RawAccou
         name,
         writable,
         signer,
+        optional,
+        docs,
         pda,
         address,
         field_class,
@@ -536,12 +565,22 @@ fn to_idl_account_item(
             to: to.clone(),
         });
 
+    let relations: Vec<String> = field
+        .constraints
+        .has_ones
+        .iter()
+        .map(|s| helpers::to_camel_case(s))
+        .collect();
+
     IdlAccountItem {
         name: helpers::to_camel_case(&field.name),
         writable: field.writable,
         signer: field.signer,
+        optional: field.optional,
+        docs: field.docs.clone(),
         pda,
         address: field.address.clone(),
+        relations,
         migration,
     }
 }

--- a/idl/tests/lint.rs
+++ b/idl/tests/lint.rs
@@ -213,7 +213,7 @@ fn l001_suppressed_by_allow_attribute() {
         #[derive(Accounts)]
         pub struct S<'info> {
             pub authority: Signer,
-            #[allow(quasar::unconstrained)]
+            #[account(allow(unconstrained))]
             pub vault: Account<Vault<'info>>,
         }
         #[account(discriminator = 1)]

--- a/idl/tests/parser.rs
+++ b/idl/tests/parser.rs
@@ -768,6 +768,8 @@ fn rust_codegen_account_metas() {
             name: "Transfer".to_string(),
             fields: vec![
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "from".to_string(),
                     writable: true,
                     signer: true,
@@ -780,6 +782,8 @@ fn rust_codegen_account_metas() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "to".to_string(),
                     writable: true,
                     signer: false,
@@ -792,6 +796,8 @@ fn rust_codegen_account_metas() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "authority".to_string(),
                     writable: false,
                     signer: true,
@@ -1652,6 +1658,8 @@ fn ts_codegen_pda_helpers_are_exported_and_reused() {
         name: "Deposit".to_string(),
         fields: vec![
             RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "vault".to_string(),
                 writable: true,
                 signer: false,
@@ -1669,6 +1677,8 @@ fn ts_codegen_pda_helpers_are_exported_and_reused() {
                 migration: None,
             },
             RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "user".to_string(),
                 writable: false,
                 signer: true,
@@ -1732,6 +1742,8 @@ fn ts_codegen_pda_arg_seeds_are_encoded_by_type() {
     parsed.accounts_structs = vec![RawAccountsStruct {
         name: "Deposit".to_string(),
         fields: vec![RawAccountField {
+            optional: false,
+            docs: vec![],
             name: "vault".to_string(),
             writable: true,
             signer: false,
@@ -1811,6 +1823,8 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
             name: "Deposit".to_string(),
             fields: vec![
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "vault".to_string(),
                     writable: true,
                     signer: false,
@@ -1828,6 +1842,8 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "user".to_string(),
                     writable: false,
                     signer: true,
@@ -1845,6 +1861,8 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
             name: "Withdraw".to_string(),
             fields: vec![
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "escrow".to_string(),
                     writable: true,
                     signer: false,
@@ -1862,6 +1880,8 @@ fn ts_codegen_duplicate_seed_sets_reuse_one_helper_name() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "user".to_string(),
                     writable: false,
                     signer: true,
@@ -1923,6 +1943,8 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
             name: "Deposit".to_string(),
             fields: vec![
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "vault".to_string(),
                     writable: true,
                     signer: false,
@@ -1940,6 +1962,8 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "user".to_string(),
                     writable: false,
                     signer: true,
@@ -1957,6 +1981,8 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
             name: "Settle".to_string(),
             fields: vec![
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "vault".to_string(),
                     writable: true,
                     signer: false,
@@ -1974,6 +2000,8 @@ fn ts_codegen_helper_name_collisions_are_disambiguated() {
                     migration: None,
                 },
                 RawAccountField {
+                    optional: false,
+                    docs: vec![],
                     name: "user".to_string(),
                     writable: false,
                     signer: true,
@@ -2199,6 +2227,8 @@ fn rust_codegen_pda_helpers() {
         name: "Deposit".to_string(),
         fields: vec![
             RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "vault".to_string(),
                 writable: true,
                 signer: false,
@@ -2216,6 +2246,8 @@ fn rust_codegen_pda_helpers() {
                 migration: None,
             },
             RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "user".to_string(),
                 writable: false,
                 signer: true,
@@ -2272,6 +2304,8 @@ fn rust_codegen_pda_dedup() {
         RawAccountsStruct {
             name: "Deposit".to_string(),
             fields: vec![RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "vault".to_string(),
                 writable: true,
                 signer: false,
@@ -2287,6 +2321,8 @@ fn rust_codegen_pda_dedup() {
         RawAccountsStruct {
             name: "Withdraw".to_string(),
             fields: vec![RawAccountField {
+                optional: false,
+                docs: vec![],
                 name: "vault".to_string(),
                 writable: true,
                 signer: false,
@@ -2571,5 +2607,41 @@ fn rust_codegen_event_discriminator_no_stutter() {
     assert!(
         code.contains("ORDER_CANCELLED_EVENT_DISCRIMINATOR"),
         "{code}"
+    );
+}
+
+// ===========================================================================
+// Optional accounts — `Option<Account<T>>` emits `"optional": true` in IDL
+// ===========================================================================
+
+#[test]
+fn optional_account_emits_optional_flag() {
+    use quasar_idl::parser::accounts;
+
+    let file = parse_file(
+        r#"
+        #[derive(Accounts)]
+        pub struct TransferFunds {
+            pub payer: Signer,
+            #[account(mut)]
+            pub vault: Account<Vault>,
+            pub maybe_dest: Option<Account<Vault>>,
+        }
+        "#,
+    );
+
+    let structs = accounts::extract_accounts_structs(&file);
+    assert_eq!(structs.len(), 1);
+    let raw = &structs[0];
+    assert_eq!(raw.fields.len(), 3);
+
+    // payer (Signer) — not optional
+    assert!(!raw.fields[0].optional, "payer should not be optional");
+    // vault (Account<Vault>) — not optional
+    assert!(!raw.fields[1].optional, "vault should not be optional");
+    // maybe_dest (Option<Account<Vault>>) — optional
+    assert!(
+        raw.fields[2].optional,
+        "Option<Account<Vault>> should be optional"
     );
 }

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -1,6 +1,6 @@
 //! Dynamic CPI builder with runtime-tracked account and data lengths.
 //!
-//! `DynCpiCall` is the variable-length counterpart to [`super::CpiCall`].
+//! `CpiDynamic` is the variable-length counterpart to [`super::CpiCall`].
 //! Both accounts and data are backed by `MaybeUninit` stack arrays with
 //! compile-time capacity, while the active count is tracked at runtime.
 //! This replaces `BufCpiCall` which only supported variable data.
@@ -36,7 +36,7 @@ const _: () = assert!(!core::mem::needs_drop::<CpiAccount>());
 ///
 /// - `MAX_ACCTS`: maximum number of accounts (capacity, not initial count).
 /// - `MAX_DATA`: maximum byte length of instruction data.
-pub struct DynCpiCall<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> {
+pub struct CpiDynamic<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> {
     program_id: &'a Address,
     accounts: MaybeUninit<[InstructionAccount<'a>; MAX_ACCTS]>,
     cpi_accounts: MaybeUninit<[CpiAccount<'a>; MAX_ACCTS]>,
@@ -45,16 +45,21 @@ pub struct DynCpiCall<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> {
     data_len: usize,
 }
 
-impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> DynCpiCall<'a, MAX_ACCTS, MAX_DATA> {
+impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS, MAX_DATA> {
     // Compile-time stack overflow guard — fires at monomorphization time.
     // InstructionAccount is 24 bytes, CpiAccount is 56 bytes, plus data +
     // bookkeeping.
     const _STACK_CHECK: () = assert!(
         56 * MAX_ACCTS + 24 * MAX_ACCTS + MAX_DATA + 24 <= 3072,
-        "DynCpiCall exceeds safe 3 KiB stack budget for SVM 4 KiB frames"
+        "CpiDynamic exceeds safe 3 KiB stack budget for SVM 4 KiB frames"
     );
 
     /// Create a new builder targeting the given program.
+    ///
+    /// Includes a compile-time assertion that the monomorphized struct fits
+    /// within the SVM 3 KiB safe stack budget. Use
+    /// [`new_unchecked`](Self::new_unchecked) to bypass this check when you
+    /// manage stack usage yourself.
     #[inline(always)]
     pub fn new(program_id: &'a Address) -> Self {
         // Force compile-time stack size check.
@@ -63,6 +68,26 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> DynCpiCall<'a, MAX_ACCTS
         Self {
             program_id,
             // Stable MaybeUninit pattern (not nightly uninit_array).
+            accounts: MaybeUninit::uninit(),
+            cpi_accounts: MaybeUninit::uninit(),
+            acct_len: 0,
+            data: MaybeUninit::uninit(),
+            data_len: 0,
+        }
+    }
+
+    /// Create a new builder **without** the compile-time stack budget check.
+    ///
+    /// Use this when you know your call site has sufficient stack headroom
+    /// (e.g., the CPI is the only large stack allocation in the frame, or you
+    /// have explicitly verified the frame fits within the SVM 4 KiB limit).
+    ///
+    /// The resulting `CpiDynamic` behaves identically to one created by
+    /// [`new`](Self::new) — only the static assertion is skipped.
+    #[inline(always)]
+    pub fn new_unchecked(program_id: &'a Address) -> Self {
+        Self {
+            program_id,
             accounts: MaybeUninit::uninit(),
             cpi_accounts: MaybeUninit::uninit(),
             acct_len: 0,
@@ -285,7 +310,7 @@ mod tests {
 
     #[test]
     fn data_mut_write_and_read_back() {
-        let mut cpi = DynCpiCall::<1, 8>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 8>::new(&PROGRAM_ID);
         // SAFETY: Writing 4 bytes into the uninitialized buffer, then reading
         // only those 4 bytes back via instruction_data().
         unsafe {
@@ -298,7 +323,7 @@ mod tests {
 
     #[test]
     fn push_account_then_set_data_round_trip() {
-        let mut cpi = DynCpiCall::<2, 16>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<2, 16>::new(&PROGRAM_ID);
 
         let mut buf = AccountBuffer::new(0);
         buf.init([1; 32], [2; 32], 0, true, true, false);
@@ -311,7 +336,7 @@ mod tests {
 
     #[test]
     fn push_account_overflow_returns_error() {
-        let mut cpi = DynCpiCall::<1, 8>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 8>::new(&PROGRAM_ID);
 
         let mut buf1 = AccountBuffer::new(0);
         buf1.init([1; 32], [2; 32], 0, true, false, false);
@@ -327,26 +352,26 @@ mod tests {
 
     #[test]
     fn set_data_overflow_returns_error() {
-        let mut cpi = DynCpiCall::<1, 4>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
         assert!(cpi.set_data(&[0; 5]).is_err());
     }
 
     #[test]
     fn set_data_exact_capacity() {
-        let mut cpi = DynCpiCall::<1, 4>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
         assert!(cpi.set_data(&[0xAA; 4]).is_ok());
         assert_eq!(cpi.instruction_data(), &[0xAA; 4]);
     }
 
     #[test]
     fn set_data_len_overflow_returns_error() {
-        let mut cpi = DynCpiCall::<1, 4>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
         assert!(cpi.set_data_len(5).is_err());
     }
 
     #[test]
     fn set_data_len_exact_capacity() {
-        let mut cpi = DynCpiCall::<1, 4>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
         // SAFETY: We're only setting the length; invoke would read these bytes
         // but we won't invoke — this tests the length validation path.
         assert!(cpi.set_data_len(4).is_ok());
@@ -354,14 +379,14 @@ mod tests {
 
     #[test]
     fn set_data_zero_length() {
-        let mut cpi = DynCpiCall::<1, 8>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 8>::new(&PROGRAM_ID);
         assert!(cpi.set_data(&[]).is_ok());
         assert_eq!(cpi.instruction_data(), &[]);
     }
 
     #[test]
     fn data_mut_returns_raw_pointer() {
-        let mut cpi = DynCpiCall::<1, 8>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<1, 8>::new(&PROGRAM_ID);
         let ptr = cpi.data_mut();
         // Verify it's a valid pointer by writing through it.
         // SAFETY: Writing within the MAX_DATA capacity.
@@ -376,7 +401,7 @@ mod tests {
 
     #[test]
     fn push_account_fills_to_capacity() {
-        let mut cpi = DynCpiCall::<3, 8>::new(&PROGRAM_ID);
+        let mut cpi = CpiDynamic::<3, 8>::new(&PROGRAM_ID);
 
         let mut buf0 = AccountBuffer::new(0);
         let mut buf1 = AccountBuffer::new(0);
@@ -407,7 +432,7 @@ mod tests {
 #[cfg(kani)]
 mod kani_proofs {
     use {
-        super::DynCpiCall,
+        super::CpiDynamic,
         crate::cpi::{AccountBuffer, MIN_ACCOUNT_BUF},
     };
 
@@ -421,7 +446,7 @@ mod kani_proofs {
         kani::assume(target <= MAX_ACCTS);
 
         let addr = solana_address::Address::new_from_array([0x11; 32]);
-        let mut cpi = DynCpiCall::<MAX_ACCTS, 8>::new(&addr);
+        let mut cpi = CpiDynamic::<MAX_ACCTS, 8>::new(&addr);
 
         let mut buf = AccountBuffer::<MIN_ACCOUNT_BUF>::new();
         buf.init([1; 32], [0; 32], 0, true, true, false);
@@ -449,7 +474,7 @@ mod kani_proofs {
         kani::assume(data_len <= 32);
 
         let addr = solana_address::Address::new_from_array([0x11; 32]);
-        let mut cpi = DynCpiCall::<1, MAX_DATA>::new(&addr);
+        let mut cpi = CpiDynamic::<1, MAX_DATA>::new(&addr);
         let buf = [0u8; 32];
 
         if data_len <= MAX_DATA {
@@ -465,7 +490,7 @@ mod kani_proofs {
     fn sequential_pushes_cover_all_indices() {
         const MAX_ACCTS: usize = 4;
         let addr = solana_address::Address::new_from_array([0x11; 32]);
-        let mut cpi = DynCpiCall::<MAX_ACCTS, 8>::new(&addr);
+        let mut cpi = CpiDynamic::<MAX_ACCTS, 8>::new(&addr);
 
         let mut buf0 = AccountBuffer::<MIN_ACCOUNT_BUF>::new();
         let mut buf1 = AccountBuffer::<MIN_ACCOUNT_BUF>::new();

--- a/lang/src/cpi/mod.rs
+++ b/lang/src/cpi/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! `CpiCall` is the primary type — a const-generic struct where account count
 //! and data size are known at compile time, keeping everything on the stack.
-//! `DynCpiCall` is the variable-length variant where both account count and
+//! `CpiDynamic` is the variable-length variant where both account count and
 //! data size are runtime-tracked within compile-time capacity bounds.
 //!
 //! Account types (`CpiAccount`, `InstructionAccount`, `Seed`, `Signer`) come
@@ -20,7 +20,7 @@ use {
     solana_program_error::{ProgramError, ProgramResult},
 };
 pub use {
-    dyn_cpi::DynCpiCall,
+    dyn_cpi::CpiDynamic,
     solana_instruction_view::{
         cpi::{CpiAccount, Seed, Signer, MAX_RETURN_DATA},
         InstructionAccount, InstructionView,
@@ -53,7 +53,7 @@ struct CInstruction<'a> {
 /// - `cpi_accounts[..cpi_accounts_len]` must be valid.
 #[inline(always)]
 #[allow(clippy::too_many_arguments, unused_variables)]
-pub(crate) unsafe fn invoke_raw(
+pub unsafe fn invoke_raw(
     program_id: *const Address,
     instruction_accounts: *const InstructionAccount,
     instruction_accounts_len: usize,
@@ -102,7 +102,7 @@ pub(crate) unsafe fn invoke_raw(
 
 /// Convert a raw syscall result to `ProgramResult`.
 #[inline(always)]
-pub(crate) fn result_from_raw(result: u64) -> ProgramResult {
+pub fn result_from_raw(result: u64) -> ProgramResult {
     if result == 0 {
         Ok(())
     } else {

--- a/lang/src/macros.rs
+++ b/lang/src/macros.rs
@@ -9,6 +9,51 @@
 
 #[macro_export]
 macro_rules! define_account {
+    // With deref target: `pub struct Token => [checks::Owner]: TokenAccountState`
+    // Generates everything from the base form plus Deref/DerefMut/ZeroCopyDeref/StaticView.
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident => [$($check:path),* $(,)?] : $target:ty
+    ) => {
+        $crate::define_account!($(#[$meta])* $vis struct $name => [$($check),*]);
+
+        unsafe impl $crate::traits::StaticView for $name {}
+
+        impl core::ops::Deref for $name {
+            type Target = $target;
+
+            #[inline(always)]
+            fn deref(&self) -> &Self::Target {
+                // SAFETY: AccountCheck validated data_len >= size_of::<$target>.
+                // $target is #[repr(C)] with alignment 1.
+                unsafe { &*(self.view.data_ptr() as *const $target) }
+            }
+        }
+
+        impl core::ops::DerefMut for $name {
+            #[inline(always)]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                // SAFETY: Same as Deref — length validated, alignment 1.
+                unsafe { &mut *(self.view.data_mut_ptr() as *mut $target) }
+            }
+        }
+
+        impl $crate::traits::ZeroCopyDeref for $name {
+            type Target = $target;
+
+            #[inline(always)]
+            unsafe fn deref_from(view: &AccountView) -> &Self::Target {
+                &*(view.data_ptr() as *const $target)
+            }
+
+            #[inline(always)]
+            unsafe fn deref_from_mut(view: &mut AccountView) -> &mut Self::Target {
+                &mut *(view.data_mut_ptr() as *mut $target)
+            }
+        }
+    };
+
+    // Base form: `pub struct Signer => [checks::Signer]`
     (
         $(#[$meta:meta])*
         $vis:vis struct $name:ident => [$($check:path),* $(,)?]

--- a/lang/src/prelude.rs
+++ b/lang/src/prelude.rs
@@ -13,7 +13,7 @@ pub use {
         context::{Context, Ctx, CtxWithRemaining},
         cpi::{
             system::{SystemProgram, SYSTEM_PROGRAM_ID},
-            CpiReturn, DynCpiCall, Seed,
+            CpiDynamic, CpiReturn, Seed,
         },
         dispatch, emit,
         error::QuasarError,

--- a/lang/tests/instruction_arg.rs
+++ b/lang/tests/instruction_arg.rs
@@ -428,18 +428,12 @@ fn repr_u8_enum_validate_recurses_through_option() {
     // the payload bytes. A corrupt inner enum with `Some` outer is the
     // highest-risk path because `from_zc` on the inner side panics via
     // `unreachable!` when `validate_zc` has not filtered it out.
-    let bad: OptionZc<u8> = OptionZc {
-        tag: 1,
-        value: core::mem::MaybeUninit::new(99u8),
-    };
+    let bad: OptionZc<u8> = OptionZc::some(99u8);
     assert!(<Option<Status> as InstructionArg>::validate_zc(&bad).is_err());
 
     // Positive control: a valid `Some(Pending)` must pass recursive
     // validation.
-    let ok: OptionZc<u8> = OptionZc {
-        tag: 1,
-        value: core::mem::MaybeUninit::new(Status::Pending as u8),
-    };
+    let ok: OptionZc<u8> = OptionZc::some(Status::Pending as u8);
     assert!(<Option<Status> as InstructionArg>::validate_zc(&ok).is_ok());
 
     // `None` is also valid and carries no inner constraint.

--- a/metadata/src/instructions/create_metadata.rs
+++ b/metadata/src/instructions/create_metadata.rs
@@ -1,6 +1,6 @@
 use {
     crate::codec::BorshCpiEncode,
-    quasar_lang::{cpi::DynCpiCall, prelude::*},
+    quasar_lang::{cpi::CpiDynamic, prelude::*},
 };
 
 const CREATE_METADATA_ACCOUNTS_V3: u8 = 33;
@@ -28,7 +28,7 @@ pub fn create_metadata_accounts_v3<'a>(
     seller_fee_basis_points: u16,
     is_mutable: bool,
     update_authority_is_signer: bool,
-) -> Result<DynCpiCall<'a, 7, 512>, ProgramError> {
+) -> Result<CpiDynamic<'a, 7, 512>, ProgramError> {
     let name_len = name.encoded_len() - 4;
     let symbol_len = symbol.encoded_len() - 4;
     let uri_len = uri.encoded_len() - 4;
@@ -39,7 +39,7 @@ pub fn create_metadata_accounts_v3<'a>(
         return Err(metadata_field_too_long());
     }
 
-    let mut cpi = DynCpiCall::<7, 512>::new(program.address());
+    let mut cpi = CpiDynamic::<7, 512>::new(program.address());
 
     // Push accounts.
     cpi.push_account(metadata, false, true)?;

--- a/metadata/src/instructions/mod.rs
+++ b/metadata/src/instructions/mod.rs
@@ -19,7 +19,7 @@ mod verify_collection;
 use {
     crate::codec::BorshCpiEncode,
     quasar_lang::{
-        cpi::{CpiCall, DynCpiCall},
+        cpi::{CpiCall, CpiDynamic},
         prelude::*,
     },
 };
@@ -34,7 +34,7 @@ const MAX_URI_LEN: usize = 200;
 /// Implemented by [`crate::MetadataProgram`].
 pub trait MetadataCpi: AsAccountView {
     // -----------------------------------------------------------------------
-    // Variable-length instructions (DynCpiCall)
+    // Variable-length instructions (CpiDynamic)
     // -----------------------------------------------------------------------
 
     /// Create a metadata account for an SPL Token mint.
@@ -58,7 +58,7 @@ pub trait MetadataCpi: AsAccountView {
         seller_fee_basis_points: u16,
         is_mutable: bool,
         update_authority_is_signer: bool,
-    ) -> Result<DynCpiCall<'a, 7, 512>, ProgramError> {
+    ) -> Result<CpiDynamic<'a, 7, 512>, ProgramError> {
         create_metadata::create_metadata_accounts_v3(
             self.to_account_view(),
             metadata.to_account_view(),
@@ -93,7 +93,7 @@ pub trait MetadataCpi: AsAccountView {
         seller_fee_basis_points: Option<u16>,
         primary_sale_happened: Option<bool>,
         is_mutable: Option<bool>,
-    ) -> Result<DynCpiCall<'a, 2, 512>, ProgramError> {
+    ) -> Result<CpiDynamic<'a, 2, 512>, ProgramError> {
         update_metadata::update_metadata_accounts_v2(
             self.to_account_view(),
             metadata.to_account_view(),
@@ -847,7 +847,7 @@ mod kani_proofs {
     // depends on runtime field lengths. We prove that every valid combination
     // of field lengths keeps the total offset within the 512-byte buffer.
 
-    // -- create_metadata_accounts_v3 (disc=33, 512-byte DynCpiCall buf) ------
+    // -- create_metadata_accounts_v3 (disc=33, 512-byte CpiDynamic buf) ------
 
     /// Prove that `create_metadata_accounts_v3` offset arithmetic stays within
     /// the 512-byte buffer for all valid field lengths.
@@ -926,7 +926,7 @@ mod kani_proofs {
         assert!(offset == expected);
     }
 
-    // -- update_metadata_accounts_v2 (disc=15, 512-byte DynCpiCall buf) ------
+    // -- update_metadata_accounts_v2 (disc=15, 512-byte CpiDynamic buf) ------
 
     /// Prove that `update_metadata_accounts_v2` offset arithmetic stays within
     /// the 512-byte buffer in the worst case: all `Option` fields are `Some`

--- a/metadata/src/instructions/update_metadata.rs
+++ b/metadata/src/instructions/update_metadata.rs
@@ -1,6 +1,6 @@
 use {
     crate::codec::CpiEncode,
-    quasar_lang::{cpi::DynCpiCall, prelude::*},
+    quasar_lang::{cpi::CpiDynamic, prelude::*},
 };
 
 const UPDATE_METADATA_ACCOUNTS_V2: u8 = 15;
@@ -24,7 +24,7 @@ pub fn update_metadata_accounts_v2<'a>(
     seller_fee_basis_points: Option<u16>,
     primary_sale_happened: Option<bool>,
     is_mutable: Option<bool>,
-) -> Result<DynCpiCall<'a, 2, 512>, ProgramError> {
+) -> Result<CpiDynamic<'a, 2, 512>, ProgramError> {
     if let Some(n) = name {
         if n.len() > super::MAX_NAME_LEN {
             return Err(metadata_field_too_long());
@@ -41,7 +41,7 @@ pub fn update_metadata_accounts_v2<'a>(
         }
     }
 
-    let mut cpi = DynCpiCall::<2, 512>::new(program.address());
+    let mut cpi = CpiDynamic::<2, 512>::new(program.address());
 
     // Push accounts.
     cpi.push_account(metadata, false, true)?;

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -176,10 +176,16 @@ pub struct IdlAccountItem {
     pub writable: bool,
     #[serde(default, skip_serializing_if = "is_false")]
     pub signer: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub optional: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub docs: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pda: Option<IdlPda>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relations: Vec<String>,
     /// Present when the field is `Migration<From, To>`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration: Option<IdlMigration>,

--- a/spl/src/associated_token.rs
+++ b/spl/src/associated_token.rs
@@ -25,6 +25,64 @@ impl Id for AssociatedTokenProgram {
     const ID: Address = Address::new_from_array(ATA_PROGRAM_BYTES);
 }
 
+/// Trait for types that can execute ATA program CPI calls.
+///
+/// Implemented by `Program<AssociatedTokenProgram>`. Import this trait to
+/// call `.create()` and `.create_idempotent()` directly on the program account.
+pub trait AssociatedTokenCpi: AsAccountView {
+    /// Create an associated token account.
+    ///
+    /// Fails if the associated token account already exists. Use
+    /// [`create_idempotent`](Self::create_idempotent) if you want a no-op on
+    /// an existing account.
+    #[inline(always)]
+    fn create<'a>(
+        &'a self,
+        payer: &'a impl AsAccountView,
+        ata: &'a AccountView,
+        wallet: &'a impl AsAccountView,
+        mint: &'a impl AsAccountView,
+        system_program: &'a Program<SystemProgram>,
+        token_program: &'a impl TokenCpi,
+    ) -> CpiCall<'a, 6, 1> {
+        build_ata_cpi(
+            self.to_account_view(),
+            payer,
+            ata,
+            wallet,
+            mint,
+            system_program,
+            token_program,
+            ATA_CREATE,
+        )
+    }
+
+    /// Create an associated token account, no-op if it already exists.
+    #[inline(always)]
+    fn create_idempotent<'a>(
+        &'a self,
+        payer: &'a impl AsAccountView,
+        ata: &'a AccountView,
+        wallet: &'a impl AsAccountView,
+        mint: &'a impl AsAccountView,
+        system_program: &'a Program<SystemProgram>,
+        token_program: &'a impl TokenCpi,
+    ) -> CpiCall<'a, 6, 1> {
+        build_ata_cpi(
+            self.to_account_view(),
+            payer,
+            ata,
+            wallet,
+            mint,
+            system_program,
+            token_program,
+            ATA_CREATE_IDEMPOTENT,
+        )
+    }
+}
+
+impl AssociatedTokenCpi for Program<AssociatedTokenProgram> {}
+
 // ---------------------------------------------------------------------------
 // Address derivation
 // ---------------------------------------------------------------------------
@@ -74,7 +132,7 @@ pub fn create<'a>(
     token_program: &'a impl TokenCpi,
 ) -> CpiCall<'a, 6, 1> {
     build_ata_cpi(
-        ata_program,
+        ata_program.to_account_view(),
         payer,
         ata,
         wallet,
@@ -102,7 +160,7 @@ pub fn create_idempotent<'a>(
     token_program: &'a impl TokenCpi,
 ) -> CpiCall<'a, 6, 1> {
     build_ata_cpi(
-        ata_program,
+        ata_program.to_account_view(),
         payer,
         ata,
         wallet,
@@ -116,7 +174,7 @@ pub fn create_idempotent<'a>(
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 fn build_ata_cpi<'a>(
-    ata_program: &'a AssociatedTokenProgram,
+    ata_program: &'a AccountView,
     payer: &'a impl AsAccountView,
     ata: &'a AccountView,
     wallet: &'a impl AsAccountView,

--- a/spl/src/lib.rs
+++ b/spl/src/lib.rs
@@ -45,92 +45,6 @@
 
 #![no_std]
 
-/// Implements the shared account wrapper contract for a type owned by a single
-/// program.
-///
-/// Generates the wrapper, owner, and zero-copy deref machinery. Account-data
-/// validation can either use the default fixed-length implementation here or a
-/// custom `AccountCheck` impl when the type needs parameterized validation.
-///
-/// Generates these trait implementations:
-///
-/// - `StaticView` — marks the type as having a fixed layout
-/// - `AsAccountView` — provides access to the underlying `AccountView`
-/// - `CheckOwner` — validates `owner == $id`
-/// - `Deref` / `DerefMut` → `$target` — zero-copy access to account data
-/// - `ZeroCopyDeref` — enables `InterfaceAccount<T>` to deref through this type
-///
-/// # Safety
-///
-/// The `Deref` / `DerefMut` impls perform `unsafe` pointer casts from the
-/// raw account data to `$target`. This is sound because:
-///
-/// 1. `AccountCheck::check` for the account type validated `data_len >=
-///    $target::LEN`
-/// 2. `$target` is `#[repr(C)]` with alignment 1 (any pointer is valid)
-/// 3. The owner check guarantees the data was written by the expected program
-macro_rules! impl_program_account {
-    ($ty:ty, $id:expr, $target:ty) => {
-        unsafe impl StaticView for $ty {}
-
-        impl AsAccountView for $ty {
-            #[inline(always)]
-            fn to_account_view(&self) -> &AccountView {
-                &self.__view
-            }
-        }
-
-        impl CheckOwner for $ty {
-            #[inline(always)]
-            fn check_owner(view: &AccountView) -> Result<(), ProgramError> {
-                if quasar_lang::utils::hint::unlikely(!quasar_lang::keys_eq(view.owner(), &$id)) {
-                    return Err(ProgramError::IllegalOwner);
-                }
-                Ok(())
-            }
-        }
-
-        impl core::ops::Deref for $ty {
-            type Target = $target;
-
-            #[inline(always)]
-            fn deref(&self) -> &Self::Target {
-                // SAFETY: `AccountCheck::check` validated `data_len >= LEN`.
-                // `$target` is `#[repr(C)]` with alignment 1 — any data
-                // pointer is valid.
-                unsafe { &*(self.__view.data_ptr() as *const $target) }
-            }
-        }
-
-        impl core::ops::DerefMut for $ty {
-            #[inline(always)]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                // SAFETY: Same as Deref — length validated, alignment 1.
-                // Mutability checked by the writable constraint.
-                unsafe { &mut *(self.__view.data_mut_ptr() as *mut $target) }
-            }
-        }
-
-        impl ZeroCopyDeref for $ty {
-            type Target = $target;
-
-            #[inline(always)]
-            unsafe fn deref_from(view: &AccountView) -> &Self::Target {
-                // SAFETY: Caller ensures `view.data_len() >= LEN`.
-                // `$target` is `#[repr(C)]` with alignment 1.
-                &*(view.data_ptr() as *const $target)
-            }
-
-            #[inline(always)]
-            unsafe fn deref_from_mut(view: &mut AccountView) -> &mut Self::Target {
-                // SAFETY: Same as `deref_from` — caller ensures length
-                // and writable.
-                &mut *(view.data_mut_ptr() as *mut $target)
-            }
-        }
-    };
-}
-
 /// Implements `AccountCheck`, `TokenClose`, and `TokenSweep` for a token
 /// account type (Token / Token2022). All token account types share the same
 /// validation logic and close/sweep dispatch.
@@ -301,7 +215,7 @@ pub use {
     associated_token::{
         create as ata_create, create_idempotent as ata_create_idempotent,
         get_associated_token_address_const, get_associated_token_address_with_program_const,
-        AssociatedTokenProgram,
+        AssociatedTokenCpi, AssociatedTokenProgram,
     },
     constants::{ATA_PROGRAM_ID, SPL_TOKEN_ID, TOKEN_2022_ID},
     exit::{close_token_account, sweep_token_account},

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -7,15 +7,17 @@ use {
     quasar_lang::{prelude::*, traits::Id},
 };
 
-/// Token account data marker — validates owner is SPL Token program.
-///
-/// Use as `Account<Token>` for single-program token accounts,
-/// or `InterfaceAccount<Token>` to accept both SPL Token and Token-2022.
-#[repr(transparent)]
-pub struct Token {
-    __view: AccountView,
+quasar_lang::define_account!(
+    /// Token account data — validates owner is SPL Token program.
+    ///
+    /// Use as `Account<Token>` for single-program token accounts,
+    /// or `InterfaceAccount<Token>` to accept both SPL Token and Token-2022.
+    pub struct Token => [checks::Owner]: TokenAccountState
+);
+
+impl Owner for Token {
+    const OWNER: Address = SPL_TOKEN_ID;
 }
-impl_program_account!(Token, SPL_TOKEN_ID, TokenAccountState);
 
 // SPL Token program marker. Use as `Program<TokenProgram>`.
 quasar_lang::define_account!(pub struct TokenProgram => [checks::Executable, checks::Address]);
@@ -24,17 +26,26 @@ impl Id for TokenProgram {
     const ID: Address = Address::new_from_array(SPL_TOKEN_BYTES);
 }
 
-/// Mint account view — validates owner is SPL Token program.
-///
-/// Use as `Account<Mint>` for single-program mints,
-/// or `InterfaceAccount<Mint>` to accept both SPL Token and Token-2022.
-#[repr(transparent)]
-pub struct Mint {
-    __view: AccountView,
-}
-impl_program_account!(Mint, SPL_TOKEN_ID, MintAccountState);
+quasar_lang::define_account!(
+    /// Mint account — validates owner is SPL Token program.
+    ///
+    /// Use as `Account<Mint>` for single-program mints,
+    /// or `InterfaceAccount<Mint>` to accept both SPL Token and Token-2022.
+    pub struct Mint => [checks::Owner]: MintAccountState
+);
 
-/// Valid owner programs for token interface accounts (SPL Token + Token-2022).
+impl Owner for Mint {
+    const OWNER: Address = SPL_TOKEN_ID;
+}
+
+/// Valid owner programs for `InterfaceAccount<Token>` and
+/// `InterfaceAccount<Mint>` — accepts accounts owned by either SPL Token
+/// or Token-2022.
+///
+/// Note: `Account<Token>` does NOT use this trait. It validates via
+/// `checks::Owner` which checks only `SPL_TOKEN_ID`. The `Owners` trait
+/// is consumed exclusively by `InterfaceAccount<T>` for multi-program
+/// acceptance.
 static SPL_TOKEN_OWNERS: [Address; 2] = [SPL_TOKEN_ID, TOKEN_2022_ID];
 
 impl quasar_lang::traits::Owners for Token {
@@ -54,8 +65,7 @@ impl quasar_lang::traits::Owners for Mint {
 impl TokenCpi for Program<TokenProgram> {}
 
 // ---------------------------------------------------------------------------
-// Shared trait impls via macros (AccountCheck, TokenClose, TokenSweep,
-// AccountInit)
+// Shared trait impls (AccountCheck, TokenClose, TokenSweep, AccountInit)
 // ---------------------------------------------------------------------------
 
 impl_token_account_traits!(Token);

--- a/spl/src/token_2022.rs
+++ b/spl/src/token_2022.rs
@@ -7,12 +7,14 @@ use {
     quasar_lang::{prelude::*, traits::Id},
 };
 
-/// Token-2022 account data marker.
-#[repr(transparent)]
-pub struct Token2022 {
-    __view: AccountView,
+quasar_lang::define_account!(
+    /// Token-2022 account data — validates owner is Token-2022 program.
+    pub struct Token2022 => [checks::Owner]: TokenAccountState
+);
+
+impl Owner for Token2022 {
+    const OWNER: Address = TOKEN_2022_ID;
 }
-impl_program_account!(Token2022, TOKEN_2022_ID, TokenAccountState);
 
 // Token-2022 program marker. Use as `Program<Token2022Program>`.
 quasar_lang::define_account!(pub struct Token2022Program => [checks::Executable, checks::Address]);
@@ -21,18 +23,19 @@ impl Id for Token2022Program {
     const ID: Address = Address::new_from_array(TOKEN_2022_BYTES);
 }
 
-/// Mint account view — validates owner is Token-2022 program.
-#[repr(transparent)]
-pub struct Mint2022 {
-    __view: AccountView,
+quasar_lang::define_account!(
+    /// Mint-2022 account data — validates owner is Token-2022 program.
+    pub struct Mint2022 => [checks::Owner]: MintAccountState
+);
+
+impl Owner for Mint2022 {
+    const OWNER: Address = TOKEN_2022_ID;
 }
-impl_program_account!(Mint2022, TOKEN_2022_ID, MintAccountState);
 
 impl TokenCpi for Program<Token2022Program> {}
 
 // ---------------------------------------------------------------------------
-// Shared trait impls via macros (AccountCheck, TokenClose, TokenSweep,
-// AccountInit)
+// Shared trait impls (AccountCheck, TokenClose, TokenSweep, AccountInit)
 // ---------------------------------------------------------------------------
 
 impl_token_account_traits!(Token2022);

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -326,4 +326,16 @@ mod quasar_test_misc {
     pub fn cpi_mut_readback(ctx: Ctx<CpiMutReadback>, new_value: u64) -> Result<(), ProgramError> {
         ctx.accounts.handler(new_value)
     }
+
+    /// Proves Option<String<N>> and Option<Vec<T, N>> compile as instruction
+    /// arguments (#144).
+    #[instruction(discriminator = 61)]
+    pub fn optional_dynamic_arg(
+        ctx: Ctx<PlainOk>,
+        maybe_name: Option<String<32>>,
+        maybe_addrs: Option<Vec<Address, 4>>,
+    ) -> Result<(), ProgramError> {
+        let _ = (maybe_name, maybe_addrs);
+        ctx.accounts.handler()
+    }
 }


### PR DESCRIPTION
## Summary

Batch cleanup that unifies SPL account infrastructure and closes several open issues.

### SPL account wrapper unification
- Replace `impl_program_account!` macro with `define_account!` for `Token`, `Mint`, `Token2022`, `Mint2022`
- All SPL types now use the same macro as `Signer` and `Program`, with the new **deref-target form** (`pub struct Token => [checks::Owner]: TokenAccountState`) that generates `Deref`/`DerefMut`/`ZeroCopyDeref`/`StaticView`
- Delete the 86-line `impl_program_account!` macro entirely

### Lint suppression migration (closes #189)
- Move `#[allow(quasar::unconstrained)]` → `#[account(allow(unconstrained))]`
- Suppressions now live inside the `#[account(...)]` attribute block as a first-class `Directive::Allow` variant
- Drop the `quasar::` prefix — suppressions are now just `unconstrained`, `disconnected_graph`, etc.
- Derive macro ignores `Allow` directives during lowering (lint-only)

### IDL completeness (closes #139)
- Add `optional`, `docs`, and `relations` fields to `IdlAccountItem`
- `Option<Account<T>>` now emits `"optional": true` in the IDL
- `///` doc comments on account fields are extracted into `"docs"` array
- `has_one` targets emit `"relations"` array (camelCased)
- Client macro also populates `optional` and `docs`

### CPI improvements (closes #127)
- Rename `DynCpiCall` → `CpiDynamic` (noun-first naming)
- Add `CpiDynamic::new_unchecked()` for bypassing the stack budget assertion
- Make `invoke_raw` and `result_from_raw` public for advanced CPI use cases

### AssociatedTokenCpi trait (supersedes #159)
- Add `AssociatedTokenCpi` trait with `.create()` / `.create_idempotent()` methods
- Implemented on `Program<AssociatedTokenProgram>` — enables method-call syntax instead of free functions
- Credit: based on @jim4067's work in #159

### Bug fixes (closes #144)
- Fix `Option<String<N>>` and `Option<Vec<T, N>>` as instruction arguments by recursively unwrapping `Option` in `pod_alias_type`
- Fix `PodOption` test to use public `::some()` API instead of private field construction

## Co-authors

Co-Authored-By: Jimii <30603522+jim4067@users.noreply.github.com>

## Test plan
- [ ] CI passes (fmt + clippy + tests)
- [ ] All existing test programs compile
- [ ] New `optional_dynamic_arg` instruction in test-misc validates Option<String/Vec> args
- [ ] `optional_account_emits_optional_flag` parser test validates IDL optional field
- [ ] Lint suppression test updated to new `#[account(allow(...))]` syntax