### PR TITLE
Add metadata protocol account support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,8 @@ version = "0.0.0"
 dependencies = [
  "quasar-lang",
  "solana-address 2.2.0",
+ "solana-program-error",
+ "trybuild",
 ]
 
 [[package]]
@@ -2293,6 +2295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quasar-test-metadata-validate"
+version = "0.1.0"
+dependencies = [
+ "quasar-derive",
+ "quasar-lang",
+ "quasar-metadata",
+ "quasar-spl",
+]
+
+[[package]]
 name = "quasar-test-migrate"
 version = "0.1.0"
 dependencies = [
@@ -2345,6 +2357,7 @@ dependencies = [
  "quasar-test-errors",
  "quasar-test-events",
  "quasar-test-heap",
+ "quasar-test-metadata-validate",
  "quasar-test-migrate",
  "quasar-test-misc",
  "quasar-test-one-of",

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SBF_TEST_PROGRAMS := tests/programs/test-misc tests/programs/test-errors \
 	tests/programs/test-token-cpi tests/programs/test-token-init \
 	tests/programs/test-token-validate tests/programs/test-sysvar \
 	tests/programs/test-one-of tests/programs/test-migrate \
-	tests/programs/test-raw
+	tests/programs/test-raw tests/programs/test-metadata-validate
 
 # Example programs that produce SBF binaries
 SBF_EXAMPLES := examples/vault examples/escrow examples/multisig
@@ -22,7 +22,7 @@ SBF_ALL := $(SBF_EXAMPLES) $(SBF_TEST_PROGRAMS)
 .PHONY: format format-fix clippy clippy-fix check-features check-workspace-lints \
 	check-runtime-panics check-workspace-invariants build build-sbf test bench-cu \
 	bench-tracked compare-tracked test-miri test-miri-strict test-all nightly-version \
-	kani help-kani check-kani kani-lang kani-spl
+	kani help-kani check-kani kani-lang kani-spl kani-metadata
 
 # Print the nightly toolchain version for CI
 nightly-version:
@@ -158,6 +158,7 @@ test:
 	@$(MAKE) build
 	@$(MAKE) build-sbf
 	@TRYBUILD=overwrite cargo test -p quasar-lang -p quasar-derive -p quasar-spl \
+		-p quasar-metadata \
 		-p quasar-vault -p quasar-escrow -p quasar-multisig \
 		-p quasar-test-suite \
 		--all-features
@@ -181,12 +182,16 @@ test-miri:
 		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-lang --test miri
 	@MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" \
 		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-spl --test miri
+	@MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" \
+		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-metadata --test miri
 
 test-miri-strict:
 	@MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance" \
 		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-lang --test miri -- --skip remaining
 	@MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance" \
 		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-spl --test miri
+	@MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance" \
+		cargo +$(NIGHTLY_TOOLCHAIN) miri test -p quasar-metadata --test miri
 
 kani-lang: check-kani
 	@cargo kani -p quasar-lang
@@ -194,7 +199,10 @@ kani-lang: check-kani
 kani-spl: check-kani
 	@cargo kani -p quasar-spl
 
-kani: kani-lang kani-spl
+kani-metadata: check-kani
+	@cargo kani -p quasar-metadata
+
+kani: kani-lang kani-spl kani-metadata
 
 # Run all checks in sequence
 test-all:

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -514,21 +514,27 @@ fn emit_behavior_assertions(semantics: &[FieldSemantics]) -> proc_macro2::TokenS
                         #at_most_one_msg,
                     );
                 });
-
-                // If the account type requires init params (DEFAULT_INIT_PARAMS_VALID
-                // = false), exactly one behavior must provide them.
-                let required_msg = format!(
-                    "field `{}` requires an init-param behavior (e.g., token(...) or mint(...))",
-                    field_name,
-                );
-                asserts.push(quote! {
-                    const _: () = assert!(
-                        <#ty as quasar_lang::account_init::AccountInit>::DEFAULT_INIT_PARAMS_VALID
-                            || #(#init_contributor_count)+* >= 1,
-                        #required_msg,
-                    );
-                });
             }
+
+            // If the account type requires init params (DEFAULT_INIT_PARAMS_VALID
+            // = false), at least one behavior must provide them.
+            // This fires even with zero behavior groups (count_expr = 0usize).
+            let count_expr = if init_contributor_count.is_empty() {
+                quote! { 0usize }
+            } else {
+                quote! { #(#init_contributor_count)+* }
+            };
+            let required_msg = format!(
+                "field `{}` requires an init-param behavior (e.g., token(...) or mint(...))",
+                field_name,
+            );
+            asserts.push(quote! {
+                const _: () = assert!(
+                    <#ty as quasar_lang::account_init::AccountInit>::DEFAULT_INIT_PARAMS_VALID
+                        || #count_expr >= 1,
+                    #required_msg,
+                );
+            });
         }
     }
 

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -365,6 +365,7 @@ impl<T> core::ops::DerefMut for Account<T> {
 
 impl<T: crate::account_init::AccountInit> crate::account_init::AccountInit for Account<T> {
     type InitParams<'a> = T::InitParams<'a>;
+    const DEFAULT_INIT_PARAMS_VALID: bool = T::DEFAULT_INIT_PARAMS_VALID;
 
     #[inline(always)]
     fn init<'a>(

--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -86,6 +86,7 @@ impl<T: ZeroCopyDeref> core::ops::DerefMut for InterfaceAccount<T> {
 
 impl<T: crate::account_init::AccountInit> crate::account_init::AccountInit for InterfaceAccount<T> {
     type InitParams<'a> = T::InitParams<'a>;
+    const DEFAULT_INIT_PARAMS_VALID: bool = T::DEFAULT_INIT_PARAMS_VALID;
 
     #[inline(always)]
     fn init<'a>(

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -10,6 +10,13 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+debug = []
+
 [dependencies]
 quasar-lang = { path = "../lang" }
 solana-address = { version = ">=2.2, <2.6", features = ["copy"] }
+
+[dev-dependencies]
+trybuild = "1"
+solana-program-error = ">=2.2"

--- a/metadata/src/account_init.rs
+++ b/metadata/src/account_init.rs
@@ -1,0 +1,152 @@
+//! AccountInit implementations for metadata account types.
+//!
+//! Defines init params enums and CPI dispatch for `create_metadata_accounts_v3`
+//! and `create_master_edition_v3`. The derive calls these via `Op::apply` when
+//! a field has `#[account(init)]` with a metadata/master_edition behavior.
+
+use {
+    crate::state::{MasterEditionAccount, MetadataAccount},
+    quasar_lang::prelude::*,
+};
+
+// ---------------------------------------------------------------------------
+// MetadataInitParams
+// ---------------------------------------------------------------------------
+
+/// Init params for metadata account creation via CPI.
+///
+/// The derive constructs `Default` (Unset) and the metadata behavior fills
+/// the `Create` variant via `AccountBehavior::set_init_param`.
+#[derive(Default)]
+pub enum MetadataInitParams<'a> {
+    /// No behavior has filled init params yet.
+    #[default]
+    Unset,
+    /// Create metadata via `create_metadata_accounts_v3` CPI.
+    Create {
+        program: &'a AccountView,
+        mint: &'a AccountView,
+        mint_authority: &'a AccountView,
+        update_authority: &'a AccountView,
+        system_program: &'a AccountView,
+        rent: &'a AccountView,
+        name: &'a str,
+        symbol: &'a str,
+        uri: &'a str,
+        seller_fee_basis_points: u16,
+        is_mutable: bool,
+    },
+}
+
+impl quasar_lang::account_init::AccountInit for MetadataAccount {
+    type InitParams<'a> = MetadataInitParams<'a>;
+    const DEFAULT_INIT_PARAMS_VALID: bool = false;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> quasar_lang::__solana_program_error::ProgramResult {
+        match params {
+            MetadataInitParams::Unset => Err(ProgramError::InvalidArgument),
+            MetadataInitParams::Create {
+                program,
+                mint,
+                mint_authority,
+                update_authority,
+                system_program,
+                rent,
+                name,
+                symbol,
+                uri,
+                seller_fee_basis_points,
+                is_mutable,
+            } => {
+                crate::validate::validate_metadata_program(program)?;
+                crate::instructions::create_metadata::create_metadata_accounts_v3(
+                    program,
+                    ctx.target,
+                    mint,
+                    mint_authority,
+                    ctx.payer,
+                    update_authority,
+                    system_program,
+                    rent,
+                    *name,
+                    *symbol,
+                    *uri,
+                    *seller_fee_basis_points,
+                    *is_mutable,
+                    true, // update_authority_is_signer
+                )?
+                .invoke()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MasterEditionInitParams
+// ---------------------------------------------------------------------------
+
+/// Init params for master edition account creation via CPI.
+#[derive(Default)]
+pub enum MasterEditionInitParams<'a> {
+    /// No behavior has filled init params yet.
+    #[default]
+    Unset,
+    /// Create master edition via `create_master_edition_v3` CPI.
+    Create {
+        program: &'a AccountView,
+        mint: &'a AccountView,
+        update_authority: &'a AccountView,
+        mint_authority: &'a AccountView,
+        metadata: &'a AccountView,
+        token_program: &'a AccountView,
+        system_program: &'a AccountView,
+        rent: &'a AccountView,
+        max_supply: Option<u64>,
+    },
+}
+
+impl quasar_lang::account_init::AccountInit for MasterEditionAccount {
+    type InitParams<'a> = MasterEditionInitParams<'a>;
+    const DEFAULT_INIT_PARAMS_VALID: bool = false;
+
+    #[inline(always)]
+    fn init<'a>(
+        ctx: quasar_lang::account_init::InitCtx<'a>,
+        params: &Self::InitParams<'a>,
+    ) -> quasar_lang::__solana_program_error::ProgramResult {
+        match params {
+            MasterEditionInitParams::Unset => Err(ProgramError::InvalidArgument),
+            MasterEditionInitParams::Create {
+                program,
+                mint,
+                update_authority,
+                mint_authority,
+                metadata,
+                token_program,
+                system_program,
+                rent,
+                max_supply,
+            } => {
+                crate::validate::validate_metadata_program(program)?;
+                crate::instructions::create_master_edition::create_master_edition_v3(
+                    program,
+                    ctx.target,
+                    mint,
+                    update_authority,
+                    mint_authority,
+                    ctx.payer,
+                    metadata,
+                    token_program,
+                    system_program,
+                    rent,
+                    *max_supply,
+                )
+                .invoke()
+            }
+        }
+    }
+}

--- a/metadata/src/accounts/master_edition.rs
+++ b/metadata/src/accounts/master_edition.rs
@@ -1,0 +1,221 @@
+//! Master edition account behavior module.
+//!
+//! Provides check and init behavior for master edition account fields.
+//!
+//! ```rust,ignore
+//! use quasar_metadata::accounts::master_edition;
+//! #[account(master_edition(program = mp, mint = mint, ...))]
+//! pub master_edition: Account<MasterEditionAccount>,
+//! ```
+//!
+//! # Field ordering
+//!
+//! The `metadata` field must be declared before `master_edition` in the struct.
+//! The `create_master_edition_v3` CPI requires the metadata account, and the
+//! derive processes init in declaration order.
+
+use quasar_lang::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+/// Max supply specification for the master edition behavior arg.
+pub enum MaxSupplyArg {
+    /// Not specified — defaults to `Some(0)` (unique 1/1 NFT).
+    Unset,
+    /// Unlimited editions (max_supply = None).
+    Unlimited,
+    /// Limited to N editions (max_supply = Some(N)).
+    Limited(u64),
+}
+
+pub struct Args<'a> {
+    pub program: &'a AccountView,
+    pub mint: &'a AccountView,
+    pub update_authority: Option<&'a AccountView>,
+    pub mint_authority: Option<&'a AccountView>,
+    pub metadata: Option<&'a AccountView>,
+    pub token_program: Option<&'a AccountView>,
+    pub system_program: Option<&'a AccountView>,
+    pub rent: Option<&'a AccountView>,
+    pub max_supply: MaxSupplyArg,
+}
+
+pub struct ArgsBuilder<'a> {
+    program: Option<&'a AccountView>,
+    mint: Option<&'a AccountView>,
+    update_authority: Option<&'a AccountView>,
+    mint_authority: Option<&'a AccountView>,
+    metadata: Option<&'a AccountView>,
+    token_program: Option<&'a AccountView>,
+    system_program: Option<&'a AccountView>,
+    rent: Option<&'a AccountView>,
+    max_supply: MaxSupplyArg,
+}
+
+impl<'a> Args<'a> {
+    pub fn builder() -> ArgsBuilder<'a> {
+        ArgsBuilder {
+            program: None,
+            mint: None,
+            update_authority: None,
+            mint_authority: None,
+            metadata: None,
+            token_program: None,
+            system_program: None,
+            rent: None,
+            max_supply: MaxSupplyArg::Unset,
+        }
+    }
+}
+
+impl<'a> ArgsBuilder<'a> {
+    #[inline(always)]
+    pub fn program(mut self, v: &'a AccountView) -> Self {
+        self.program = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn mint(mut self, v: &'a AccountView) -> Self {
+        self.mint = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn update_authority(mut self, v: &'a AccountView) -> Self {
+        self.update_authority = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn mint_authority(mut self, v: &'a AccountView) -> Self {
+        self.mint_authority = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn metadata(mut self, v: &'a AccountView) -> Self {
+        self.metadata = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn token_program(mut self, v: &'a AccountView) -> Self {
+        self.token_program = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn system_program(mut self, v: &'a AccountView) -> Self {
+        self.system_program = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn rent(mut self, v: &'a AccountView) -> Self {
+        self.rent = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn max_supply(mut self, v: Option<u64>) -> Self {
+        self.max_supply = match v {
+            None => MaxSupplyArg::Unlimited,
+            Some(n) => MaxSupplyArg::Limited(n),
+        };
+        self
+    }
+
+    /// Build args for the check phase. Only `program` and `mint` are required.
+    #[inline(always)]
+    pub fn build_check(self) -> Result<Args<'a>, ProgramError> {
+        Ok(Args {
+            program: self.program.ok_or(ProgramError::InvalidArgument)?,
+            mint: self.mint.ok_or(ProgramError::InvalidArgument)?,
+            update_authority: self.update_authority,
+            mint_authority: self.mint_authority,
+            metadata: self.metadata,
+            token_program: self.token_program,
+            system_program: self.system_program,
+            rent: self.rent,
+            max_supply: self.max_supply,
+        })
+    }
+
+    /// Build args for the init phase. All CPI-relevant fields required.
+    #[inline(always)]
+    pub fn build_init(self) -> Result<Args<'a>, ProgramError> {
+        Ok(Args {
+            program: self.program.ok_or(ProgramError::InvalidArgument)?,
+            mint: self.mint.ok_or(ProgramError::InvalidArgument)?,
+            update_authority: Some(self.update_authority.ok_or(ProgramError::InvalidArgument)?),
+            mint_authority: Some(self.mint_authority.ok_or(ProgramError::InvalidArgument)?),
+            metadata: Some(self.metadata.ok_or(ProgramError::InvalidArgument)?),
+            token_program: Some(self.token_program.ok_or(ProgramError::InvalidArgument)?),
+            system_program: Some(self.system_program.ok_or(ProgramError::InvalidArgument)?),
+            rent: Some(self.rent.ok_or(ProgramError::InvalidArgument)?),
+            max_supply: self.max_supply,
+        })
+    }
+
+    #[inline(always)]
+    pub fn build_exit(self) -> Result<Args<'a>, ProgramError> {
+        self.build_check()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behavior
+// ---------------------------------------------------------------------------
+
+pub struct Behavior;
+
+impl AccountBehavior<Account<crate::MasterEditionAccount>> for Behavior {
+    type Args<'a> = Args<'a>;
+    const SETS_INIT_PARAMS: bool = true;
+
+    #[inline(always)]
+    fn set_init_param<'a>(
+        params: &mut <Account<crate::MasterEditionAccount> as AccountInit>::InitParams<'a>,
+        args: &Args<'a>,
+    ) -> Result<(), ProgramError> {
+        *params = crate::MasterEditionInitParams::Create {
+            program: args.program,
+            mint: args.mint,
+            update_authority: args.update_authority.ok_or(ProgramError::InvalidArgument)?,
+            mint_authority: args.mint_authority.ok_or(ProgramError::InvalidArgument)?,
+            metadata: args.metadata.ok_or(ProgramError::InvalidArgument)?,
+            token_program: args.token_program.ok_or(ProgramError::InvalidArgument)?,
+            system_program: args.system_program.ok_or(ProgramError::InvalidArgument)?,
+            rent: args.rent.ok_or(ProgramError::InvalidArgument)?,
+            max_supply: match &args.max_supply {
+                MaxSupplyArg::Unset => Some(0),
+                MaxSupplyArg::Unlimited => None,
+                MaxSupplyArg::Limited(n) => Some(*n),
+            },
+        };
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn check<'a>(
+        account: &Account<crate::MasterEditionAccount>,
+        args: &Args<'a>,
+    ) -> Result<(), ProgramError> {
+        // Validate the metadata program address.
+        crate::validate::validate_metadata_program(args.program)?;
+        // PDA verification (AccountLoad already checked owner/data_len/key).
+        crate::pda::verify_master_edition_address(
+            account.to_account_view().address(),
+            args.mint.address(),
+        )?;
+        // Validate metadata account when provided (owner, key, mint, and PDA).
+        if let Some(metadata) = args.metadata {
+            crate::validate::validate_metadata_account(metadata, args.mint.address(), None)?;
+            crate::pda::verify_metadata_address(metadata.address(), args.mint.address())?;
+        }
+        Ok(())
+    }
+}

--- a/metadata/src/accounts/metadata.rs
+++ b/metadata/src/accounts/metadata.rs
@@ -1,0 +1,240 @@
+//! Metadata account behavior module.
+//!
+//! Provides check and init behavior for metadata account fields.
+//!
+//! ```rust,ignore
+//! use quasar_metadata::accounts::metadata;
+//! #[account(metadata(program = mp, mint = mint, mint_authority = auth, ...))]
+//! pub metadata: Account<MetadataAccount>,
+//! ```
+//!
+//! # Field ordering
+//!
+//! When using `#[account(init, metadata(...))]`, the metadata field must appear
+//! before any `master_edition` field in the struct — the derive processes init
+//! in declaration order and `create_master_edition_v3` requires the metadata
+//! account to exist.
+
+use quasar_lang::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+pub struct Args<'a> {
+    pub program: &'a AccountView,
+    pub mint: &'a AccountView,
+    pub mint_authority: Option<&'a AccountView>,
+    pub update_authority: Option<&'a AccountView>,
+    pub system_program: Option<&'a AccountView>,
+    pub rent: Option<&'a AccountView>,
+    pub name: Option<&'a str>,
+    pub symbol: Option<&'a str>,
+    pub uri: Option<&'a str>,
+    pub seller_fee_basis_points: Option<u16>,
+    pub is_mutable: Option<bool>,
+}
+
+pub struct ArgsBuilder<'a> {
+    program: Option<&'a AccountView>,
+    mint: Option<&'a AccountView>,
+    mint_authority: Option<&'a AccountView>,
+    update_authority: Option<&'a AccountView>,
+    system_program: Option<&'a AccountView>,
+    rent: Option<&'a AccountView>,
+    name: Option<&'a str>,
+    symbol: Option<&'a str>,
+    uri: Option<&'a str>,
+    seller_fee_basis_points: Option<u16>,
+    is_mutable: Option<bool>,
+}
+
+impl<'a> Args<'a> {
+    pub fn builder() -> ArgsBuilder<'a> {
+        ArgsBuilder {
+            program: None,
+            mint: None,
+            mint_authority: None,
+            update_authority: None,
+            system_program: None,
+            rent: None,
+            name: None,
+            symbol: None,
+            uri: None,
+            seller_fee_basis_points: None,
+            is_mutable: None,
+        }
+    }
+}
+
+impl<'a> ArgsBuilder<'a> {
+    #[inline(always)]
+    pub fn program(mut self, v: &'a AccountView) -> Self {
+        self.program = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn mint(mut self, v: &'a AccountView) -> Self {
+        self.mint = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn mint_authority(mut self, v: &'a AccountView) -> Self {
+        self.mint_authority = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn update_authority(mut self, v: &'a AccountView) -> Self {
+        self.update_authority = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn system_program(mut self, v: &'a AccountView) -> Self {
+        self.system_program = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn rent(mut self, v: &'a AccountView) -> Self {
+        self.rent = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn name(mut self, v: &'a str) -> Self {
+        self.name = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn symbol(mut self, v: &'a str) -> Self {
+        self.symbol = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn uri(mut self, v: &'a str) -> Self {
+        self.uri = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn seller_fee_basis_points(mut self, v: u16) -> Self {
+        self.seller_fee_basis_points = Some(v);
+        self
+    }
+
+    #[inline(always)]
+    pub fn is_mutable(mut self, v: bool) -> Self {
+        self.is_mutable = Some(v);
+        self
+    }
+
+    /// Build args for the check phase. Only `program` and `mint` are required.
+    #[inline(always)]
+    pub fn build_check(self) -> Result<Args<'a>, ProgramError> {
+        Ok(Args {
+            program: self.program.ok_or(ProgramError::InvalidArgument)?,
+            mint: self.mint.ok_or(ProgramError::InvalidArgument)?,
+            mint_authority: self.mint_authority,
+            update_authority: self.update_authority,
+            system_program: self.system_program,
+            rent: self.rent,
+            name: self.name,
+            symbol: self.symbol,
+            uri: self.uri,
+            seller_fee_basis_points: self.seller_fee_basis_points,
+            is_mutable: self.is_mutable,
+        })
+    }
+
+    /// Build args for the init phase. All CPI-relevant fields required.
+    #[inline(always)]
+    pub fn build_init(self) -> Result<Args<'a>, ProgramError> {
+        Ok(Args {
+            program: self.program.ok_or(ProgramError::InvalidArgument)?,
+            mint: self.mint.ok_or(ProgramError::InvalidArgument)?,
+            mint_authority: Some(self.mint_authority.ok_or(ProgramError::InvalidArgument)?),
+            update_authority: Some(self.update_authority.ok_or(ProgramError::InvalidArgument)?),
+            system_program: Some(self.system_program.ok_or(ProgramError::InvalidArgument)?),
+            rent: Some(self.rent.ok_or(ProgramError::InvalidArgument)?),
+            name: Some(self.name.ok_or(ProgramError::InvalidArgument)?),
+            symbol: Some(self.symbol.ok_or(ProgramError::InvalidArgument)?),
+            uri: Some(self.uri.ok_or(ProgramError::InvalidArgument)?),
+            seller_fee_basis_points: Some(self.seller_fee_basis_points.unwrap_or(0)),
+            is_mutable: Some(self.is_mutable.unwrap_or(true)),
+        })
+    }
+
+    #[inline(always)]
+    pub fn build_exit(self) -> Result<Args<'a>, ProgramError> {
+        self.build_check()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behavior
+// ---------------------------------------------------------------------------
+
+pub struct Behavior;
+
+impl AccountBehavior<Account<crate::MetadataAccount>> for Behavior {
+    type Args<'a> = Args<'a>;
+    const SETS_INIT_PARAMS: bool = true;
+
+    #[inline(always)]
+    fn set_init_param<'a>(
+        params: &mut <Account<crate::MetadataAccount> as AccountInit>::InitParams<'a>,
+        args: &Args<'a>,
+    ) -> Result<(), ProgramError> {
+        *params = crate::MetadataInitParams::Create {
+            program: args.program,
+            mint: args.mint,
+            mint_authority: args.mint_authority.ok_or(ProgramError::InvalidArgument)?,
+            update_authority: args.update_authority.ok_or(ProgramError::InvalidArgument)?,
+            system_program: args.system_program.ok_or(ProgramError::InvalidArgument)?,
+            rent: args.rent.ok_or(ProgramError::InvalidArgument)?,
+            name: args.name.ok_or(ProgramError::InvalidArgument)?,
+            symbol: args.symbol.ok_or(ProgramError::InvalidArgument)?,
+            uri: args.uri.ok_or(ProgramError::InvalidArgument)?,
+            seller_fee_basis_points: args.seller_fee_basis_points.unwrap_or(0),
+            is_mutable: args.is_mutable.unwrap_or(true),
+        };
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn check<'a>(
+        account: &Account<crate::MetadataAccount>,
+        args: &Args<'a>,
+    ) -> Result<(), ProgramError> {
+        // Validate the metadata program address.
+        crate::validate::validate_metadata_program(args.program)?;
+        // PDA verification (AccountLoad already checked owner/data_len/key).
+        crate::pda::verify_metadata_address(
+            account.to_account_view().address(),
+            args.mint.address(),
+        )?;
+        // Cross-validate mint field in prefix matches the mint account.
+        if quasar_lang::utils::hint::unlikely(!quasar_lang::keys_eq(
+            account.mint(),
+            args.mint.address(),
+        )) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        // Optional update_authority check.
+        if let Some(ua) = args.update_authority {
+            if quasar_lang::utils::hint::unlikely(!quasar_lang::keys_eq(
+                account.update_authority(),
+                ua.address(),
+            )) {
+                return Err(ProgramError::InvalidAccountData);
+            }
+        }
+        Ok(())
+    }
+}

--- a/metadata/src/accounts/mod.rs
+++ b/metadata/src/accounts/mod.rs
@@ -1,0 +1,18 @@
+//! Metadata behavior modules for `#[derive(Accounts)]`.
+//!
+//! Each module exports `Args`, `Args::builder()`, and `Behavior`, implementing
+//! `AccountBehavior` for supported account wrapper types.
+//!
+//! # Adding a new behavior
+//!
+//! 1. Create `accounts/foo.rs`
+//! 2. Define `Args` struct + `ArgsBuilder` with `build_init()`,
+//!    `build_check()`, `build_exit()` methods
+//! 3. Define `Behavior` unit struct
+//! 4. Implement `AccountBehavior<T>` for each supported wrapper type
+//! 5. Export from `accounts/mod.rs`, `accounts/prelude.rs`, and `prelude.rs`
+//! 6. Add compile-pass and compile-fail tests in `metadata/tests/`
+
+pub mod master_edition;
+pub mod metadata;
+pub mod prelude;

--- a/metadata/src/accounts/prelude.rs
+++ b/metadata/src/accounts/prelude.rs
@@ -1,0 +1,1 @@
+pub use super::{master_edition, metadata};

--- a/metadata/src/instructions/mod.rs
+++ b/metadata/src/instructions/mod.rs
@@ -1,7 +1,7 @@
 mod approve_collection;
 mod burn;
-mod create_master_edition;
-mod create_metadata;
+pub(crate) mod create_master_edition;
+pub(crate) mod create_metadata;
 mod freeze_thaw;
 mod mint_edition;
 mod remove_creator;

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -7,17 +7,26 @@
 
 #![no_std]
 
+mod account_init;
+pub mod accounts;
 mod codec;
 mod constants;
 mod init;
 pub mod instructions;
+pub mod pda;
+pub mod prelude;
 mod program;
 mod state;
+pub mod validate;
 
 pub use {
+    account_init::{MasterEditionInitParams, MetadataInitParams},
     constants::METADATA_PROGRAM_ID,
     init::{InitMasterEdition, InitMetadata},
     instructions::MetadataCpi,
     program::MetadataProgram,
-    state::{MasterEditionPrefix, MetadataPrefix},
+    state::{
+        MasterEditionAccount, MasterEditionPrefix, MasterEditionPrefixZc, MetadataAccount,
+        MetadataPrefix, MetadataPrefixZc,
+    },
 };

--- a/metadata/src/pda.rs
+++ b/metadata/src/pda.rs
@@ -1,0 +1,80 @@
+//! PDA derivation and verification helpers for Metaplex Token Metadata.
+//!
+//! Canonical seeds:
+//! - Metadata: `["metadata", metadata_program_id, mint]`
+//! - Master Edition: `["metadata", metadata_program_id, mint, "edition"]`
+
+use {
+    crate::constants::{METADATA_PROGRAM_BYTES, METADATA_PROGRAM_ID},
+    quasar_lang::__solana_program_error::ProgramError,
+    solana_address::Address,
+};
+
+const METADATA_SEED: &[u8] = b"metadata";
+const EDITION_SEED: &[u8] = b"edition";
+
+/// Derive the metadata PDA address from a mint.
+///
+/// **Cost:** ~544 CU (SHA-256 loop). Prefer [`verify_metadata_address`] when
+/// the address is already known.
+#[inline(always)]
+pub fn metadata_address(mint: &Address) -> (Address, u8) {
+    quasar_lang::pda::based_try_find_program_address(
+        &[METADATA_SEED, &METADATA_PROGRAM_BYTES, mint.as_ref()],
+        &METADATA_PROGRAM_ID,
+    )
+    .unwrap()
+}
+
+/// Derive the master edition PDA address from a mint.
+///
+/// **Cost:** ~544 CU. Prefer [`verify_master_edition_address`] when known.
+#[inline(always)]
+pub fn master_edition_address(mint: &Address) -> (Address, u8) {
+    quasar_lang::pda::based_try_find_program_address(
+        &[
+            METADATA_SEED,
+            &METADATA_PROGRAM_BYTES,
+            mint.as_ref(),
+            EDITION_SEED,
+        ],
+        &METADATA_PROGRAM_ID,
+    )
+    .unwrap()
+}
+
+/// Verify a metadata address matches the expected PDA for a mint.
+///
+/// **Cost:** ~90 CU per attempt (single SHA-256 + compare).
+#[inline(always)]
+pub fn verify_metadata_address(address: &Address, mint: &Address) -> Result<(), ProgramError> {
+    quasar_lang::pda::find_bump_for_address(
+        &[METADATA_SEED, &METADATA_PROGRAM_BYTES, mint.as_ref()],
+        &METADATA_PROGRAM_ID,
+        address,
+    )
+    .map(|_| ())
+    .map_err(|_| ProgramError::InvalidSeeds)
+}
+
+/// Verify a master edition address matches the expected PDA for a mint.
+///
+/// **Cost:** ~90 CU per attempt.
+#[inline(always)]
+pub fn verify_master_edition_address(
+    address: &Address,
+    mint: &Address,
+) -> Result<(), ProgramError> {
+    quasar_lang::pda::find_bump_for_address(
+        &[
+            METADATA_SEED,
+            &METADATA_PROGRAM_BYTES,
+            mint.as_ref(),
+            EDITION_SEED,
+        ],
+        &METADATA_PROGRAM_ID,
+        address,
+    )
+    .map(|_| ())
+    .map_err(|_| ProgramError::InvalidSeeds)
+}

--- a/metadata/src/prelude.rs
+++ b/metadata/src/prelude.rs
@@ -1,0 +1,15 @@
+//! Convenience re-exports for metadata programs.
+//!
+//! ```rust,ignore
+//! use quasar_lang::prelude::*;
+//! use quasar_metadata::prelude::*;
+//! ```
+
+pub use crate::{
+    accounts::{master_edition, metadata},
+    init::{InitMasterEdition, InitMetadata},
+    instructions::MetadataCpi,
+    pda::*,
+    MasterEditionAccount, MasterEditionPrefix, MasterEditionPrefixZc, MetadataAccount,
+    MetadataPrefix, MetadataPrefixZc, MetadataProgram,
+};

--- a/metadata/src/program.rs
+++ b/metadata/src/program.rs
@@ -8,3 +8,5 @@ quasar_lang::define_account!(pub struct MetadataProgram => [checks::Executable, 
 impl Id for MetadataProgram {
     const ID: Address = Address::new_from_array(METADATA_PROGRAM_BYTES);
 }
+
+impl crate::instructions::MetadataCpi for Program<MetadataProgram> {}

--- a/metadata/src/state.rs
+++ b/metadata/src/state.rs
@@ -1,14 +1,19 @@
-use solana_address::Address;
+use {
+    crate::constants::METADATA_PROGRAM_ID,
+    quasar_lang::{__zeropod as zeropod, prelude::*},
+    solana_address::Address,
+};
+
+// Re-export zeropod so #[derive(ZeroPod)] expansion resolves `zeropod::*`
+// paths.
 
 /// Metaplex Key enum discriminant for MetadataV1 accounts.
-#[allow(dead_code)]
-const KEY_METADATA_V1: u8 = 4;
+pub(crate) const KEY_METADATA_V1: u8 = 4;
 /// Metaplex Key enum discriminant for MasterEditionV2 accounts.
-#[allow(dead_code)]
-const KEY_MASTER_EDITION_V2: u8 = 6;
+pub(crate) const KEY_MASTER_EDITION_V2: u8 = 6;
 
 // ---------------------------------------------------------------------------
-// MetadataPrefix — zero-copy layout for the fixed 65-byte header
+// MetadataPrefix — ZeroPod schema for the fixed 65-byte header
 // ---------------------------------------------------------------------------
 
 /// Zero-copy layout for the fixed-size prefix of Metaplex Metadata accounts.
@@ -20,37 +25,21 @@ const KEY_MASTER_EDITION_V2: u8 = 6;
 ///
 /// Fields after the prefix (name, symbol, uri, creators, etc.) are
 /// variable-length Borsh-serialized data and require offset walking to access.
-#[repr(C)]
+#[derive(quasar_lang::__zeropod::ZeroPod)]
 pub struct MetadataPrefix {
-    key: u8,
-    update_authority: Address,
-    mint: Address,
+    pub key: u8,
+    pub update_authority: Address,
+    pub mint: Address,
 }
 
-impl MetadataPrefix {
-    pub const LEN: usize = core::mem::size_of::<Self>();
-
-    #[inline(always)]
-    pub fn key(&self) -> u8 {
-        self.key
-    }
-
-    #[inline(always)]
-    pub fn update_authority(&self) -> &Address {
-        &self.update_authority
-    }
-
-    #[inline(always)]
-    pub fn mint(&self) -> &Address {
-        &self.mint
-    }
-}
-
-const _: () = assert!(core::mem::size_of::<MetadataPrefix>() == 65);
-const _: () = assert!(core::mem::align_of::<MetadataPrefix>() == 1);
+const _: () = assert!(core::mem::size_of::<MetadataPrefixZc>() == 65);
+const _: () = assert!(core::mem::align_of::<MetadataPrefixZc>() == 1);
+const _: () = assert!(core::mem::offset_of!(MetadataPrefixZc, key) == 0);
+const _: () = assert!(core::mem::offset_of!(MetadataPrefixZc, update_authority) == 1);
+const _: () = assert!(core::mem::offset_of!(MetadataPrefixZc, mint) == 33);
 
 // ---------------------------------------------------------------------------
-// MasterEditionPrefix — zero-copy layout for the fixed 18-byte header
+// MasterEditionPrefix — ZeroPod schema for the fixed 18-byte header
 // ---------------------------------------------------------------------------
 
 /// Zero-copy layout for the fixed-size prefix of Metaplex MasterEdition
@@ -59,55 +48,79 @@ const _: () = assert!(core::mem::align_of::<MetadataPrefix>() == 1);
 /// - `key` (1 byte): Metaplex account type discriminant (`Key::MasterEditionV2
 ///   = 6`)
 /// - `supply` (8 bytes, u64 LE): number of editions printed
-/// - `max_supply_flag` (1 byte): `Option<u64>` tag — 0 = None (unlimited), 1 =
-///   Some
-/// - `max_supply` (8 bytes, u64 LE): maximum editions (valid only when flag ==
-///   1)
-#[repr(C)]
+/// - `max_supply` (9 bytes): Borsh `Option<u64>` — 1-byte tag + 8-byte value
+#[derive(quasar_lang::__zeropod::ZeroPod)]
 pub struct MasterEditionPrefix {
-    key: u8,
-    supply: [u8; 8],
-    max_supply_flag: u8,
-    max_supply: [u8; 8],
+    pub key: u8,
+    pub supply: u64,
+    pub max_supply: zeropod::pod::PodOption<zeropod::pod::PodU64, 1>,
 }
 
-impl MasterEditionPrefix {
-    pub const LEN: usize = core::mem::size_of::<Self>();
+const _: () = assert!(core::mem::size_of::<MasterEditionPrefixZc>() == 18);
+const _: () = assert!(core::mem::align_of::<MasterEditionPrefixZc>() == 1);
+const _: () = assert!(core::mem::offset_of!(MasterEditionPrefixZc, key) == 0);
+const _: () = assert!(core::mem::offset_of!(MasterEditionPrefixZc, supply) == 1);
+const _: () = assert!(core::mem::offset_of!(MasterEditionPrefixZc, max_supply) == 9);
 
+/// Semantic accessors for MasterEditionPrefixZc.
+impl MasterEditionPrefixZc {
     #[inline(always)]
-    pub fn key(&self) -> u8 {
-        self.key
+    pub fn supply_value(&self) -> u64 {
+        self.supply.get()
     }
 
     #[inline(always)]
-    pub fn supply(&self) -> u64 {
-        u64::from_le_bytes(self.supply)
-    }
-
-    #[inline(always)]
-    pub fn max_supply(&self) -> Option<u64> {
-        if self.max_supply_flag == 1 {
-            Some(u64::from_le_bytes(self.max_supply))
-        } else {
-            None
-        }
+    pub fn max_supply_value(&self) -> Option<u64> {
+        self.max_supply.get_ref().map(|v| v.get())
     }
 }
 
-const _: () = assert!(core::mem::size_of::<MasterEditionPrefix>() == 18);
-const _: () = assert!(core::mem::align_of::<MasterEditionPrefix>() == 1);
-
 // ---------------------------------------------------------------------------
-// MetadataAccount / MasterEditionAccount — TODO: rework in follow-up PR
-//
-// These marker types predate the current AccountLoad pattern. They need to be
-// reworked as #[repr(transparent)] over AccountView (like Token/Mint) to
-// satisfy AccountLoad's AsAccountView supertrait. Left commented out to
-// demonstrate how easy external account types are with the new system.
+// MetadataAccount — schema form define_account!
 // ---------------------------------------------------------------------------
 
-// pub struct MetadataAccount { ... }
-// pub struct MasterEditionAccount { ... }
+quasar_lang::define_account!(
+    /// Metaplex Metadata account — validates owner is Metadata program.
+    ///
+    /// Derefs to [`MetadataPrefixZc`] for zero-copy access to the fixed-size
+    /// header (update_authority, mint). Variable-length fields (name, symbol,
+    /// uri, creators) require Borsh deserialization and are not exposed here.
+    ///
+    /// Checks: owner == Metadata program, data_len >= 65, key byte == 4,
+    /// ZeroPod validation.
+    pub struct MetadataAccount => [checks::Owner, checks::Discriminator, checks::DataLen, checks::ZeroPod]: MetadataPrefix
+);
+
+impl Owner for MetadataAccount {
+    const OWNER: Address = METADATA_PROGRAM_ID;
+}
+
+impl quasar_lang::traits::Discriminator for MetadataAccount {
+    const DISCRIMINATOR: &'static [u8] = &[KEY_METADATA_V1];
+}
+
+// ---------------------------------------------------------------------------
+// MasterEditionAccount — schema form define_account!
+// ---------------------------------------------------------------------------
+
+quasar_lang::define_account!(
+    /// Metaplex MasterEdition account — validates owner is Metadata program.
+    ///
+    /// Derefs to [`MasterEditionPrefixZc`] for zero-copy access to supply and
+    /// max_supply fields.
+    ///
+    /// Checks: owner == Metadata program, data_len >= 18, key byte == 6,
+    /// ZeroPod validation.
+    pub struct MasterEditionAccount => [checks::Owner, checks::Discriminator, checks::DataLen, checks::ZeroPod]: MasterEditionPrefix
+);
+
+impl Owner for MasterEditionAccount {
+    const OWNER: Address = METADATA_PROGRAM_ID;
+}
+
+impl quasar_lang::traits::Discriminator for MasterEditionAccount {
+    const DISCRIMINATOR: &'static [u8] = &[KEY_MASTER_EDITION_V2];
+}
 
 // ---------------------------------------------------------------------------
 // Kani model-checking proof harnesses
@@ -117,66 +130,55 @@ const _: () = assert!(core::mem::align_of::<MasterEditionPrefix>() == 1);
 mod kani_proofs {
     use super::*;
 
-    // --- MetadataPrefix ---
+    // --- MetadataPrefixZc ---
 
-    /// Prove MetadataPrefix::LEN matches the actual struct size.
+    /// Prove MetadataPrefixZc is exactly 65 bytes (matches ZeroPodFixed::SIZE).
     #[kani::proof]
-    fn metadata_prefix_len_matches_sizeof() {
-        assert!(MetadataPrefix::LEN == core::mem::size_of::<MetadataPrefix>());
+    fn metadata_prefix_zc_size_65() {
+        assert!(core::mem::size_of::<MetadataPrefixZc>() == 65);
+        assert!(<MetadataPrefix as quasar_lang::__zeropod::ZeroPodFixed>::SIZE == 65);
     }
 
-    /// Prove MetadataPrefix has alignment 1 (safe for pointer cast from
+    /// Prove MetadataPrefixZc has alignment 1 (safe for pointer cast from
     /// arbitrary account data).
     #[kani::proof]
-    fn metadata_prefix_align_one() {
-        assert!(core::mem::align_of::<MetadataPrefix>() == 1);
+    fn metadata_prefix_zc_align_one() {
+        assert!(core::mem::align_of::<MetadataPrefixZc>() == 1);
     }
 
-    /// Prove MetadataPrefix is exactly 65 bytes.
-    #[kani::proof]
-    fn metadata_prefix_size_65() {
-        assert!(core::mem::size_of::<MetadataPrefix>() == 65);
-    }
-
-    /// Prove: for any `data_len >= MetadataPrefix::LEN`, the data covers
-    /// the full struct — verifies the runtime guard in `MetadataAccount::check`
-    /// is sufficient for the pointer cast in `deref_from`.
+    /// Prove: for any `data_len >= ZeroPodFixed::SIZE`, the data covers
+    /// the full Zc struct — verifies the DataLen check is sufficient for
+    /// the pointer cast in Deref.
     #[kani::proof]
     fn metadata_prefix_data_len_guard_sufficient() {
         let data_len: usize = kani::any();
-        kani::assume(data_len >= MetadataPrefix::LEN);
-        assert!(data_len >= core::mem::size_of::<MetadataPrefix>());
+        kani::assume(data_len >= <MetadataPrefix as quasar_lang::__zeropod::ZeroPodFixed>::SIZE);
+        assert!(data_len >= core::mem::size_of::<MetadataPrefixZc>());
     }
 
-    // --- MasterEditionPrefix ---
+    // --- MasterEditionPrefixZc ---
 
-    /// Prove MasterEditionPrefix::LEN matches the actual struct size.
+    /// Prove MasterEditionPrefixZc is exactly 18 bytes.
     #[kani::proof]
-    fn master_edition_prefix_len_matches_sizeof() {
-        assert!(MasterEditionPrefix::LEN == core::mem::size_of::<MasterEditionPrefix>());
+    fn master_edition_prefix_zc_size_18() {
+        assert!(core::mem::size_of::<MasterEditionPrefixZc>() == 18);
+        assert!(<MasterEditionPrefix as quasar_lang::__zeropod::ZeroPodFixed>::SIZE == 18);
     }
 
-    /// Prove MasterEditionPrefix has alignment 1 (safe for pointer cast from
-    /// arbitrary account data).
+    /// Prove MasterEditionPrefixZc has alignment 1.
     #[kani::proof]
-    fn master_edition_prefix_align_one() {
-        assert!(core::mem::align_of::<MasterEditionPrefix>() == 1);
+    fn master_edition_prefix_zc_align_one() {
+        assert!(core::mem::align_of::<MasterEditionPrefixZc>() == 1);
     }
 
-    /// Prove MasterEditionPrefix is exactly 18 bytes.
-    #[kani::proof]
-    fn master_edition_prefix_size_18() {
-        assert!(core::mem::size_of::<MasterEditionPrefix>() == 18);
-    }
-
-    /// Prove: for any `data_len >= MasterEditionPrefix::LEN`, the data covers
-    /// the full struct — verifies the runtime guard in
-    /// `MasterEditionAccount::check` is sufficient for the pointer cast in
-    /// `deref_from`.
+    /// Prove: for any `data_len >= ZeroPodFixed::SIZE`, the data covers
+    /// the full Zc struct.
     #[kani::proof]
     fn master_edition_prefix_data_len_guard_sufficient() {
         let data_len: usize = kani::any();
-        kani::assume(data_len >= MasterEditionPrefix::LEN);
-        assert!(data_len >= core::mem::size_of::<MasterEditionPrefix>());
+        kani::assume(
+            data_len >= <MasterEditionPrefix as quasar_lang::__zeropod::ZeroPodFixed>::SIZE,
+        );
+        assert!(data_len >= core::mem::size_of::<MasterEditionPrefixZc>());
     }
 }

--- a/metadata/src/validate.rs
+++ b/metadata/src/validate.rs
@@ -1,0 +1,114 @@
+//! Account validation helpers.
+//!
+//! Single source of truth for validating metadata accounts, master editions,
+//! and the Metadata program. Every error path uses `unlikely()` hints for
+//! expected-success paths.
+//!
+//! These functions perform full validation (owner, data_len, key byte, fields).
+//! The behavior module's `check()` skips base checks already done by
+//! `AccountLoad::check` and calls PDA/field checks directly.
+
+use {
+    crate::state::{
+        MasterEditionPrefixZc, MetadataPrefixZc, KEY_MASTER_EDITION_V2, KEY_METADATA_V1,
+    },
+    quasar_lang::{prelude::*, utils::hint::unlikely},
+};
+
+/// Validate a metadata account (standalone, full checks).
+///
+/// Performs owner, data length, key discriminant, and field validation.
+/// `mint` is mandatory (always known from PDA derivation or behavior args).
+/// `update_authority` is optional — omit to skip that check.
+#[inline(always)]
+pub fn validate_metadata_account(
+    view: &AccountView,
+    mint: &Address,
+    update_authority: Option<&Address>,
+) -> Result<(), ProgramError> {
+    if unlikely(!quasar_lang::keys_eq(
+        view.owner(),
+        &crate::METADATA_PROGRAM_ID,
+    )) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_metadata_account: wrong program owner");
+        return Err(ProgramError::IllegalOwner);
+    }
+    if unlikely(view.data_len() < core::mem::size_of::<MetadataPrefixZc>()) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_metadata_account: data too small");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    // SAFETY: owner + data_len checked. MetadataPrefixZc is #[repr(C)] align 1.
+    let prefix = unsafe { &*(view.data_ptr() as *const MetadataPrefixZc) };
+    if unlikely(prefix.key() != KEY_METADATA_V1) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_metadata_account: wrong key discriminant");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if unlikely(!quasar_lang::keys_eq(prefix.mint(), mint)) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_metadata_account: mint mismatch");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if let Some(expected_ua) = update_authority {
+        if unlikely(!quasar_lang::keys_eq(
+            prefix.update_authority(),
+            expected_ua,
+        )) {
+            #[cfg(feature = "debug")]
+            quasar_lang::prelude::log("validate_metadata_account: update_authority mismatch");
+            return Err(ProgramError::InvalidAccountData);
+        }
+    }
+    Ok(())
+}
+
+/// Validate a master edition account (standalone, full checks).
+///
+/// Performs owner, data length, key discriminant, and optional PDA validation.
+#[inline(always)]
+pub fn validate_master_edition_account(
+    view: &AccountView,
+    mint: Option<&Address>,
+) -> Result<(), ProgramError> {
+    if unlikely(!quasar_lang::keys_eq(
+        view.owner(),
+        &crate::METADATA_PROGRAM_ID,
+    )) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_master_edition: wrong program owner");
+        return Err(ProgramError::IllegalOwner);
+    }
+    if unlikely(view.data_len() < core::mem::size_of::<MasterEditionPrefixZc>()) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_master_edition: data too small");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    // SAFETY: owner + data_len checked. MasterEditionPrefixZc is #[repr(C)] align
+    // 1.
+    let prefix = unsafe { &*(view.data_ptr() as *const MasterEditionPrefixZc) };
+    if unlikely(prefix.key() != KEY_MASTER_EDITION_V2) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("validate_master_edition: wrong key discriminant");
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if let Some(mint_addr) = mint {
+        crate::pda::verify_master_edition_address(view.address(), mint_addr)?;
+    }
+    Ok(())
+}
+
+/// Validate that an `AccountView` is the Metadata program.
+#[inline(always)]
+pub fn validate_metadata_program(view: &AccountView) -> Result<(), ProgramError> {
+    if unlikely(!quasar_lang::keys_eq(
+        view.address(),
+        &crate::METADATA_PROGRAM_ID,
+    )) {
+        #[cfg(feature = "debug")]
+        quasar_lang::prelude::log("Invalid metadata program");
+        return Err(ProgramError::IncorrectProgramId);
+    }
+    Ok(())
+}

--- a/metadata/tests/compile_fail.rs
+++ b/metadata/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/metadata/tests/compile_fail/init_master_edition_without_behavior.rs
+++ b/metadata/tests/compile_fail/init_master_edition_without_behavior.rs
@@ -1,0 +1,20 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+/// ERROR: init on MasterEditionAccount without a behavior module.
+#[derive(Accounts)]
+pub struct BadInit {
+    #[account(mut)]
+    pub payer: Signer,
+
+    pub system_program: Program<SystemProgram>,
+    pub rent: Sysvar<Rent>,
+
+    #[account(init, payer = payer)]
+    pub master_edition: Account<MasterEditionAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/compile_fail/init_master_edition_without_behavior.stderr
+++ b/metadata/tests/compile_fail/init_master_edition_without_behavior.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `quasar_metadata::MasterEditionAccount: quasar_lang::prelude::Space` is not satisfied
+  --> tests/compile_fail/init_master_edition_without_behavior.rs:17:25
+   |
+17 |     pub master_edition: Account<MasterEditionAccount>,
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `quasar_lang::prelude::Space` is not implemented for `quasar_metadata::MasterEditionAccount`
+   |
+   = help: the following other types implement trait `quasar_lang::prelude::Space`:
+             InterfaceAccount<T>
+             Migration<From, To>
+             quasar_lang::accounts::Account<T>
+   = note: required for `quasar_lang::accounts::Account<quasar_metadata::MasterEditionAccount>` to implement `quasar_lang::prelude::Space`
+
+error[E0271]: type mismatch resolving `<Account<MasterEditionAccount> as AccountInit>::InitParams<'_> == ()`
+  --> tests/compile_fail/init_master_edition_without_behavior.rs:17:25
+   |
+17 |     pub master_edition: Account<MasterEditionAccount>,
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `MasterEditionInitParams<'_>`
+   |
+note: required by a bound in `quasar_lang::ops::init::Op::<'a, P>::apply`
+  --> $WORKSPACE/lang/src/ops/init.rs
+   |
+   |     pub fn apply<F: AccountLoad + AccountInit<InitParams<'a> = P>>(
+   |                                               ^^^^^^^^^^^^^^^^^^ required by this bound in `Op::<'a, P>::apply`
+
+error[E0080]: evaluation panicked: field `master_edition` requires an init-param behavior (e.g., token(...) or mint(...))
+ --> tests/compile_fail/init_master_edition_without_behavior.rs:8:10
+  |
+8 | #[derive(Accounts)]
+  |          ^^^^^^^^ evaluation of `<BadInit as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here

--- a/metadata/tests/compile_fail/init_without_behavior.rs
+++ b/metadata/tests/compile_fail/init_without_behavior.rs
@@ -1,0 +1,20 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct BadInit {
+    #[account(mut)]
+    pub payer: Signer,
+
+    pub system_program: Program<SystemProgram>,
+    pub rent: Sysvar<Rent>,
+
+    /// This should fail: init without a behavior module on a protocol account.
+    #[account(init, payer = payer)]
+    pub metadata: Account<MetadataAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/compile_fail/init_without_behavior.stderr
+++ b/metadata/tests/compile_fail/init_without_behavior.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `quasar_metadata::MetadataAccount: quasar_lang::prelude::Space` is not satisfied
+  --> tests/compile_fail/init_without_behavior.rs:17:19
+   |
+17 |     pub metadata: Account<MetadataAccount>,
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `quasar_lang::prelude::Space` is not implemented for `quasar_metadata::MetadataAccount`
+   |
+   = help: the following other types implement trait `quasar_lang::prelude::Space`:
+             InterfaceAccount<T>
+             Migration<From, To>
+             quasar_lang::accounts::Account<T>
+   = note: required for `quasar_lang::accounts::Account<quasar_metadata::MetadataAccount>` to implement `quasar_lang::prelude::Space`
+
+error[E0271]: type mismatch resolving `<Account<MetadataAccount> as AccountInit>::InitParams<'_> == ()`
+  --> tests/compile_fail/init_without_behavior.rs:17:19
+   |
+17 |     pub metadata: Account<MetadataAccount>,
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `MetadataInitParams<'_>`
+   |
+note: required by a bound in `quasar_lang::ops::init::Op::<'a, P>::apply`
+  --> $WORKSPACE/lang/src/ops/init.rs
+   |
+   |     pub fn apply<F: AccountLoad + AccountInit<InitParams<'a> = P>>(
+   |                                               ^^^^^^^^^^^^^^^^^^ required by this bound in `Op::<'a, P>::apply`
+
+error[E0080]: evaluation panicked: field `metadata` requires an init-param behavior (e.g., token(...) or mint(...))
+ --> tests/compile_fail/init_without_behavior.rs:7:10
+  |
+7 | #[derive(Accounts)]
+  |          ^^^^^^^^ evaluation of `<BadInit as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here

--- a/metadata/tests/compile_fail/metadata_bad_field_ref.rs
+++ b/metadata/tests/compile_fail/metadata_bad_field_ref.rs
@@ -1,0 +1,17 @@
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::*;
+use quasar_metadata::accounts::metadata;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+/// ERROR: `nonexistent_field` is not a field in the struct.
+#[derive(Accounts)]
+pub struct Bad {
+    pub metadata_program: Program<MetadataProgram>,
+
+    #[account(metadata(program = metadata_program, mint = nonexistent_field))]
+    pub metadata: Account<MetadataAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/compile_fail/metadata_bad_field_ref.stderr
+++ b/metadata/tests/compile_fail/metadata_bad_field_ref.stderr
@@ -1,0 +1,13 @@
+error: `mint = nonexistent_field` — no field `nonexistent_field` in this accounts struct
+  --> tests/compile_fail/metadata_bad_field_ref.rs:13:59
+   |
+13 |     #[account(metadata(program = metadata_program, mint = nonexistent_field))]
+   |                                                           ^^^^^^^^^^^^^^^^^
+
+warning: unused import: `quasar_metadata::accounts::metadata`
+ --> tests/compile_fail/metadata_bad_field_ref.rs:4:5
+  |
+4 | use quasar_metadata::accounts::metadata;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/metadata/tests/compile_pass.rs
+++ b/metadata/tests/compile_pass.rs
@@ -1,0 +1,10 @@
+//! Compile-pass tests for metadata behavior modules.
+//!
+//! These verify that valid account declarations with metadata/master_edition
+//! behaviors compile successfully.
+
+#[test]
+fn compile_pass_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/compile_pass/*.rs");
+}

--- a/metadata/tests/compile_pass/init_metadata_with_behavior.rs
+++ b/metadata/tests/compile_pass/init_metadata_with_behavior.rs
@@ -1,0 +1,39 @@
+//! Compile-pass: init metadata account with behavior module.
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::{accounts::metadata, *};
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct InitMetadataAccount {
+    #[account(mut)]
+    pub payer: Signer,
+    pub metadata_program: Program<MetadataProgram>,
+    pub system_program: Program<SystemProgram>,
+    pub rent: Sysvar<Rent>,
+    pub mint: UncheckedAccount,
+    pub mint_authority: Signer,
+    pub update_authority: Signer,
+
+    #[account(
+        init,
+        payer = payer,
+        metadata(
+            program = metadata_program,
+            mint = mint,
+            mint_authority = mint_authority,
+            update_authority = update_authority,
+            system_program = system_program,
+            rent = rent,
+            name = "My NFT",
+            symbol = "NFT",
+            uri = "https://example.com/meta.json",
+            seller_fee_basis_points = 500,
+            is_mutable = true,
+        )
+    )]
+    pub metadata: Account<MetadataAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/compile_pass/validate_master_edition_check.rs
+++ b/metadata/tests/compile_pass/validate_master_edition_check.rs
@@ -1,0 +1,17 @@
+//! Compile-pass: existing master edition account with behavior check constraints.
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::{accounts::master_edition, *};
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct ValidateMasterEdition {
+    pub metadata_program: Program<MetadataProgram>,
+    pub mint: UncheckedAccount,
+
+    #[account(master_edition(program = metadata_program, mint = mint))]
+    pub master_edition: Account<MasterEditionAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/compile_pass/validate_metadata_check.rs
+++ b/metadata/tests/compile_pass/validate_metadata_check.rs
@@ -1,0 +1,17 @@
+//! Compile-pass: existing metadata account with behavior check constraints.
+#![allow(unexpected_cfgs)]
+use quasar_lang::prelude::*;
+use quasar_metadata::{accounts::metadata, *};
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[derive(Accounts)]
+pub struct ValidateMetadata {
+    pub metadata_program: Program<MetadataProgram>,
+    pub mint: UncheckedAccount,
+
+    #[account(metadata(program = metadata_program, mint = mint))]
+    pub metadata: Account<MetadataAccount>,
+}
+
+fn main() {}

--- a/metadata/tests/miri.rs
+++ b/metadata/tests/miri.rs
@@ -1,0 +1,378 @@
+//! Miri UB tests for quasar-metadata unsafe code paths.
+//!
+//! ## Run
+//!
+//! ```sh
+//! MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" \
+//!   cargo +nightly miri test -p quasar-metadata --test miri
+//! ```
+#![allow(clippy::needless_range_loop)]
+
+use {
+    quasar_lang::__internal::{
+        AccountView, RuntimeAccount, MAX_PERMITTED_DATA_INCREASE, NOT_BORROWED,
+    },
+    quasar_metadata::{
+        MasterEditionAccount, MasterEditionPrefixZc, MetadataAccount, MetadataPrefixZc,
+    },
+    solana_address::Address,
+    solana_program_error::ProgramError,
+    std::mem::size_of,
+};
+
+const METADATA_OWNER: [u8; 32] = [
+    11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184, 108, 115,
+    26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70,
+];
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+struct AccountBuffer {
+    inner: Vec<u64>,
+}
+
+impl AccountBuffer {
+    fn new(data_len: usize) -> Self {
+        let byte_len =
+            size_of::<RuntimeAccount>() + data_len + MAX_PERMITTED_DATA_INCREASE + size_of::<u64>();
+        let u64_count = byte_len.div_ceil(8);
+        Self {
+            inner: vec![0; u64_count],
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.inner.as_mut_ptr() as *mut u8
+    }
+
+    fn raw(&mut self) -> *mut RuntimeAccount {
+        self.inner.as_mut_ptr() as *mut RuntimeAccount
+    }
+
+    fn init(
+        &mut self,
+        address: [u8; 32],
+        owner: [u8; 32],
+        lamports: u64,
+        data_len: u64,
+        is_signer: bool,
+        is_writable: bool,
+    ) {
+        let raw = self.raw();
+        unsafe {
+            (*raw).borrow_state = NOT_BORROWED;
+            (*raw).is_signer = is_signer as u8;
+            (*raw).is_writable = is_writable as u8;
+            (*raw).executable = 0;
+            (*raw).padding = [0u8; 4];
+            (*raw).address = Address::new_from_array(address);
+            (*raw).owner = Address::new_from_array(owner);
+            (*raw).lamports = lamports;
+            (*raw).data_len = data_len;
+        }
+    }
+
+    unsafe fn view(&mut self) -> AccountView {
+        AccountView::new_unchecked(self.raw())
+    }
+
+    fn write_data(&mut self, data: &[u8]) {
+        let data_start = size_of::<RuntimeAccount>();
+        let dst = unsafe {
+            std::slice::from_raw_parts_mut(self.as_mut_ptr().add(data_start), data.len())
+        };
+        dst.copy_from_slice(data);
+    }
+}
+
+/// Build a 65+ byte metadata account data buffer.
+fn build_metadata_data(key: u8, update_authority: [u8; 32], mint: [u8; 32]) -> Vec<u8> {
+    let mut data = vec![0u8; 128]; // larger than prefix to simulate real account
+    data[0] = key;
+    data[1..33].copy_from_slice(&update_authority);
+    data[33..65].copy_from_slice(&mint);
+    data
+}
+
+/// Build an 18+ byte master edition account data buffer.
+fn build_master_edition_data(key: u8, supply: u64, max_supply: Option<u64>) -> Vec<u8> {
+    let mut data = vec![0u8; 32]; // larger than prefix
+    data[0] = key;
+    data[1..9].copy_from_slice(&supply.to_le_bytes());
+    match max_supply {
+        Some(v) => {
+            data[9] = 1;
+            data[10..18].copy_from_slice(&v.to_le_bytes());
+        }
+        None => {
+            data[9] = 0;
+            data[10..18].copy_from_slice(&0u64.to_le_bytes());
+        }
+    }
+    data
+}
+
+const FAKE_ADDR: [u8; 32] = [1u8; 32];
+const FAKE_MINT: [u8; 32] = [2u8; 32];
+const FAKE_UA: [u8; 32] = [3u8; 32];
+
+// ---------------------------------------------------------------------------
+// Size / alignment assertions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metadata_prefix_zc_size_65() {
+    assert_eq!(size_of::<MetadataPrefixZc>(), 65);
+    assert_eq!(std::mem::align_of::<MetadataPrefixZc>(), 1);
+}
+
+#[test]
+fn master_edition_prefix_zc_size_18() {
+    assert_eq!(size_of::<MasterEditionPrefixZc>(), 18);
+    assert_eq!(std::mem::align_of::<MasterEditionPrefixZc>(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// MetadataAccount Deref — Miri UB detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metadata_deref_reads_correct_fields() {
+    let data = build_metadata_data(4, FAKE_UA, FAKE_MINT);
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(result.is_ok());
+
+    let account = unsafe { MetadataAccount::from_account_view_unchecked(&view) };
+    assert_eq!(account.key, 4);
+    assert_eq!(account.update_authority.as_ref(), &FAKE_UA);
+    assert_eq!(account.mint.as_ref(), &FAKE_MINT);
+}
+
+#[test]
+fn metadata_wrong_key_byte_rejected() {
+    let data = build_metadata_data(6, FAKE_UA, FAKE_MINT); // key=6, not 4
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(result.is_err());
+}
+
+#[test]
+fn metadata_wrong_owner_rejected() {
+    let data = build_metadata_data(4, FAKE_UA, FAKE_MINT);
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        [0u8; 32],
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    ); // wrong owner
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(matches!(result, Err(ProgramError::IllegalOwner)));
+}
+
+#[test]
+fn metadata_data_too_small_rejected() {
+    let data = vec![4u8; 10]; // only 10 bytes, need 65
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// MasterEditionAccount Deref — Miri UB detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn master_edition_deref_reads_correct_fields() {
+    let data = build_master_edition_data(6, 42, Some(100));
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result = <MasterEditionAccount as quasar_lang::account_load::AccountLoad>::check(
+        &view,
+        "master_edition",
+    );
+    assert!(result.is_ok());
+
+    let account = unsafe { MasterEditionAccount::from_account_view_unchecked(&view) };
+    assert_eq!(account.key, 6);
+    assert_eq!(account.supply_value(), 42);
+    assert_eq!(account.max_supply_value(), Some(100));
+}
+
+#[test]
+fn master_edition_unlimited_supply() {
+    let data = build_master_edition_data(6, 0, None);
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result = <MasterEditionAccount as quasar_lang::account_load::AccountLoad>::check(
+        &view,
+        "master_edition",
+    );
+    assert!(result.is_ok());
+
+    let account = unsafe { MasterEditionAccount::from_account_view_unchecked(&view) };
+    assert_eq!(account.supply_value(), 0);
+    assert_eq!(account.max_supply_value(), None);
+}
+
+#[test]
+fn master_edition_wrong_key_byte_rejected() {
+    let data = build_master_edition_data(4, 0, None); // key=4, not 6
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result = <MasterEditionAccount as quasar_lang::account_load::AccountLoad>::check(
+        &view,
+        "master_edition",
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn master_edition_data_too_small_rejected() {
+    let data = vec![6u8; 10]; // only 10 bytes, need 18
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    let result = <MasterEditionAccount as quasar_lang::account_load::AccountLoad>::check(
+        &view,
+        "master_edition",
+    );
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial data — Miri UB detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metadata_all_zeros_rejected() {
+    let data = vec![0u8; 128];
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    // key=0, should be rejected (not 4)
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(result.is_err());
+}
+
+#[test]
+fn metadata_all_ff_rejected_or_valid() {
+    let data = vec![0xFFu8; 128];
+    let mut buf = AccountBuffer::new(data.len());
+    buf.init(
+        FAKE_ADDR,
+        METADATA_OWNER,
+        1_000_000,
+        data.len() as u64,
+        false,
+        false,
+    );
+    buf.write_data(&data);
+
+    let view = unsafe { buf.view() };
+    // key=0xFF, should be rejected (not 4)
+    let result =
+        <MetadataAccount as quasar_lang::account_load::AccountLoad>::check(&view, "metadata");
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// PDA helpers — require SVM runtime (syscalls unavailable in unit tests)
+// ---------------------------------------------------------------------------
+// PDA derivation and verification tests belong in SVM integration tests
+// because `based_try_find_program_address` and `find_bump_for_address`
+// use Solana syscalls that are only available in the runtime.

--- a/tests/programs/test-metadata-validate/Cargo.toml
+++ b/tests/programs/test-metadata-validate/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "quasar-test-metadata-validate"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true
+
+[features]
+default = ["alloc"]
+alloc = []
+debug = []
+
+[dependencies]
+quasar-lang = { path = "../../../lang" }
+quasar-spl = { path = "../../../spl" }
+quasar-derive = { path = "../../../derive" }
+quasar-metadata = { path = "../../../metadata" }
+
+[dev-dependencies]

--- a/tests/programs/test-metadata-validate/src/instructions/init_master_edition.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/init_master_edition.rs
@@ -1,0 +1,95 @@
+use {
+    quasar_lang::prelude::*,
+    quasar_metadata::{
+        accounts::{master_edition, metadata},
+        prelude::*,
+    },
+    quasar_spl::prelude::*,
+};
+
+/// Init BOTH metadata + master edition via derive behaviors, then verify ALL
+/// prefix fields on both accounts.
+///
+/// Metadata MUST be declared before master_edition — the derive processes
+/// init in field declaration order.
+#[derive(Accounts)]
+pub struct InitMasterEditionTest {
+    #[account(mut)]
+    pub payer: Signer,
+    pub metadata_program: Program<MetadataProgram>,
+    pub system_program: Program<SystemProgram>,
+    pub rent: Sysvar<Rent>,
+    #[account(mut)]
+    pub mint: UncheckedAccount,
+    pub update_authority: Signer,
+    pub mint_authority: Signer,
+    pub token_program: Program<TokenProgram>,
+
+    /// Metadata is init'd first (field order determines init order).
+    #[account(
+        init,
+        payer = payer,
+        metadata(
+            program = metadata_program,
+            mint = mint,
+            mint_authority = mint_authority,
+            update_authority = update_authority,
+            system_program = system_program,
+            rent = rent,
+            name = "Test NFT",
+            symbol = "TNFT",
+            uri = "https://example.com/nft.json",
+            seller_fee_basis_points = 500,
+            is_mutable = true,
+        )
+    )]
+    pub metadata_account: Account<MetadataAccount>,
+
+    /// Master edition init'd second — uses the now-existing metadata.
+    #[account(
+        init,
+        payer = payer,
+        master_edition(
+            program = metadata_program,
+            mint = mint,
+            update_authority = update_authority,
+            mint_authority = mint_authority,
+            metadata = metadata_account,
+            token_program = token_program,
+            system_program = system_program,
+            rent = rent,
+            max_supply = Some(0),
+        )
+    )]
+    pub master_edition: Account<MasterEditionAccount>,
+}
+
+impl InitMasterEditionTest {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        // Verify ALL metadata prefix fields
+        let meta = &*self.metadata_account;
+        require!(meta.key == 4, ProgramError::InvalidAccountData);
+        require_keys_eq!(
+            meta.update_authority,
+            *self.update_authority.to_account_view().address(),
+            ProgramError::InvalidAccountData
+        );
+        require_keys_eq!(
+            meta.mint,
+            *self.mint.to_account_view().address(),
+            ProgramError::InvalidAccountData
+        );
+
+        // Verify ALL master edition prefix fields
+        let me = &*self.master_edition;
+        require!(me.key == 6, ProgramError::InvalidAccountData);
+        require!(me.supply_value() == 0, ProgramError::InvalidAccountData);
+        match me.max_supply_value() {
+            Some(0) => {}
+            _ => return Err(ProgramError::InvalidAccountData),
+        }
+
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/init_metadata.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/init_metadata.rs
@@ -1,0 +1,64 @@
+use {
+    quasar_lang::prelude::*,
+    quasar_metadata::{accounts::metadata, prelude::*},
+};
+
+/// Init metadata account via CPI to Metaplex, then verify ALL prefix fields.
+#[derive(Accounts)]
+pub struct InitMetadataTest {
+    #[account(mut)]
+    pub payer: Signer,
+    pub metadata_program: Program<MetadataProgram>,
+    pub system_program: Program<SystemProgram>,
+    pub rent: Sysvar<Rent>,
+    pub mint: UncheckedAccount,
+    pub mint_authority: Signer,
+    pub update_authority: Signer,
+
+    #[account(
+        init,
+        payer = payer,
+        metadata(
+            program = metadata_program,
+            mint = mint,
+            mint_authority = mint_authority,
+            update_authority = update_authority,
+            system_program = system_program,
+            rent = rent,
+            name = "Test NFT",
+            symbol = "TNFT",
+            uri = "https://example.com/nft.json",
+            seller_fee_basis_points = 500,
+            is_mutable = true,
+        )
+    )]
+    pub metadata: Account<MetadataAccount>,
+}
+
+impl InitMetadataTest {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        // After CPI, read back ALL accessible prefix fields via Deref to
+        // MetadataPrefixZc and verify they match.
+        let meta = &*self.metadata;
+
+        // key byte == 4 (MetadataV1)
+        require!(meta.key == 4, ProgramError::InvalidAccountData);
+
+        // update_authority matches what was passed in
+        require_keys_eq!(
+            meta.update_authority,
+            *self.update_authority.to_account_view().address(),
+            ProgramError::InvalidAccountData
+        );
+
+        // mint matches
+        require_keys_eq!(
+            meta.mint,
+            *self.mint.to_account_view().address(),
+            ProgramError::InvalidAccountData
+        );
+
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/mod.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/mod.rs
@@ -1,0 +1,13 @@
+mod init_master_edition;
+mod init_metadata;
+mod validate_bare_master_edition;
+mod validate_bare_metadata;
+mod validate_master_edition_check;
+mod validate_metadata_check;
+mod validate_metadata_with_ua;
+
+pub use {
+    init_master_edition::*, init_metadata::*, validate_bare_master_edition::*,
+    validate_bare_metadata::*, validate_master_edition_check::*, validate_metadata_check::*,
+    validate_metadata_with_ua::*,
+};

--- a/tests/programs/test-metadata-validate/src/instructions/validate_bare_master_edition.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/validate_bare_master_edition.rs
@@ -1,0 +1,14 @@
+use {quasar_lang::prelude::*, quasar_metadata::prelude::*};
+
+/// Validate bare master edition account (no behavior, just AccountLoad check).
+#[derive(Accounts)]
+pub struct ValidateBareMasterEdition {
+    pub master_edition: Account<MasterEditionAccount>,
+}
+
+impl ValidateBareMasterEdition {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/validate_bare_metadata.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/validate_bare_metadata.rs
@@ -1,0 +1,15 @@
+use {quasar_lang::prelude::*, quasar_metadata::prelude::*};
+
+/// Validate bare metadata account (no behavior, just AccountLoad check:
+/// owner + data_len + discriminator + ZeroPod).
+#[derive(Accounts)]
+pub struct ValidateBareMetadata {
+    pub metadata: Account<MetadataAccount>,
+}
+
+impl ValidateBareMetadata {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/validate_master_edition_check.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/validate_master_edition_check.rs
@@ -1,0 +1,18 @@
+use {quasar_lang::prelude::*, quasar_metadata::prelude::*};
+
+/// Validate master edition account with behavior: PDA check.
+#[derive(Accounts)]
+pub struct ValidateMasterEditionCheck {
+    pub metadata_program: Program<MetadataProgram>,
+    pub mint: UncheckedAccount,
+
+    #[account(master_edition(program = metadata_program, mint = mint))]
+    pub master_edition: Account<MasterEditionAccount>,
+}
+
+impl ValidateMasterEditionCheck {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/validate_metadata_check.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/validate_metadata_check.rs
@@ -1,0 +1,18 @@
+use {quasar_lang::prelude::*, quasar_metadata::prelude::*};
+
+/// Validate metadata account with behavior: PDA + mint cross-validation.
+#[derive(Accounts)]
+pub struct ValidateMetadataCheck {
+    pub metadata_program: Program<MetadataProgram>,
+    pub mint: UncheckedAccount,
+
+    #[account(metadata(program = metadata_program, mint = mint))]
+    pub metadata: Account<MetadataAccount>,
+}
+
+impl ValidateMetadataCheck {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/instructions/validate_metadata_with_ua.rs
+++ b/tests/programs/test-metadata-validate/src/instructions/validate_metadata_with_ua.rs
@@ -1,0 +1,23 @@
+use {quasar_lang::prelude::*, quasar_metadata::prelude::*};
+
+/// Validate metadata account with behavior + update_authority check.
+#[derive(Accounts)]
+pub struct ValidateMetadataWithUa {
+    pub metadata_program: Program<MetadataProgram>,
+    pub mint: UncheckedAccount,
+    pub update_authority: Signer,
+
+    #[account(metadata(
+        program = metadata_program,
+        mint = mint,
+        update_authority = update_authority,
+    ))]
+    pub metadata: Account<MetadataAccount>,
+}
+
+impl ValidateMetadataWithUa {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-metadata-validate/src/lib.rs
+++ b/tests/programs/test-metadata-validate/src/lib.rs
@@ -1,0 +1,63 @@
+#![no_std]
+#![allow(dead_code)]
+
+use quasar_lang::prelude::*;
+
+mod instructions;
+use instructions::*;
+declare_id!("11111111111111111111111111111113");
+
+#[program]
+mod quasar_test_metadata_validate {
+    use super::*;
+
+    // ------- Validation (existing accounts) -------
+
+    /// Metadata with behavior: PDA + mint cross-validation.
+    #[instruction(discriminator = 0)]
+    pub fn validate_metadata_check(ctx: Ctx<ValidateMetadataCheck>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Metadata with behavior + update_authority check.
+    #[instruction(discriminator = 1)]
+    pub fn validate_metadata_with_ua(ctx: Ctx<ValidateMetadataWithUa>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Master edition with behavior: PDA check.
+    #[instruction(discriminator = 2)]
+    pub fn validate_master_edition_check(
+        ctx: Ctx<ValidateMasterEditionCheck>,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Bare metadata — only AccountLoad checks (owner + key byte + data_len).
+    #[instruction(discriminator = 3)]
+    pub fn validate_bare_metadata(ctx: Ctx<ValidateBareMetadata>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Bare master edition — only AccountLoad checks.
+    #[instruction(discriminator = 4)]
+    pub fn validate_bare_master_edition(
+        ctx: Ctx<ValidateBareMasterEdition>,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    // ------- Init (CPI to Metaplex) -------
+
+    /// Init metadata via CPI + verify all prefix fields.
+    #[instruction(discriminator = 10)]
+    pub fn init_metadata_test(ctx: Ctx<InitMetadataTest>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Init master edition via CPI + verify all prefix fields.
+    #[instruction(discriminator = 11)]
+    pub fn init_master_edition_test(ctx: Ctx<InitMasterEditionTest>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+}

--- a/tests/suite/Cargo.toml
+++ b/tests/suite/Cargo.toml
@@ -21,6 +21,7 @@ quasar-test-token-cpi = { path = "../programs/test-token-cpi" }
 quasar-test-token-validate = { path = "../programs/test-token-validate" }
 quasar-test-heap = { path = "../programs/test-heap", features = ["client"] }
 quasar-test-token-init = { path = "../programs/test-token-init" }
+quasar-test-metadata-validate = { path = "../programs/test-metadata-validate" }
 quasar-test-one-of = { path = "../programs/test-one-of" }
 quasar-test-migrate = { path = "../programs/test-migrate" }
 quasar-test-raw = { path = "../programs/test-raw" }

--- a/tests/suite/src/helpers.rs
+++ b/tests/suite/src/helpers.rs
@@ -321,3 +321,101 @@ pub fn prefunded_account(address: Pubkey, lamports: u64) -> Account {
         executable: false,
     }
 }
+
+// ---------------------------------------------------------------------------
+// SVM factory — test-metadata-validate
+// ---------------------------------------------------------------------------
+
+const METADATA_PROGRAM_BYTES: [u8; 32] = [
+    11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184, 108, 115,
+    26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70,
+];
+
+pub fn svm_metadata_validate() -> QuasarSvm {
+    let elf = read_deploy_elf("quasar_test_metadata_validate");
+    let mpl_elf = std::fs::read("../../tests/fixtures/mpl_token_metadata.so")
+        .expect("missing mpl_token_metadata.so fixture — run `make build-sbf` first");
+    QuasarSvm::new()
+        .with_program(&quasar_test_metadata_validate::ID, &elf)
+        .with_program(&Address::new_from_array(METADATA_PROGRAM_BYTES), &mpl_elf)
+}
+
+/// NFT mint with supply=1 and freeze_authority set (both required by Metaplex).
+pub fn nft_mint_account(address: Pubkey, authority: Pubkey, token_program: Pubkey) -> Account {
+    quasar_svm::token::create_keyed_mint_account_with_program(
+        &address,
+        &Mint {
+            mint_authority: Some(authority).into(),
+            supply: 1,
+            decimals: 0,
+            is_initialized: true,
+            freeze_authority: Some(authority).into(),
+        },
+        &token_program,
+    )
+}
+
+pub fn metadata_program_id() -> Pubkey {
+    Address::new_from_array(METADATA_PROGRAM_BYTES)
+}
+
+/// Build raw metadata account data (65+ bytes).
+///
+/// Layout: key(1) | update_authority(32) | mint(32) | trailing zeros
+pub fn build_metadata_account_data(update_authority: Pubkey, mint: Pubkey) -> Vec<u8> {
+    let mut data = vec![0u8; 128]; // larger than prefix to simulate real account
+    data[0] = 4; // KEY_METADATA_V1
+    data[1..33].copy_from_slice(update_authority.as_ref());
+    data[33..65].copy_from_slice(mint.as_ref());
+    data
+}
+
+/// Build raw master edition account data (18+ bytes).
+///
+/// Layout: key(1) | supply(8) | max_supply_flag(1) | max_supply(8)
+pub fn build_master_edition_data(supply: u64, max_supply: Option<u64>) -> Vec<u8> {
+    let mut data = vec![0u8; 32];
+    data[0] = 6; // KEY_MASTER_EDITION_V2
+    data[1..9].copy_from_slice(&supply.to_le_bytes());
+    match max_supply {
+        Some(v) => {
+            data[9] = 1;
+            data[10..18].copy_from_slice(&v.to_le_bytes());
+        }
+        None => {
+            data[9] = 0;
+        }
+    }
+    data
+}
+
+/// Valid metadata account owned by Metaplex.
+pub fn metadata_account(address: Pubkey, update_authority: Pubkey, mint: Pubkey) -> Account {
+    raw_account(
+        address,
+        1_000_000,
+        build_metadata_account_data(update_authority, mint),
+        metadata_program_id(),
+    )
+}
+
+/// Valid master edition account owned by Metaplex.
+pub fn master_edition_account(address: Pubkey, supply: u64, max_supply: Option<u64>) -> Account {
+    raw_account(
+        address,
+        1_000_000,
+        build_master_edition_data(supply, max_supply),
+        metadata_program_id(),
+    )
+}
+
+/// Metadata program account (executable).
+pub fn metadata_program_account() -> Account {
+    Account {
+        address: metadata_program_id(),
+        lamports: 1_000_000,
+        data: vec![],
+        owner: Pubkey::default(), // BPF loader doesn't matter for address check
+        executable: true,
+    }
+}

--- a/tests/suite/src/lib.rs
+++ b/tests/suite/src/lib.rs
@@ -109,3 +109,7 @@ mod test_migrate;
 // Raw instruction escape hatch
 #[cfg(test)]
 mod test_raw;
+
+// Metadata account validation
+#[cfg(test)]
+mod test_validate_metadata;

--- a/tests/suite/src/test_validate_metadata.rs
+++ b/tests/suite/src/test_validate_metadata.rs
@@ -1,0 +1,516 @@
+use {
+    crate::helpers::*,
+    quasar_svm::{Instruction, Pubkey},
+    quasar_test_metadata_validate::cpi::*,
+    solana_address::Address,
+};
+
+const METADATA_PROGRAM_BYTES: [u8; 32] = [
+    11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184, 108, 115,
+    26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70,
+];
+
+fn derive_metadata_pda(mint: &Pubkey) -> Pubkey {
+    let program = Address::new_from_array(METADATA_PROGRAM_BYTES);
+    let (addr, _) =
+        Address::find_program_address(&[b"metadata", program.as_ref(), mint.as_ref()], &program);
+    Pubkey::from(addr.to_bytes())
+}
+
+fn rent_sysvar() -> Pubkey {
+    Pubkey::from(Address::from_str_const("SysvarRent111111111111111111111111111111111").to_bytes())
+}
+
+fn derive_master_edition_pda(mint: &Pubkey) -> Pubkey {
+    let program = Address::new_from_array(METADATA_PROGRAM_BYTES);
+    let (addr, _) = Address::find_program_address(
+        &[b"metadata", program.as_ref(), mint.as_ref(), b"edition"],
+        &program,
+    );
+    Pubkey::from(addr.to_bytes())
+}
+
+// ===========================================================================
+// Bare Account<MetadataAccount> — ValidateBareMetadata (disc=3)
+// ===========================================================================
+
+#[test]
+fn bare_metadata_happy() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+    let meta_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMetadataInstruction { metadata: meta_key }.into();
+
+    let result = svm.process_instruction(&instruction, &[metadata_account(meta_key, ua, mint)]);
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn bare_metadata_wrong_owner() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+    let meta_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMetadataInstruction { metadata: meta_key }.into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            meta_key,
+            1_000_000,
+            build_metadata_account_data(ua, mint),
+            Pubkey::default(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: wrong owner");
+}
+
+#[test]
+fn bare_metadata_wrong_key_byte() {
+    let mut svm = svm_metadata_validate();
+    let meta_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMetadataInstruction { metadata: meta_key }.into();
+
+    let mut data = vec![0u8; 128];
+    data[0] = 6; // master edition key, not metadata
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            meta_key,
+            1_000_000,
+            data,
+            metadata_program_id(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: wrong key discriminant");
+}
+
+#[test]
+fn bare_metadata_data_too_small() {
+    let mut svm = svm_metadata_validate();
+    let meta_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMetadataInstruction { metadata: meta_key }.into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            meta_key,
+            1_000_000,
+            vec![4u8; 10],
+            metadata_program_id(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: data too small");
+}
+
+#[test]
+fn bare_metadata_all_zeros() {
+    let mut svm = svm_metadata_validate();
+    let meta_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMetadataInstruction { metadata: meta_key }.into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            meta_key,
+            1_000_000,
+            vec![0u8; 128],
+            metadata_program_id(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: key=0 is not metadata");
+}
+
+// ===========================================================================
+// Bare Account<MasterEditionAccount> — ValidateBareMasterEdition (disc=4)
+// ===========================================================================
+
+#[test]
+fn bare_master_edition_happy() {
+    let mut svm = svm_metadata_validate();
+    let me_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMasterEditionInstruction {
+        master_edition: me_key,
+    }
+    .into();
+
+    let result =
+        svm.process_instruction(&instruction, &[master_edition_account(me_key, 0, Some(0))]);
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn bare_master_edition_unlimited() {
+    let mut svm = svm_metadata_validate();
+    let me_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMasterEditionInstruction {
+        master_edition: me_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(&instruction, &[master_edition_account(me_key, 42, None)]);
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn bare_master_edition_wrong_owner() {
+    let mut svm = svm_metadata_validate();
+    let me_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMasterEditionInstruction {
+        master_edition: me_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            me_key,
+            1_000_000,
+            build_master_edition_data(0, Some(0)),
+            Pubkey::default(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: wrong owner");
+}
+
+#[test]
+fn bare_master_edition_wrong_key() {
+    let mut svm = svm_metadata_validate();
+    let me_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMasterEditionInstruction {
+        master_edition: me_key,
+    }
+    .into();
+
+    let mut data = vec![0u8; 32];
+    data[0] = 4; // metadata key, not master edition
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(me_key, 1_000_000, data, metadata_program_id())],
+    );
+    assert!(result.is_err(), "should fail: wrong key discriminant");
+}
+
+#[test]
+fn bare_master_edition_data_too_small() {
+    let mut svm = svm_metadata_validate();
+    let me_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateBareMasterEditionInstruction {
+        master_edition: me_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[raw_account(
+            me_key,
+            1_000_000,
+            vec![6u8; 10],
+            metadata_program_id(),
+        )],
+    );
+    assert!(result.is_err(), "should fail: data too small");
+}
+
+// ===========================================================================
+// Metadata with behavior — ValidateMetadataCheck (disc=0)
+// ===========================================================================
+
+#[test]
+fn metadata_check_happy() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+
+    let meta_key = derive_metadata_pda(&mint);
+
+    let instruction: Instruction = ValidateMetadataCheckInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        metadata: meta_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            metadata_account(meta_key, ua, mint),
+        ],
+    );
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn metadata_check_wrong_mint_in_data() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let wrong_mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+
+    let meta_key = derive_metadata_pda(&mint);
+
+    let instruction: Instruction = ValidateMetadataCheckInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        metadata: meta_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            metadata_account(meta_key, ua, wrong_mint), // data has wrong mint
+        ],
+    );
+    assert!(result.is_err(), "should fail: mint in data doesn't match");
+}
+
+#[test]
+fn metadata_check_wrong_pda() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+    let wrong_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateMetadataCheckInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        metadata: wrong_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            metadata_account(wrong_key, ua, mint),
+        ],
+    );
+    assert!(result.is_err(), "should fail: address doesn't match PDA");
+}
+
+// ===========================================================================
+// Metadata with update_authority — ValidateMetadataWithUa (disc=1)
+// ===========================================================================
+
+#[test]
+fn metadata_with_ua_happy() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+
+    let meta_key = derive_metadata_pda(&mint);
+
+    let instruction: Instruction = ValidateMetadataWithUaInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        update_authority: ua,
+        metadata: meta_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            signer_account(ua),
+            metadata_account(meta_key, ua, mint),
+        ],
+    );
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn metadata_with_ua_wrong_authority() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let ua = Pubkey::new_unique();
+    let wrong_ua = Pubkey::new_unique();
+
+    let meta_key = derive_metadata_pda(&mint);
+
+    let instruction: Instruction = ValidateMetadataWithUaInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        update_authority: ua,
+        metadata: meta_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            signer_account(ua),
+            metadata_account(meta_key, wrong_ua, mint), // data has wrong_ua
+        ],
+    );
+    assert!(result.is_err(), "should fail: update_authority mismatch");
+}
+
+// ===========================================================================
+// Master Edition with behavior — ValidateMasterEditionCheck (disc=2)
+// ===========================================================================
+
+#[test]
+fn master_edition_check_happy() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+
+    let me_key = derive_master_edition_pda(&mint);
+
+    let instruction: Instruction = ValidateMasterEditionCheckInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        master_edition: me_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            master_edition_account(me_key, 0, Some(0)),
+        ],
+    );
+    assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+}
+
+#[test]
+fn master_edition_check_wrong_pda() {
+    let mut svm = svm_metadata_validate();
+    let mint = Pubkey::new_unique();
+    let wrong_key = Pubkey::new_unique();
+
+    let instruction: Instruction = ValidateMasterEditionCheckInstruction {
+        metadata_program: metadata_program_id(),
+        mint,
+        master_edition: wrong_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            metadata_program_account(),
+            signer_account(mint),
+            master_edition_account(wrong_key, 0, Some(0)),
+        ],
+    );
+    assert!(result.is_err(), "should fail: address doesn't match PDA");
+}
+
+// ===========================================================================
+// Init Metadata via CPI — InitMetadataTest (disc=10)
+// Full end-to-end: create mint -> CPI to Metaplex -> verify prefix fields
+// ===========================================================================
+
+#[test]
+fn init_metadata_happy() {
+    let mut svm = svm_metadata_validate();
+    let payer = Pubkey::new_unique();
+    let mint_key = Pubkey::new_unique();
+    let mint_authority = Pubkey::new_unique();
+    let update_authority = Pubkey::new_unique();
+    let token_program = spl_token_program_id();
+
+    let meta_key = derive_metadata_pda(&mint_key);
+
+    let instruction: Instruction = InitMetadataTestInstruction {
+        payer,
+        metadata_program: metadata_program_id(),
+        system_program: quasar_svm::system_program::ID,
+        rent: rent_sysvar(),
+        mint: mint_key,
+        mint_authority,
+        update_authority,
+        metadata: meta_key,
+    }
+    .into();
+
+    // All accounts the instruction + CPI need. SVM matches by address, not order.
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            rich_signer_account(payer),
+            empty_account(meta_key),
+            mint_account(mint_key, mint_authority, 0, token_program),
+            signer_account(mint_authority),
+            signer_account(update_authority),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "init metadata should succeed: {:?}",
+        result.raw_result
+    );
+}
+
+// ===========================================================================
+// Init Master Edition via CPI — InitMasterEditionTest (disc=11)
+// ===========================================================================
+
+#[test]
+fn init_master_edition_happy() {
+    let mut svm = svm_metadata_validate();
+    let payer = Pubkey::new_unique();
+    let mint_key = Pubkey::new_unique();
+    let mint_authority = Pubkey::new_unique();
+    let update_authority = Pubkey::new_unique();
+    let token_program = spl_token_program_id();
+
+    let meta_key = derive_metadata_pda(&mint_key);
+    let me_key = derive_master_edition_pda(&mint_key);
+
+    // Both metadata_account and master_edition are init'd by derive behaviors.
+    let instruction: Instruction = InitMasterEditionTestInstruction {
+        payer,
+        metadata_program: metadata_program_id(),
+        system_program: quasar_svm::system_program::ID,
+        rent: rent_sysvar(),
+        mint: mint_key,
+        update_authority,
+        mint_authority,
+        token_program,
+        metadata_account: meta_key,
+        master_edition: me_key,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &instruction,
+        &[
+            rich_signer_account(payer),
+            nft_mint_account(mint_key, mint_authority, token_program),
+            signer_account(update_authority),
+            signer_account(mint_authority),
+            empty_account(meta_key),
+            empty_account(me_key),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "init master edition should succeed: {:?}\nlogs: {:?}",
+        result.raw_result,
+        result.logs,
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `quasar-metadata` account types for Metaplex Metadata and Master Edition accounts, using ZeroPod-backed fixed-prefix layouts for owner/key/data-length validation and zero-copy access to stable fields.
- Introduces metadata behavior modules for `#[derive(Accounts)]`, so programs can validate metadata PDAs and initialize Metadata/Master Edition accounts through the existing behavior-driven `init` pipeline.
- Tightens the generic init contract in `quasar-lang` and `quasar-derive` so wrapper account types preserve `DEFAULT_INIT_PARAMS_VALID` and protocol accounts fail at compile time when `#[account(init)]` is used without an init-param behavior.
- Adds local compile-pass/fail and Miri-oriented coverage for the metadata crate, plus an SVM test program that validates existing accounts and exercises Metaplex CPI init end-to-end.
- Wires the new metadata SBF test program and metadata-specific checks into the standard Makefile flows so fresh checkouts build the required runtime artifact.

## Commit storyline

| # | Commit | Description |
|---|--------|-------------|
| 1 | `2b656645` Propagate required init-param metadata through wrappers | Keeps the framework-level init safety bit intact through `Account<T>` and `InterfaceAccount<T>` before adding protocol accounts that depend on it. |
| 2 | `4ccacd2b` Add metadata protocol account support | Adds the production metadata account model, behavior modules, CPI init dispatch, PDA helpers, and validation API as one coherent protocol-crate layer. |
| 3 | `fef1d8ae` Cover metadata account behavior locally | Adds crate-local compile and layout coverage to verify the new account behavior surface before moving into SVM integration. |
| 4 | `3f692fb7` Add SVM coverage for metadata validation and init | Adds the on-chain test program, suite tests, lockfile updates, and build/test wiring that prove validation and CPI init work in runtime-style tests. |

Best reviewed commit-by-commit.

## Design notes

The metadata account data has a stable fixed prefix followed by variable-length Borsh fields. This PR intentionally models only the fixed prefix as ZeroPod data: `MetadataPrefixZc` exposes `key`, `update_authority`, and `mint`; `MasterEditionPrefixZc` exposes `key`, `supply`, and `max_supply`. The variable-length fields remain outside the zero-copy account type because they require offset walking and separate Borsh handling.

Initialization follows the existing SPL behavior pattern. `metadata(...)` and `master_edition(...)` behavior groups fill typed init params, and `AccountInit` dispatches to the Metaplex CPI builders. The derive assertion change makes this safer: protocol account types with invalid default init params now produce a compile-time error when an init behavior is missing.

Validation is split by responsibility. `AccountLoad` handles the base owner/discriminator/data-length/ZeroPod checks, behavior checks validate PDA and cross-field relationships, and `metadata::validate` provides standalone helpers for callers that need full validation outside a behavior group.

## Changes overview

<details>
<summary>44 files changed, 2571 insertions, 122 deletions</summary>

```text
 Cargo.lock                                         |  13 +
 Makefile                                           |  14 +-
 derive/src/accounts/emit/parse.rs                  |  32 +-
 lang/src/accounts/account.rs                       |   1 +
 lang/src/accounts/interface_account.rs             |   1 +
 metadata/Cargo.toml                                |   7 +
 metadata/src/account_init.rs                       | 152 ++++++
 metadata/src/accounts/master_edition.rs            | 221 +++++++++
 metadata/src/accounts/metadata.rs                  | 240 ++++++++++
 metadata/src/accounts/mod.rs                       |  18 +
 metadata/src/accounts/prelude.rs                   |   1 +
 metadata/src/instructions/mod.rs                   |   4 +-
 metadata/src/lib.rs                                |  11 +-
 metadata/src/pda.rs                                |  80 ++++
 metadata/src/prelude.rs                            |  15 +
 metadata/src/program.rs                            |   2 +
 metadata/src/state.rs                              | 208 +++++----
 metadata/src/validate.rs                           | 114 +++++
 metadata/tests/compile_fail.rs                     |   5 +
 .../init_master_edition_without_behavior.rs        |  20 +
 .../init_master_edition_without_behavior.stderr    |  29 ++
 .../tests/compile_fail/init_without_behavior.rs    |  20 +
 .../compile_fail/init_without_behavior.stderr      |  29 ++
 .../tests/compile_fail/metadata_bad_field_ref.rs   |  17 +
 .../compile_fail/metadata_bad_field_ref.stderr     |  13 +
 metadata/tests/compile_pass.rs                     |  10 +
 .../compile_pass/init_metadata_with_behavior.rs    |  39 ++
 .../compile_pass/validate_master_edition_check.rs  |  17 +
 .../tests/compile_pass/validate_metadata_check.rs  |  17 +
 metadata/tests/miri.rs                             | 378 +++++++++++++++
 tests/programs/test-metadata-validate/Cargo.toml   |  23 +
 .../src/instructions/init_master_edition.rs        |  95 ++++
 .../src/instructions/init_metadata.rs              |  64 +++
 .../test-metadata-validate/src/instructions/mod.rs |  13 +
 .../instructions/validate_bare_master_edition.rs   |  14 +
 .../src/instructions/validate_bare_metadata.rs     |  15 +
 .../instructions/validate_master_edition_check.rs  |  18 +
 .../src/instructions/validate_metadata_check.rs    |  18 +
 .../src/instructions/validate_metadata_with_ua.rs  |  23 +
 tests/programs/test-metadata-validate/src/lib.rs   |  63 +++
 tests/suite/Cargo.toml                             |   1 +
 tests/suite/src/helpers.rs                         |  98 ++++
 tests/suite/src/lib.rs                             |   4 +
 tests/suite/src/test_validate_metadata.rs          | 516 +++++++++++++++++++++
 44 files changed, 2571 insertions(+), 122 deletions(-)
```

</details>

Reimplemented from [`feat/quasar-metadata-protocol-crate`](https://github.com/blueshift-gg/quasar/tree/feat/quasar-metadata-protocol-crate) with clean commit history.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p quasar-metadata`
- [x] `cargo clippy -p quasar-metadata --tests -- -D warnings`
- [x] `cargo test -p quasar-test-suite test_validate_metadata -- --test-threads=1`
- [x] `cargo clippy -p quasar-test-suite --tests -- -D warnings`
- [x] `cargo build-sbf --tools-version v1.52 --manifest-path tests/programs/test-metadata-validate/Cargo.toml --features debug,alloc`
- [x] Pre-push hook passed fmt and full clippy before branch push
- [x] Branch end-state matches source: `git diff feat/quasar-metadata-protocol-crate feat/quasar-metadata-protocol-crate-clean` is empty