### PR TITLE
fix(lang): allow optional none duplicate sentinels

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -328,14 +328,34 @@ pub mod __internal {
         } else {
             // Dup branch: borrow_state != NOT_BORROWED means the SVM
             // deduplicated this account slot.
-            if !flags.allow_dup {
-                // Dups are only accepted for explicit #[account(dup)] fields.
-                return Err(ProgramError::AccountBorrowFailed);
-            }
-
             let idx = (actual_header & 0xFF) as usize;
             if crate::utils::hint::unlikely(idx >= offset) {
                 return Err(ProgramError::InvalidAccountData);
+            }
+
+            if flags.is_optional {
+                // Optional None uses the program id as a sentinel. Repeated
+                // sentinels may be serialized as SVM duplicate entries, but
+                // they are not aliases of a real user account.
+                let orig_view = unsafe { core::ptr::read(base.add(idx)) };
+                if crate::keys_eq(orig_view.address(), program_id) {
+                    unsafe { core::ptr::write(base.add(offset), orig_view) };
+                    let input = unsafe { input.add(core::mem::size_of::<u64>()) };
+                    return Ok(input);
+                }
+
+                if !flags.allow_dup {
+                    return Err(ProgramError::AccountBorrowFailed);
+                }
+
+                unsafe { core::ptr::write(base.add(offset), orig_view) };
+                let input = unsafe { input.add(core::mem::size_of::<u64>()) };
+                return Ok(input);
+            }
+
+            if !flags.allow_dup {
+                // Dups are only accepted for explicit #[account(dup)] fields.
+                return Err(ProgramError::AccountBorrowFailed);
             }
 
             // SAFETY: `idx < offset` means the source slot is already

--- a/tests/programs/test-misc/src/instructions/mod.rs
+++ b/tests/programs/test-misc/src/instructions/mod.rs
@@ -142,3 +142,6 @@ pub use dynamic_view_mut_missing_field::*;
 
 pub mod cpi_mut_readback;
 pub use cpi_mut_readback::*;
+
+pub mod optional_mut_accounts;
+pub use optional_mut_accounts::*;

--- a/tests/programs/test-misc/src/instructions/optional_mut_accounts.rs
+++ b/tests/programs/test-misc/src/instructions/optional_mut_accounts.rs
@@ -1,0 +1,23 @@
+use {crate::state::SimpleAccount, quasar_derive::Accounts, quasar_lang::prelude::*};
+
+#[derive(Accounts)]
+pub struct OptionalMutAccounts {
+    #[account(mut)]
+    pub authority: Signer,
+
+    #[account(mut)]
+    pub first: Option<Account<SimpleAccount>>,
+
+    #[account(mut)]
+    pub second: Option<Account<SimpleAccount>>,
+
+    #[account(mut)]
+    pub third: Option<Account<SimpleAccount>>,
+}
+
+impl OptionalMutAccounts {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -336,4 +336,9 @@ mod quasar_test_misc {
         }
         ctx.accounts.handler()
     }
+
+    #[instruction(discriminator = 62)]
+    pub fn optional_mut_accounts(ctx: Ctx<OptionalMutAccounts>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
 }

--- a/tests/suite/src/optional_accounts.rs
+++ b/tests/suite/src/optional_accounts.rs
@@ -156,3 +156,25 @@ fn some_wrong_discriminator() {
     assert!(result.is_err(), "wrong disc on present optional");
     result.assert_error(ProgramError::InvalidAccountData);
 }
+
+#[test]
+fn multiple_mut_optional_none_sentinels() {
+    let mut svm = svm_misc();
+    let authority = Pubkey::new_unique();
+    let sentinel = quasar_test_misc::ID;
+
+    let ix: Instruction = OptionalMutAccountsInstruction {
+        authority,
+        first: sentinel,
+        second: sentinel,
+        third: sentinel,
+    }
+    .into();
+
+    let result = svm.process_instruction(&ix, &[signer_account(authority)]);
+    assert!(
+        result.is_ok(),
+        "all mut optionals as None sentinel should parse: {:?}",
+        result.raw_result
+    );
+}


### PR DESCRIPTION
## Summary

Supersedes #194 with the same behavioral fix on current master.

- Treat duplicate entries that resolve to an optional account None sentinel as absent accounts, not real duplicate borrows.
- Keep real duplicate accounts rejected unless the field explicitly opts into `#[account(dup)]`.
- Add a regression instruction and suite test for multiple `#[account(mut)] Option<Account<_>>` fields all passed as the program-id sentinel.

## Verification

- Red: `cargo test -p quasar-test-suite multiple_mut_optional_none_sentinels -- --nocapture` failed with `Err(AccountBorrowFailed)` before the runtime change.
- `cargo build-sbf --tools-version v1.51 --manifest-path tests/programs/test-misc/Cargo.toml`
- `cargo test -p quasar-test-suite multiple_mut_optional_none_sentinels -- --nocapture`
- `make build-sbf`
- `cargo test -p quasar-test-suite optional_accounts -- --nocapture`
- `cargo test -p quasar-test-suite duplicate_same_address -- --nocapture`
- `cargo test -p quasar-test-suite -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p quasar-lang -p quasar-test-misc -p quasar-test-suite --all-targets -- -D warnings`
- `scripts/bench-tracked-programs.sh compare origin/master`
- pre-push hook: fmt + full clippy

Tracked CU and binary-size comparison against `origin/master` was all zero delta.
