### PR TITLE
Require address-constrained accounts in generated clients

### DIFF
--- a/cli/tests/generated_clients_smoke.rs
+++ b/cli/tests/generated_clients_smoke.rs
@@ -125,6 +125,30 @@ fn compile_typescript_client(client_dir: &Path) -> Result<(), Box<dyn Error>> {
     )
 }
 
+fn assert_typescript_client_requires_address_constraint_accounts(
+    client_dir: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let kit = fs::read_to_string(client_dir.join("kit.ts"))?;
+    let web3 = fs::read_to_string(client_dir.join("web3.ts"))?;
+
+    for source in [&kit, &web3] {
+        assert!(
+            !source.contains(" :: seeds("),
+            "generated TypeScript client contains an unresolved typed seed expression"
+        );
+        assert!(
+            source.contains("  config: Address;"),
+            "generated TypeScript client should require the config account"
+        );
+        assert!(
+            source.contains("  vault: Address;"),
+            "generated TypeScript client should require the vault account"
+        );
+    }
+
+    Ok(())
+}
+
 #[test]
 fn generated_clients_compile_from_fresh_project() -> Result<(), Box<dyn Error>> {
     let fixture = fixture_program();
@@ -156,6 +180,7 @@ fn generated_clients_compile_from_fresh_project() -> Result<(), Box<dyn Error>> 
 
     let ts_dir = clients_path.join("typescript").join("quasar-multisig");
     if ts_dir.exists() {
+        assert_typescript_client_requires_address_constraint_accounts(&ts_dir)?;
         compile_typescript_client(&ts_dir)?;
     }
 

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -193,18 +193,8 @@ fn emit_idl_accounts_meta(
             let writable = sem.is_writable();
             let signer = is_signer_type(&sem.core.effective_ty);
 
-            // Determine resolver
-            let resolver_tokens = if let Some(addr_expr) = &sem.address {
-                let addr_str = quote::quote!(#addr_expr).to_string();
-                quote! {
-                    quasar_lang::idl_build::__reexport::IdlResolver::Const {
-                        address: quasar_lang::idl_build::s(#addr_str),
-                    }
-                }
-            } else {
-                quote! {
-                    quasar_lang::idl_build::__reexport::IdlResolver::Input {}
-                }
+            let resolver_tokens = quote! {
+                quasar_lang::idl_build::__reexport::IdlResolver::Input {}
             };
 
             quote! {


### PR DESCRIPTION
Treat address constraints as input-resolved in IDL account metadata so generated clients require callers to pass those accounts instead of serializing Rust expressions as fixed addresses.

Add smoke coverage that generated TypeScript clients no longer emit typed seed expressions and include the constrained accounts in instruction inputs.

Fixes https://github.com/blueshift-gg/quasar/issues/201
