### PR TITLE
ci(release): smoke test generated project workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.worktrees
+target
+**/target
+node_modules
+**/node_modules
+.DS_Store

--- a/.github/docker/release-cli-smoke.Dockerfile
+++ b/.github/docker/release-cli-smoke.Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:slim-trixie
+
+ARG SOLANA_VERSION=stable
+
+ENV CARGO_TERM_COLOR=always
+ENV PATH="/opt/quasar-cli/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
+ENV QUASAR_SOURCE=/workspace/quasar
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libssl-dev \
+    pkg-config \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/quasar
+COPY . /workspace/quasar
+
+RUN sh -c "$(curl -sSfL https://release.anza.xyz/${SOLANA_VERSION}/install)" \
+    && cargo install --path cli --root /opt/quasar-cli \
+    && cargo build-sbf --version \
+    && quasar --version \
+    && rm -rf target /usr/local/cargo/registry/cache /usr/local/cargo/git/checkouts
+
+WORKDIR /workspace
+ENTRYPOINT ["/workspace/quasar/.github/scripts/release-cli-smoke.sh"]

--- a/.github/scripts/release-cli-smoke.sh
+++ b/.github/scripts/release-cli-smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir="${QUASAR_SOURCE:-/workspace/quasar}"
+demo_root="${TMPDIR:-/tmp}/quasar-release-cli-smoke"
+demo_name="quasar-release-demo"
+
+rm -rf "$demo_root"
+mkdir -p "$demo_root"
+
+cd "$demo_root"
+quasar init "$demo_name" \
+  --yes \
+  --no-git \
+  --test-language rust \
+  --rust-framework quasar-svm \
+  --template minimal \
+  --toolchain solana
+
+cd "$demo_name"
+
+export QUASAR_SOURCE="$source_dir"
+python3 - <<'PY'
+import os
+import re
+from pathlib import Path
+
+manifest = Path("Cargo.toml")
+text = manifest.read_text()
+replacement = f'quasar-lang = {{ path = "{os.environ["QUASAR_SOURCE"]}/lang" }}'
+text, count = re.subn(
+    r'quasar-lang = (?:\{ git = "https://github.com/blueshift-gg/quasar", branch = "master" \}|"=[^"]+")',
+    replacement,
+    text,
+)
+if count != 1:
+    raise SystemExit(f"expected to patch one quasar-lang dependency, patched {count}")
+manifest.write_text(text)
+PY
+
+quasar build
+quasar test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags: ["v*"]
 
 env:
+  SOLANA_VERSION: stable
   CARGO_TERM_COLOR: always
 
 permissions:
@@ -70,10 +71,30 @@ jobs:
         with:
           command: cargo kani -p ${{ matrix.crate }}
 
+  # ── CLI smoke: verify a fresh Solana project before publishing a tag ──
+  release-cli-smoke:
+    name: Release CLI Smoke
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build release smoke image
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            --build-arg SOLANA_VERSION=${{ env.SOLANA_VERSION }} \
+            --file .github/docker/release-cli-smoke.Dockerfile \
+            --tag quasar-release-cli-smoke:${{ github.sha }} \
+            .
+
+      - name: Run release smoke
+        run: docker run --rm quasar-release-cli-smoke:${{ github.sha }}
+
   # ── Publish crates to crates.io in dependency order ──
   publish:
     name: Publish to crates.io
-    needs: [ci, miri, kani]
+    needs: [ci, miri, kani, release-cli-smoke]
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
@@ -126,7 +147,7 @@ jobs:
   # ── GitHub Release with auto-generated notes ──
   github-release:
     name: GitHub Release
-    needs: [ci, miri, kani]
+    needs: [ci, miri, kani, release-cli-smoke]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Supersedes #209 by keeping the valuable CLI demo smoke idea, but moving it to the release path where it belongs: this now runs only when a `v*` release tag is pushed.

The release workflow now builds a clean Docker image from the checked-out tag, installs the Quasar CLI plus Solana SBF tooling, initializes a fresh Solana Rust demo project, runs `quasar build`, and runs `quasar test`. Both crates.io publishing and GitHub release creation are blocked on this smoke job.

## Why this replaces #209

#209 had the right test target: prove `quasar init`, `quasar build`, and `quasar test` work for a fresh project. The problem was scope and fidelity:

- it ran on every PR/push instead of only during releases;
- it added a root product-looking Dockerfile rather than a CI-only smoke image;
- it did not install the Solana SBF toolchain needed by `--toolchain solana` builds;
- generated dev builds would resolve `quasar-lang` from `master`, so the smoke could test the wrong framework source.

This PR keeps the intent and fixes those boundaries. The smoke script patches the generated demo manifest to use the checked-out release source, so the release gate validates the tag being published rather than `master` or crates.io.

## Attribution

Supersedes #209 by @datasalaryman. The commit includes:

`Co-authored-by: Data Salaryman <datasalaryman@protonmail.com>`

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'`
- `bash -n .github/scripts/release-cli-smoke.sh`
- `git diff --check`
- `cargo run -p quasar-cli -- --version`
- `PATH="$PWD/target/debug:$PATH" QUASAR_SOURCE="$PWD" .github/scripts/release-cli-smoke.sh`
- `docker build --progress=plain --platform linux/amd64 --build-arg SOLANA_VERSION=stable --file .github/docker/release-cli-smoke.Dockerfile --tag quasar-release-cli-smoke:local .`
- `docker run --rm quasar-release-cli-smoke:local`
- pre-push hook: `cargo +nightly fmt --all -- --check` and `cargo +nightly clippy --all --all-features --all-targets -- -D warnings`
