### PR TITLE
Clarify missing IDL build feature errors

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -10,7 +10,7 @@ pub enum CliError {
     TomlParseError(#[from] toml::de::Error),
     #[error("Toml serialize error")]
     TomlSerError(#[from] toml::ser::Error),
-    #[error("Anyhow error")]
+    #[error("{0}")]
     Anyhow(#[from] anyhow::Error),
     #[error("{0}")]
     Message(String),

--- a/cli/src/idl.rs
+++ b/cli/src/idl.rs
@@ -46,6 +46,13 @@ fn build_idl_from_crate(crate_path: &Path) -> Result<Idl, anyhow::Error> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("does not contain this feature: idl-build") {
+            return Err(anyhow::anyhow!(
+                "IDL build failed because package `{package_name}` does not define the \
+                 `idl-build` feature.\n\nAdd this to Cargo.toml:\n\n[features]\nidl-build = \
+                 [\"quasar-lang/idl-build\"]\n\ncargo stderr:\n{stderr}"
+            ));
+        }
         return Err(anyhow::anyhow!(
             "IDL build failed (cargo test --features idl-build):\n{stderr}"
         ));

--- a/cli/tests/idl_errors.rs
+++ b/cli/tests/idl_errors.rs
@@ -1,0 +1,88 @@
+use {
+    quasar_cli::idl,
+    std::{
+        error::Error,
+        fs,
+        path::{Path, PathBuf},
+    },
+    tempfile::tempdir,
+};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn write_file(path: &Path, contents: impl AsRef<str>) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents.as_ref())?;
+    Ok(())
+}
+
+#[test]
+fn missing_idl_build_feature_reports_actionable_message() -> Result<(), Box<dyn Error>> {
+    let temp = tempdir()?;
+    let program_dir = temp.path().join("programs/missing-idl-build");
+
+    write_file(
+        &temp.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["programs/missing-idl-build"]
+resolver = "3"
+"#,
+    )?;
+    write_file(
+        &program_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "missing-idl-build"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+quasar-lang = {{ path = "{}" }}
+"#,
+            workspace_root().join("lang").display()
+        ),
+    )?;
+    write_file(
+        &program_dir.join("src/lib.rs"),
+        r#"#![cfg_attr(not(test), no_std)]
+
+use quasar_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod missing_idl_build {
+    use super::*;
+
+    pub fn noop(_ctx: Ctx<Noop>) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Noop {}
+"#,
+    )?;
+
+    let err = idl::generate(&program_dir, &[], &temp.path().join("clients"))
+        .expect_err("IDL generation should fail without the idl-build feature");
+    let message = err.to_string();
+
+    assert!(
+        !message.contains("Anyhow error"),
+        "missing idl-build feature should not be hidden behind generic Anyhow output: {message}"
+    );
+    assert!(
+        message.contains("idl-build = [\"quasar-lang/idl-build\"]"),
+        "missing idl-build feature should include the Cargo.toml fix: {message}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Surface the inner anyhow error from the CLI instead of replacing it with a generic label.

<img width="480" height="120" alt="image" src="https://github.com/user-attachments/assets/2944e604-600b-438f-b04a-21b7d9fb0258" />


Detect Cargo's missing idl-build feature failure and report the Cargo.toml feature entry required by Quasar IDL generation.

Add a CLI regression test that builds a temporary program without the feature and asserts the actionable error text.
