### PR TITLE
feat: add new default path for upstream build artifacts

### DIFF
--- a/examples/upstream-vault/src/tests.rs
+++ b/examples/upstream-vault/src/tests.rs
@@ -6,8 +6,7 @@ use {
 };
 
 fn setup() -> QuasarSvm {
-    let elf =
-        std::fs::read("../../target/deploy/upstream_vault.so").unwrap();
+    let elf = std::fs::read("../../target/deploy/upstream_vault.so").unwrap();
     QuasarSvm::new().with_program(&crate::ID, &elf)
 }
 

--- a/examples/upstream-vault/src/tests.rs
+++ b/examples/upstream-vault/src/tests.rs
@@ -7,7 +7,7 @@ use {
 
 fn setup() -> QuasarSvm {
     let elf =
-        std::fs::read("../../target/bpfel-unknown-none/release/libupstream_vault.so").unwrap();
+        std::fs::read("../../target/deploy/upstream_vault.so").unwrap();
     QuasarSvm::new().with_program(&crate::ID, &elf)
 }
 


### PR DESCRIPTION
# Description
After sbpf-linker 1.9 ( latest ) the artifacts are compiled default to `target/deploy/{name}.so` like toolchain. 
This is supposed to be the new default for upstream as well.
