### PR TITLE
fix(idl): emit optional account flags

### DIFF
--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -199,6 +199,7 @@ fn emit_idl_accounts_meta(
         .iter()
         .map(|sem| {
             let field_name = crate::helpers::snake_to_camel(&sem.core.ident.to_string());
+            let optional = sem.core.optional;
             let writable = sem.is_writable();
             let signer = is_signer_type(&sem.core.effective_ty);
 
@@ -210,6 +211,7 @@ fn emit_idl_accounts_meta(
                 quasar_lang::idl_build::__reexport::IdlAccountNode {
                     name: quasar_lang::idl_build::s(#field_name),
                     client_type: None,
+                    optional: #optional,
                     writable: quasar_lang::idl_build::__reexport::AccountFlag::Fixed(#writable),
                     signer: quasar_lang::idl_build::__reexport::AccountFlag::Fixed(#signer),
                     resolver: #resolver_tokens,

--- a/idl/schema/src/account.rs
+++ b/idl/schema/src/account.rs
@@ -26,6 +26,8 @@ pub struct IdlAccountNode {
         skip_serializing_if = "Option::is_none"
     )]
     pub client_type: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub optional: bool,
     #[serde(default)]
     pub writable: AccountFlag,
     #[serde(default)]
@@ -33,6 +35,10 @@ pub struct IdlAccountNode {
     pub resolver: IdlResolver,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub docs: Vec<String>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Account meta flag: fixed boolean, caller-provided, or runtime-resolved.

--- a/idl/schema/src/canonical.rs
+++ b/idl/schema/src/canonical.rs
@@ -280,6 +280,7 @@ mod tests {
                 accounts: vec![IdlAccountNode {
                     name: "authority".to_owned(),
                     client_type: None,
+                    optional: false,
                     writable: AccountFlag::Fixed(false),
                     signer: AccountFlag::Fixed(false),
                     resolver,

--- a/idl/src/codegen/mod.rs
+++ b/idl/src/codegen/mod.rs
@@ -71,6 +71,7 @@ mod tests {
                 accounts: vec![IdlAccountNode {
                     name: "vault".to_owned(),
                     client_type: None,
+                    optional: false,
                     writable: AccountFlag::Fixed(true),
                     signer: AccountFlag::Fixed(false),
                     resolver: IdlResolver::Pda {

--- a/idl/src/lint/rules.rs
+++ b/idl/src/lint/rules.rs
@@ -451,19 +451,22 @@ fn diff_instructions(old: &ProgramSurface, new: &ProgramSurface, report: &mut Li
             else {
                 continue;
             };
-            if old_account.signer != new_account.signer
+            if old_account.optional != new_account.optional
+                || old_account.signer != new_account.signer
                 || old_account.writable != new_account.writable
             {
                 report.push(Diagnostic::new(
                     RuleCode::R010,
                     format!("{}.{}", old_instruction.name, old_account.name),
                     format!(
-                        "account flags for `{}.{}` changed from signer={}, writable={} to \
-                         signer={}, writable={}",
+                        "account flags for `{}.{}` changed from optional={}, signer={}, \
+                         writable={} to optional={}, signer={}, writable={}",
                         old_instruction.name,
                         old_account.name,
+                        old_account.optional,
                         old_account.signer,
                         old_account.writable,
+                        new_account.optional,
                         new_account.signer,
                         new_account.writable
                     ),

--- a/idl/src/lint/surface.rs
+++ b/idl/src/lint/surface.rs
@@ -51,6 +51,7 @@ pub struct InstructionSurface {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountMetaSurface {
     pub name: String,
+    pub optional: bool,
     pub signer: String,
     pub writable: String,
     pub resolver: String,
@@ -198,6 +199,7 @@ impl AccountMetaSurface {
     fn from_idl(account: &IdlAccountNode) -> Self {
         Self {
             name: account.name.clone(),
+            optional: account.optional,
             signer: flag_key(&account.signer),
             writable: flag_key(&account.writable),
             resolver: json_key(&account.resolver),

--- a/idl/tests/lint_surface.rs
+++ b/idl/tests/lint_surface.rs
@@ -64,6 +64,7 @@ fn account_node(name: &str, signer: bool, writable: bool, resolver: IdlResolver)
     IdlAccountNode {
         name: name.to_owned(),
         client_type: None,
+        optional: false,
         writable: AccountFlag::Fixed(writable),
         signer: AccountFlag::Fixed(signer),
         resolver,

--- a/lang/tests/idl_optional_account.rs
+++ b/lang/tests/idl_optional_account.rs
@@ -1,0 +1,64 @@
+#![allow(unexpected_cfgs)]
+
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+pub struct OptionalState {
+    pub value: u64,
+}
+
+#[derive(Accounts)]
+pub struct UseOptional {
+    pub required: Account<OptionalState>,
+    pub maybe_state: Option<Account<OptionalState>>,
+}
+
+#[program(no_entrypoint)]
+pub mod idl_optional_account_program {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn use_optional(ctx: Ctx<UseOptional>) -> Result<(), ProgramError> {
+        let _ = &ctx.accounts.required;
+        let _ = &ctx.accounts.maybe_state;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "idl-build")]
+#[test]
+fn optional_accounts_emit_optional_flag() {
+    use quasar_lang::idl_build::__reexport::serde_json;
+
+    let json = crate::__quasar_build_idl();
+    let idl: serde_json::Value =
+        serde_json::from_str(&json).expect("generated IDL should deserialize");
+    let instruction = idl["instructions"]
+        .as_array()
+        .expect("instructions should be an array")
+        .iter()
+        .next()
+        .expect("instruction should be emitted");
+    let accounts = instruction["accounts"]
+        .as_array()
+        .expect("instruction accounts should be an array");
+
+    let required = accounts
+        .iter()
+        .find(|account| account["name"] == "required")
+        .expect("required account should be emitted");
+    assert_eq!(required.get("optional"), None);
+
+    let maybe_state = accounts
+        .iter()
+        .find(|account| account["name"] == "maybeState")
+        .expect("optional account should be emitted");
+    assert_eq!(
+        maybe_state
+            .get("optional")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the remaining IDL regression from the open issues above #186.

- Restore the `optional: true` account flag in generated IDL for `Option<Account<...>>` fields.
- Keep required accounts unchanged by omitting the field when `optional` is false.
- Carry account optionality into the lint surface so upgrade-safety diffs can catch optional/non-optional account meta changes.

Closes #221.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p quasar-lang --features idl-build --test idl_optional_account`
- `cargo test -p quasar-idl`
- pre-push hook: fmt + full clippy gate

## Deferred

#214 stays open. The default lazy-rent attempt was not safe or free enough: it broke existing partial-prefund init tests and failed the CU guard due small non-init regressions.
