### PR TITLE
fix(CLI): trim trailing whitespace in project names

### DIFF
--- a/cli/src/init/mod.rs
+++ b/cli/src/init/mod.rs
@@ -109,7 +109,9 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             prompt = prompt.default(default);
         }
         prompt.interact_text().map_err(anyhow::Error::from)?
-    };
+    }
+    .trim()
+    .to_string();
 
     // Validate the target directory before prompting for remaining options
     scaffold::validate_target_dir(&name)?;
@@ -271,7 +273,10 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
                     .default("pnpm test".into())
                     .interact_text()
                     .map_err(anyhow::Error::from)?;
-                PackageManager::Other { install, test }
+                PackageManager::Other {
+                    install: install.trim().to_string(),
+                    test: test.trim().to_string(),
+                }
             }
         })
     } else {


### PR DESCRIPTION
creating a project with `'project name '` works which ideally should not as trying to build this will result in an error 

```bash
quasar build

  ✘  failed to generate Cargo.lock
error: invalid character ` ` in package name: `test-idl `, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
 --> Cargo.toml:2:8
  |
2 | name = "test-idl "
  |        ^^^^^^^^^^^

The Solana toolchain bundles an older cargo that cannot resolve
some newer crate versions. Ensure your system cargo is up to date:
  rustup update
```