### PR TITLE
Add CI for `init`, `build`, and `test` commands

### DIFF
--- a/.github/workflows/demo-stable-ci.yml
+++ b/.github/workflows/demo-stable-ci.yml
@@ -1,0 +1,41 @@
+name: Demo Stable CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  demo_stable:
+    name: Demo Stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: docker build -t quasar-demo .
+
+      - name: Run Docker container
+        run: docker run -d --name quasar quasar-demo
+
+      - name: Run quasar init
+        run: |
+          docker exec quasar quasar init demo-program \
+            --yes \
+            --no-git \
+            --test-language rust \
+            --rust-framework quasar-svm \
+            --template minimal \
+            --toolchain solana
+
+      - name: Run quasar build
+        run: |
+          docker exec quasar bash -c "cd demo-program && quasar build"
+
+      - name: Run quasar test
+        run: |
+          docker exec quasar bash -c "cd demo-program && quasar test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM rust:slim-trixie
+
+# Accept TARGETARCH for multi-platform builds (Docker BuildKit).
+ARG TARGETARCH
+
+# Install minimal dependencies needed to build from source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the workspace source into the image.
+COPY . /usr/src/quasar
+
+# Build and install the Quasar CLI from source, then clean up build artifacts
+# to keep the final image small.
+WORKDIR /usr/src/quasar
+RUN cargo install --path cli && \
+    rm -rf /usr/src/quasar \
+           /usr/local/cargo/registry/cache \
+           /usr/local/cargo/git/checkouts
+
+# Create an empty working directory editable by any user.
+RUN mkdir -p /workspace && chmod 777 /workspace
+WORKDIR /workspace
+
+# Programmatically identify the architecture and make it available inside
+# running containers via the ARCH environment variable. If built with Docker
+# BuildKit, TARGETARCH is used; otherwise we fall back to dpkg.
+ARG TARGETARCH
+ENV ARCH=${TARGETARCH}
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    echo "export ARCH=$ARCH" > /etc/profile.d/arch.sh && \
+    echo "$ARCH" > /etc/arch.txt && \
+    chmod 644 /etc/profile.d/arch.sh /etc/arch.txt
+
+# Keep the container running in the background so you can exec into it.
+CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
**Motivation**

I've gotten a bunch of bugs starting a new project from scratch using the CLI. 

Recent one in #210.

If I'm experiencing them as new changes are being pushed, chances are users are as well. This PR will allow for us to catch errors before they reach users.

**Description**

In order to ensure that any changes will not affect the core CLI workflows adversely, I've added the following:

- Add a docker image that installs the Quasar CLI which can be used by others or by CI
- Add a new Github action workflow that runs the quasar cli commands from within the docker container

We can use this to check that the commands don't break when starting a first project

**Limitations**

We only support the main three commands for now and we only run things on the stable Solana toolchain. We can test that the CLI doesn't fail on the other configurations on a future PR.