### PR TITLE
solana-compiler-builtins memcmp libcall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["lang", "derive", "spl", "metadata", "idl", "idl/schema", "idl/gen", "schema", "profile", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli"]
+members = ["lang", "derive", "spl", "metadata", "idl", "idl/schema", "idl/gen", "schema", "profile", "solana-compiler-builtins", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli"]
 exclude = []
 
 [workspace.package]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -33,6 +33,9 @@ solana-define-syscall = { version = "5.0.0", features = [
     "unstable-static-syscalls",
 ] }
 
+[target.'cfg(target_arch = "bpf")'.dependencies]
+solana-compiler-builtins = { path = "../solana-compiler-builtins" }
+
 [target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 zeropod = { version = "0.3.0", features = ["wincode", "solana-address", "solana-program-error"] }
 solana-instruction = "3.2.0"

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -40,6 +40,8 @@
 #[cfg(any(feature = "debug", feature = "idl-build"))]
 extern crate alloc;
 extern crate self as quasar_lang;
+#[cfg(target_arch = "bpf")]
+use solana_compiler_builtins as _;
 
 /// Internal re-exports for proc macro codegen. Not part of the public API.
 /// Breaking changes to this module are not considered semver violations.
@@ -409,15 +411,22 @@ pub use zeropod::{
 /// bounds-checked slicing, `Result` construction, and panic paths.
 #[inline(always)]
 pub fn keys_eq(a: &solana_address::Address, b: &solana_address::Address) -> bool {
-    let a = a.as_array().as_ptr() as *const u64;
-    let b = b.as_array().as_ptr() as *const u64;
-    // SAFETY: `Address` is a 32-byte array. Reading four u64 words covers
-    // all 32 bytes. `read_unaligned` is used because `Address` has align 1.
-    unsafe {
-        core::ptr::read_unaligned(a) == core::ptr::read_unaligned(b)
-            && core::ptr::read_unaligned(a.add(1)) == core::ptr::read_unaligned(b.add(1))
-            && core::ptr::read_unaligned(a.add(2)) == core::ptr::read_unaligned(b.add(2))
-            && core::ptr::read_unaligned(a.add(3)) == core::ptr::read_unaligned(b.add(3))
+    #[cfg(not(target_os = "solana"))]
+    {
+        a == b
+    }
+    #[cfg(target_os = "solana")]
+    {
+        let a = a.as_array().as_ptr() as *const u64;
+        let b = b.as_array().as_ptr() as *const u64;
+        // SAFETY: `Address` is a 32-byte array. Reading four u64 words covers
+        // all 32 bytes. `read_unaligned` is used because `Address` has align 1.
+        unsafe {
+            core::ptr::read_unaligned(a) == core::ptr::read_unaligned(b)
+                && core::ptr::read_unaligned(a.add(1)) == core::ptr::read_unaligned(b.add(1))
+                && core::ptr::read_unaligned(a.add(2)) == core::ptr::read_unaligned(b.add(2))
+                && core::ptr::read_unaligned(a.add(3)) == core::ptr::read_unaligned(b.add(3))
+        }
     }
 }
 

--- a/solana-compiler-builtins/Cargo.toml
+++ b/solana-compiler-builtins/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "solana-compiler-builtins"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"

--- a/solana-compiler-builtins/src/lib.rs
+++ b/solana-compiler-builtins/src/lib.rs
@@ -1,0 +1,45 @@
+#![cfg_attr(target_arch = "bpf", no_std)]
+
+#[cfg(target_arch = "bpf")]
+const SOL_MEMCMP: usize = 0x5FDCDE31;
+#[cfg(target_arch = "bpf")]
+const INLINE_MEMCMP_THRESHOLD: usize = 32;
+
+#[cfg(target_arch = "bpf")]
+#[inline(always)]
+fn sol_memcmp(a: *const u8, b: *const u8, n: usize) -> i32 {
+    let mut result = 0i32;
+    let syscall: unsafe extern "C" fn(*const u8, *const u8, usize, *mut i32) -> i32 =
+        unsafe { core::mem::transmute(SOL_MEMCMP) };
+    unsafe {
+        syscall(a, b, n, &mut result as *mut i32);
+    }
+    result
+}
+
+#[cfg(target_arch = "bpf")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn memcmp(a: *const u8, b: *const u8, n: usize) -> i32 {
+    if n > INLINE_MEMCMP_THRESHOLD {
+        sol_memcmp(a, b, n)
+    } else {
+        let mut i = 0usize;
+        while i + 8 <= n {
+            let wa = unsafe { core::ptr::read_unaligned(a.add(i) as *const u64) };
+            let wb = unsafe { core::ptr::read_unaligned(b.add(i) as *const u64) };
+            if wa != wb {
+                return 1;
+            }
+            i += 8;
+        }
+
+        while i < n {
+            if unsafe { *a.add(i) != *b.add(i) } {
+                return 1;
+            }
+            i += 1;
+        }
+
+        0
+    }
+}


### PR DESCRIPTION
add `memcmp` libcall optimized for SVM so developers no longer need to hand-roll 32-byte array comparisons to get performant BPF code, and can just write `pubkey_a == pubkey_b` like normal people normally writing normal Rust in the normal universe

CU delta for upstream vault with this patch
WITHDRAW CU: 396 (-1)
DEPOSIT CU: 1563
DEVEX: 10 (+11)