### PR TITLE
Fix issues 227-230

### DIFF
--- a/cli/src/new.rs
+++ b/cli/src/new.rs
@@ -68,12 +68,12 @@ pub fn run_instruction(name: &str) -> CliResult {
         r#"use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct {pascal}<'info> {{
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<SystemProgram>,
+pub struct {pascal} {{
+    pub payer: Signer,
+    pub system_program: Program<SystemProgram>,
 }}
 
-impl<'info> {pascal}<'info> {{
+impl {pascal} {{
     #[inline(always)]
     pub fn {snake}(&self) -> Result<(), ProgramError> {{
         Ok(())
@@ -295,7 +295,12 @@ pub enum {pascal} {{
 
 #[cfg(test)]
 mod tests {
-    use super::{add_instruction_to_entrypoint, parse_discriminator};
+    use {
+        super::{add_instruction_to_entrypoint, parse_discriminator, run_instruction},
+        std::sync::{Mutex, OnceLock},
+    };
+
+    static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[test]
     fn discriminator_parser_accepts_space_or_no_space() {
@@ -324,5 +329,38 @@ mod demo {
 
         assert!(updated.contains("#[instruction]"));
         assert!(updated.contains("pub fn settle(ctx: Ctx<Settle>)"));
+    }
+
+    #[test]
+    fn add_instruction_generates_owned_account_wrappers() {
+        let _guard = CWD_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let src_dir = temp.path().join("src");
+        std::fs::create_dir(&src_dir).unwrap();
+        std::fs::write(
+            src_dir.join("lib.rs"),
+            r#"use quasar_lang::prelude::*;
+
+#[program]
+mod demo {
+    use super::*;
+}
+"#,
+        )
+        .unwrap();
+
+        std::env::set_current_dir(temp.path()).unwrap();
+        let result = run_instruction("create_pool");
+        std::env::set_current_dir(original_dir).unwrap();
+        result.unwrap();
+
+        let generated =
+            std::fs::read_to_string(src_dir.join("instructions/create_pool.rs")).unwrap();
+        assert!(generated.contains("pub struct CreatePool {"));
+        assert!(generated.contains("pub payer: Signer,"));
+        assert!(generated.contains("pub system_program: Program<SystemProgram>,"));
+        assert!(!generated.contains("'info"));
+        assert!(!generated.contains("&'info"));
     }
 }

--- a/cli/tests/generated_clients_smoke.rs
+++ b/cli/tests/generated_clients_smoke.rs
@@ -596,6 +596,91 @@ pub struct Submit {
 }
 
 #[test]
+fn generated_typescript_client_lowers_pod_vec_args_to_builtin_codecs() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempdir()?;
+    let program_dir = temp.path().join("programs/pod-vec-args");
+
+    write_file(
+        &temp.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["programs/pod-vec-args"]
+resolver = "3"
+"#,
+    )?;
+    write_file(
+        &program_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "pod-vec-args"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+idl-build = ["quasar-lang/idl-build"]
+
+[dependencies]
+quasar-lang = {{ path = "{}" }}
+"#,
+            workspace_root().join("lang").display()
+        ),
+    )?;
+    write_file(
+        &program_dir.join("src/lib.rs"),
+        r#"#![no_std]
+use quasar_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod pod_vec_args {
+    use super::*;
+
+    #[instruction(discriminator = 0)]
+    pub fn submit(_ctx: Ctx<Submit>, nums: Vec<PodU64, 16>) -> Result<(), ProgramError> {
+        let _ = nums;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Submit {
+    pub authority: Signer,
+}
+"#,
+    )?;
+
+    let clients_path = temp.path().join("clients");
+    idl::generate(&program_dir, &["typescript"], &clients_path)?;
+    let ts_dir = clients_path.join("typescript").join("pod_vec_args");
+    let kit = read_file(&ts_dir.join("kit.ts"))?;
+
+    assert!(
+        kit.contains("nums: Array<bigint>;"),
+        "PodU64 vec args should surface as bigint arrays"
+    );
+    assert!(
+        kit.contains("getArrayCodec(getU64Codec(), { size: input.nums.length })"),
+        "PodU64 vec args should encode through the builtin u64 codec"
+    );
+    assert!(
+        !kit.contains("PodU64Codec"),
+        "PodU64 vec args should not reference an undefined PodU64Codec"
+    );
+    assert!(
+        !kit.contains("Array<PodU64>"),
+        "PodU64 vec args should not expose undefined PodU64 types"
+    );
+
+    compile_typescript_client(&ts_dir)?;
+
+    Ok(())
+}
+
+#[test]
 fn kit_program_plugin_exposes_only_supported_accounts_and_instructions(
 ) -> Result<(), Box<dyn Error>> {
     let temp = tempdir()?;

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -55,19 +55,10 @@ fn emit_parse_body_inner(
     cx: &super::EmitCx,
     include_behavior_assertions: bool,
 ) -> proc_macro2::TokenStream {
-    let ctx_init = emit_rent_context(&plan.rent);
+    let parse_sequence = emit_parse_sequence(semantics, plan);
     let bump_vars = emit_bump_vars(semantics);
     let init_state_vars = emit_init_state_vars(&plan.fields, semantics);
 
-    // Phase 1: load non-init fields.
-    let load_non_init = emit_load_filtered(semantics, false);
-    // Phase 2: address verify + init CPI (from typed plan).
-    let init_phase = emit_init_phase_typed(&plan.fields, semantics);
-    // Phase 3: load init fields (all init fields: behavior init CPI already
-    // ran in phase 2, so the slot is initialized and ready to load).
-    let load_init = emit_load_filtered(semantics, true);
-    // Phase 4: post-load steps.
-    let phase4 = emit_post_load_typed(&plan.fields, semantics);
     let bump_init = emit_bump_init(semantics, &cx.bumps_name);
 
     // Behavior const assertions: REQUIRES_MUT and SETS_INIT_PARAMS.
@@ -89,11 +80,7 @@ fn emit_parse_body_inner(
         #behavior_asserts
         #bump_vars
         #(#init_state_vars)*
-        #ctx_init
-        #(#load_non_init)*
-        #(#init_phase)*
-        #(#load_init)*
-        #(#phase4)*
+        #parse_sequence
         Ok((Self { #(#construct_fields,)* }, #bump_init))
     }
 }
@@ -105,19 +92,12 @@ fn emit_rent_context(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
         RentPlan::NotNeeded => quote! {},
         RentPlan::FromSysvarField { field } => {
             quote! {
-                // SAFETY: the rent sysvar account was parsed into an AccountView,
-                // and Sysvar<Rent> validation is handled by the field load path.
-                let __rent: &quasar_lang::sysvars::rent::Rent = unsafe {
-                    <quasar_lang::sysvars::rent::Rent as quasar_lang::sysvars::Sysvar>::from_bytes_unchecked(
-                        #field.borrow_unchecked()
-                    )
-                };
                 let __rent_ctx = quasar_lang::ops::OpCtx::new(
                     // SAFETY: `__program_id` is already a valid `&Address`;
                     // this reborrow preserves the same address while keeping
                     // generated SBF in its cheaper shape.
                     unsafe { &*(__program_id as *const quasar_lang::prelude::Address) },
-                    __rent,
+                    #field.get(),
                 );
             }
         }
@@ -130,6 +110,53 @@ fn emit_rent_context(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
                     unsafe { &*(__program_id as *const quasar_lang::prelude::Address) },
                     quasar_lang::ops::RentResolver::fetch_once(),
                 );
+            }
+        }
+    }
+}
+
+fn emit_parse_sequence(
+    semantics: &[FieldSemantics],
+    plan: &AccountsPlanTyped,
+) -> proc_macro2::TokenStream {
+    let init_phase = emit_init_phase_typed(&plan.fields, semantics);
+    let load_init = emit_load_filtered(semantics, true);
+    let phase4 = emit_post_load_typed(&plan.fields, semantics);
+
+    match &plan.rent {
+        RentPlan::NotNeeded => {
+            let load_non_init = emit_load_filtered(semantics, false);
+            quote! {
+                #(#load_non_init)*
+                #(#init_phase)*
+                #(#load_init)*
+                #(#phase4)*
+            }
+        }
+        RentPlan::FetchOnce => {
+            let ctx_init = emit_rent_context(&plan.rent);
+            let load_non_init = emit_load_filtered(semantics, false);
+            quote! {
+                #ctx_init
+                #(#load_non_init)*
+                #(#init_phase)*
+                #(#load_init)*
+                #(#phase4)*
+            }
+        }
+        RentPlan::FromSysvarField { field } => {
+            // The rent field must be loaded before `__rent_ctx` can borrow it;
+            // all other non-init fields keep their normal phase position.
+            let rent_load = emit_load_by_ident(semantics, field);
+            let ctx_init = emit_rent_context(&plan.rent);
+            let load_non_init = emit_load_filtered_excluding(semantics, false, Some(field));
+            quote! {
+                #rent_load
+                #ctx_init
+                #(#load_non_init)*
+                #(#init_phase)*
+                #(#load_init)*
+                #(#phase4)*
             }
         }
     }
@@ -389,12 +416,32 @@ fn emit_load_filtered(
     semantics: &[FieldSemantics],
     init_only: bool,
 ) -> Vec<proc_macro2::TokenStream> {
+    emit_load_filtered_excluding(semantics, init_only, None)
+}
+
+fn emit_load_filtered_excluding(
+    semantics: &[FieldSemantics],
+    init_only: bool,
+    skip_ident: Option<&syn::Ident>,
+) -> Vec<proc_macro2::TokenStream> {
     semantics
         .iter()
         .filter(|sem| sem.core.kind == FieldKind::Single)
         .filter(|sem| sem.has_init() == init_only)
+        .filter(|sem| skip_ident.is_none_or(|skip| sem.core.ident != *skip))
         .map(emit_one_load)
         .collect()
+}
+
+fn emit_load_by_ident(
+    semantics: &[FieldSemantics],
+    field: &syn::Ident,
+) -> proc_macro2::TokenStream {
+    semantics
+        .iter()
+        .find(|sem| sem.core.kind == FieldKind::Single && sem.core.ident == *field)
+        .map(emit_one_load)
+        .expect("rent plan field should exist in account semantics")
 }
 
 fn emit_one_load(sem: &FieldSemantics) -> proc_macro2::TokenStream {

--- a/idl/src/codegen/typescript.rs
+++ b/idl/src/codegen/typescript.rs
@@ -2296,22 +2296,75 @@ fn is_optional_dynamic_vec(ty: &IdlType) -> bool {
 
 fn is_u8_type(ty: &IdlType) -> bool {
     matches!(ty, IdlType::Primitive(p) if p == "u8")
+        || matches!(
+            ty,
+            IdlType::Defined { defined } if builtin_defined_primitive(&defined.name) == Some("u8")
+        )
+}
+
+fn builtin_defined_primitive(name: &str) -> Option<&'static str> {
+    match name {
+        "PodBool" => Some("bool"),
+        "PodU8" => Some("u8"),
+        "PodI8" => Some("i8"),
+        "PodU16" => Some("u16"),
+        "PodI16" => Some("i16"),
+        "PodU32" => Some("u32"),
+        "PodI32" => Some("i32"),
+        "PodU64" => Some("u64"),
+        "PodI64" => Some("i64"),
+        "PodU128" => Some("u128"),
+        "PodI128" => Some("i128"),
+        _ => None,
+    }
+}
+
+fn primitive_ts_type(primitive: &str) -> String {
+    match primitive {
+        "u8" | "u16" | "u32" | "i8" | "i16" | "i32" => "number".to_string(),
+        "u64" | "u128" | "i64" | "i128" => "bigint".to_string(),
+        "bool" => "boolean".to_string(),
+        "pubkey" => "Address".to_string(),
+        "string" => "string".to_string(),
+        "bytes" => "Uint8Array".to_string(),
+        other if other.starts_with('[') => "Uint8Array".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn primitive_ts_codec(primitive: &str, target: TsTarget) -> String {
+    match primitive {
+        "u8" => "getU8Codec()".to_string(),
+        "u16" => "getU16Codec()".to_string(),
+        "u32" => "getU32Codec()".to_string(),
+        "u64" => "getU64Codec()".to_string(),
+        "u128" => "getU128Codec()".to_string(),
+        "i8" => "getI8Codec()".to_string(),
+        "i16" => "getI16Codec()".to_string(),
+        "i32" => "getI32Codec()".to_string(),
+        "i64" => "getI64Codec()".to_string(),
+        "i128" => "getI128Codec()".to_string(),
+        "bool" => "getBooleanCodec()".to_string(),
+        "pubkey" => match target {
+            TsTarget::Web3js => "getPublicKeyCodec()".to_string(),
+            TsTarget::Kit => "getAddressCodec()".to_string(),
+        },
+        "string" => "addCodecSizePrefix(getUtf8Codec(), getU32Codec())".to_string(),
+        other if other.starts_with('[') => {
+            let size = super::parse_fixed_array_size(other).unwrap_or(1);
+            format!("fixCodecSize(getBytesCodec(), {})", size)
+        }
+        other => format!("/* unknown: {} */", other),
+    }
 }
 
 fn ts_type(ty: &IdlType) -> String {
     match ty {
-        IdlType::Primitive(p) => match p.as_str() {
-            "u8" | "u16" | "u32" | "i8" | "i16" | "i32" => "number".to_string(),
-            "u64" | "u128" | "i64" | "i128" => "bigint".to_string(),
-            "bool" => "boolean".to_string(),
-            "pubkey" => "Address".to_string(),
-            "string" => "string".to_string(),
-            "bytes" => "Uint8Array".to_string(),
-            other if other.starts_with('[') => "Uint8Array".to_string(),
-            other => other.to_string(),
-        },
+        IdlType::Primitive(p) => primitive_ts_type(p),
         IdlType::Option { option } => format!("{} | null", ts_type(option)),
-        IdlType::Defined { defined } => defined.name.clone(),
+        IdlType::Defined { defined } => builtin_defined_primitive(&defined.name)
+            .map(primitive_ts_type)
+            .unwrap_or_else(|| defined.name.clone()),
         IdlType::Vec { vec } => format!("Array<{}>", ts_type(vec)),
         IdlType::Array { array } => {
             let (item, _size) = array;
@@ -2328,31 +2381,11 @@ fn ts_type(ty: &IdlType) -> String {
 /// Generate codec expression for a type (no codec metadata).
 fn ts_codec(ty: &IdlType, target: TsTarget) -> String {
     match ty {
-        IdlType::Primitive(p) => match p.as_str() {
-            "u8" => "getU8Codec()".to_string(),
-            "u16" => "getU16Codec()".to_string(),
-            "u32" => "getU32Codec()".to_string(),
-            "u64" => "getU64Codec()".to_string(),
-            "u128" => "getU128Codec()".to_string(),
-            "i8" => "getI8Codec()".to_string(),
-            "i16" => "getI16Codec()".to_string(),
-            "i32" => "getI32Codec()".to_string(),
-            "i64" => "getI64Codec()".to_string(),
-            "i128" => "getI128Codec()".to_string(),
-            "bool" => "getBooleanCodec()".to_string(),
-            "pubkey" => match target {
-                TsTarget::Web3js => "getPublicKeyCodec()".to_string(),
-                TsTarget::Kit => "getAddressCodec()".to_string(),
-            },
-            "string" => "addCodecSizePrefix(getUtf8Codec(), getU32Codec())".to_string(),
-            other if other.starts_with('[') => {
-                let size = super::parse_fixed_array_size(other).unwrap_or(1);
-                format!("fixCodecSize(getBytesCodec(), {})", size)
-            }
-            other => format!("/* unknown: {} */", other),
-        },
+        IdlType::Primitive(p) => primitive_ts_codec(p, target),
         IdlType::Option { option } => format!("getOptionCodec({})", ts_codec(option, target)),
-        IdlType::Defined { defined } => format!("{}Codec", defined.name),
+        IdlType::Defined { defined } => builtin_defined_primitive(&defined.name)
+            .map(|primitive| primitive_ts_codec(primitive, target))
+            .unwrap_or_else(|| format!("{}Codec", defined.name)),
         IdlType::Vec { vec } => {
             format!(
                 "getArrayCodec({}, {{ size: getU32Codec() }})",
@@ -2484,7 +2517,11 @@ fn collect_used_codecs(idl: &Idl) -> HashSet<String> {
                     visit_type_into(&array.0, used);
                 }
             }
-            IdlType::Defined { .. } => {}
+            IdlType::Defined { defined } => {
+                if let Some(primitive) = builtin_defined_primitive(&defined.name) {
+                    used.insert(primitive.to_string());
+                }
+            }
             IdlType::Generic { .. } => {}
         }
     }

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -177,7 +177,8 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
     ///
     /// Returns a raw pointer because the buffer contents are logically
     /// uninitialized; callers must write before reading any byte.
-    /// After writing, call `set_data_len()` with the number of bytes written.
+    /// After writing, call unsafe [`set_data_len`](Self::set_data_len) with
+    /// the number of bytes written.
     ///
     /// # Safety
     ///
@@ -188,9 +189,17 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
         self.data.as_mut_ptr()
     }
 
-    /// Set the active data length (after writing via `data_mut()`).
+    /// Set the active data length after writing via
+    /// [`data_mut`](Self::data_mut).
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that every byte in `data[0..len]` has been
+    /// initialized. CPI invocation and
+    /// [`instruction_data`](Self::instruction_data) read exactly that byte
+    /// range.
     #[inline(always)]
-    pub fn set_data_len(&mut self, len: usize) -> Result<(), ProgramError> {
+    pub unsafe fn set_data_len(&mut self, len: usize) -> Result<(), ProgramError> {
         if unlikely(len > MAX_DATA) {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -321,7 +330,8 @@ mod tests {
             let buf = &mut *cpi.data_mut();
             buf[..4].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
         }
-        cpi.set_data_len(4).unwrap();
+        // SAFETY: The first four bytes were written above.
+        unsafe { cpi.set_data_len(4) }.unwrap();
         assert_eq!(cpi.instruction_data(), &[0xAA, 0xBB, 0xCC, 0xDD]);
     }
 
@@ -370,15 +380,19 @@ mod tests {
     #[test]
     fn set_data_len_overflow_returns_error() {
         let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
-        assert!(cpi.set_data_len(5).is_err());
+        // SAFETY: The call must fail before any byte can become active.
+        assert!(unsafe { cpi.set_data_len(5) }.is_err());
     }
 
     #[test]
     fn set_data_len_exact_capacity() {
         let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
-        // SAFETY: We're only setting the length; invoke would read these bytes
-        // but we won't invoke; this tests the length validation path.
-        assert!(cpi.set_data_len(4).is_ok());
+        unsafe {
+            let buf = &mut *cpi.data_mut();
+            buf.copy_from_slice(&[0xAA; 4]);
+        }
+        // SAFETY: All four bytes were written above.
+        assert!(unsafe { cpi.set_data_len(4) }.is_ok());
     }
 
     #[test]
@@ -398,7 +412,8 @@ mod tests {
             buf[0] = 0xBE;
             buf[1] = 0xEF;
         }
-        cpi.set_data_len(2).unwrap();
+        // SAFETY: The first two bytes were written above.
+        unsafe { cpi.set_data_len(2) }.unwrap();
         assert_eq!(cpi.instruction_data(), &[0xBE, 0xEF]);
     }
 

--- a/lang/tests/compile_fail/cpi_dynamic_safe_set_data_len.rs
+++ b/lang/tests/compile_fail/cpi_dynamic_safe_set_data_len.rs
@@ -1,0 +1,8 @@
+use {quasar_lang::cpi::CpiDynamic, solana_address::Address};
+
+fn main() {
+    let program_id = Address::new_from_array([0u8; 32]);
+    let mut cpi = CpiDynamic::<0, 4>::new(&program_id);
+
+    cpi.set_data_len(4).unwrap();
+}

--- a/lang/tests/compile_fail/cpi_dynamic_safe_set_data_len.stderr
+++ b/lang/tests/compile_fail/cpi_dynamic_safe_set_data_len.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function `CpiDynamic::<'a, MAX_ACCTS, MAX_DATA>::set_data_len` is unsafe and requires unsafe function or block
+ --> tests/compile_fail/cpi_dynamic_safe_set_data_len.rs:7:5
+  |
+7 |     cpi.set_data_len(4).unwrap();
+  |     ^^^^^^^^^^^^^^^^^^^ call to unsafe function
+  |
+  = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/lang/tests/miri.rs
+++ b/lang/tests/miri.rs
@@ -96,6 +96,8 @@ use {
     std::mem::{align_of, size_of, MaybeUninit},
 };
 
+solana_address::declare_id!("11111111111111111111111111111112");
+
 mod remaining_group_fixture {
     use quasar_lang::prelude::*;
 
@@ -103,6 +105,25 @@ mod remaining_group_fixture {
     pub struct RemainingPair {
         pub first: UncheckedAccount,
         pub second: UncheckedAccount,
+    }
+}
+
+#[allow(dead_code)]
+mod init_with_rent_fixture {
+    use quasar_lang::prelude::*;
+
+    #[account(discriminator = 1)]
+    pub struct ProbeData {
+        pub value: PodU64,
+    }
+
+    #[derive(quasar_derive::Accounts)]
+    pub struct InitWithRent {
+        #[account(mut)]
+        pub payer: Signer,
+        pub rent: Sysvar<Rent>,
+        #[account(mut, init)]
+        pub target: Account<ProbeData>,
     }
 }
 
@@ -1733,6 +1754,25 @@ fn uninit_sysvar_rent_2x_threshold() {
     let data_len = 100usize;
     let expected = 2 * (ACCOUNT_STORAGE_OVERHEAD + data_len as u64) * 3480;
     assert_eq!(rent.minimum_balance_unchecked(data_len), expected);
+}
+
+#[test]
+fn generated_parse_validates_explicit_rent_before_using_it_for_init() {
+    use init_with_rent_fixture::InitWithRent;
+
+    let mut payer_buf = AccountBuffer::new(0);
+    payer_buf.init([1; 32], [9; 32], 1_000_000, 0, true, true);
+
+    let mut short_fake_rent = AccountBuffer::exact(size_of::<RuntimeAccount>());
+    short_fake_rent.init([2; 32], [9; 32], 1_000_000, 0, false, false);
+
+    let mut target_buf = AccountBuffer::new(0);
+    target_buf.init([3; 32], [0; 32], 0, 0, false, true);
+
+    let mut accounts = unsafe { [payer_buf.view(), short_fake_rent.view(), target_buf.view()] };
+    let result = unsafe { InitWithRent::parse_unchecked(&mut accounts, &ID) };
+
+    assert_eq!(result.map(|_| ()), Err(ProgramError::IncorrectProgramId));
 }
 
 #[repr(C)]

--- a/metadata/src/instructions/create_metadata.rs
+++ b/metadata/src/instructions/create_metadata.rs
@@ -106,6 +106,8 @@ pub(crate) fn create_metadata_accounts_v3<'a>(
         offset += 1;
     }
 
-    cpi.set_data_len(offset)?;
+    // SAFETY: The serialization block above initialized every byte in
+    // `data[0..offset]`.
+    unsafe { cpi.set_data_len(offset) }?;
     Ok(cpi)
 }

--- a/metadata/src/instructions/update_metadata.rs
+++ b/metadata/src/instructions/update_metadata.rs
@@ -129,6 +129,8 @@ pub(super) fn update_metadata_accounts_v2<'a>(
         }
     }
 
-    cpi.set_data_len(offset)?;
+    // SAFETY: The serialization block above initialized every byte in
+    // `data[0..offset]`.
+    unsafe { cpi.set_data_len(offset) }?;
     Ok(cpi)
 }


### PR DESCRIPTION
## Summary

- Generate owned Quasar account wrappers from `quasar add -i` instead of Anchor-style `<'info>` references.
- Lower built-in Pod defined types to TypeScript primitives/codecs, so generated Kit clients use `bigint` plus `getU64Codec()` for `Vec<PodU64, N>` and the same primitive path for the rest of the Pod scalar family.
- Make `CpiDynamic::set_data_len` unsafe and update internal zero-copy CPI call sites to document that the active byte range was initialized.
- Load an explicit `Sysvar<Rent>` field before constructing lifecycle rent context for init/realloc, so generated parsers validate the sysvar wrapper before borrowing rent data.

Closes #227
Closes #228
Closes #229
Closes #230

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p quasar-cli add_instruction_generates_owned_account_wrappers -- --nocapture`
- `cargo test -p quasar-cli --test generated_clients_smoke -- --nocapture`
- `cargo test -p quasar-lang --test compile_fail -- --nocapture`
- `MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" cargo +nightly miri test -p quasar-lang --test miri generated_parse_validates_explicit_rent_before_using_it_for_init -- --exact --nocapture`
- `cargo test -p quasar-lang --tests -- --nocapture`
- `cargo test -p quasar-idl -- --nocapture`
- `cargo test -p quasar-metadata -- --nocapture`
- `cargo clippy -p quasar-lang -p quasar-idl -p quasar-cli -p quasar-metadata --all-targets -- -D warnings`
- `scripts/bench-tracked-programs.sh compare origin/master`

Tracked benchmark result: vault and multisig CU/size unchanged; escrow size unchanged; escrow CU deltas are `MAKE +1`, `TAKE +3`, `REFUND +1`.
