### PR TITLE
fix rent preload order, cpi set_data_len safety, add -i template

### DIFF
--- a/cli/src/new.rs
+++ b/cli/src/new.rs
@@ -68,12 +68,12 @@ pub fn run_instruction(name: &str) -> CliResult {
         r#"use quasar_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct {pascal}<'info> {{
-    pub payer: &'info mut Signer,
-    pub system_program: &'info Program<SystemProgram>,
+pub struct {pascal} {{
+    pub payer: Signer,
+    pub system_program: Program<SystemProgram>,
 }}
 
-impl<'info> {pascal}<'info> {{
+impl {pascal} {{
     #[inline(always)]
     pub fn {snake}(&self) -> Result<(), ProgramError> {{
         Ok(())

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -3,8 +3,8 @@
 //! Generated parse body shape:
 //!
 //! ```text
-//! // Rent source (only when init/realloc/migration may need it)
-//! let __rent_ctx = OpCtx::new(&program_id, &__rent);
+//! // RentResolver (fetch syscall) when no Sysvar<Rent> field, else deferred:
+//! //   after phase 1, `__rent`/`__rent_ctx` from validated `Sysvar<Rent>` field.
 //!
 //! // Phase 1: load non-init fields
 //! let field_a = <Ty>::load(field_a)?;
@@ -55,7 +55,8 @@ fn emit_parse_body_inner(
     cx: &super::EmitCx,
     include_behavior_assertions: bool,
 ) -> proc_macro2::TokenStream {
-    let ctx_init = emit_rent_context(&plan.rent);
+    let ctx_init_early = emit_rent_context_early(&plan.rent);
+    let ctx_init_after_non_init = emit_rent_context_after_non_init_loads(&plan.rent);
     let bump_vars = emit_bump_vars(semantics);
     let init_state_vars = emit_init_state_vars(&plan.fields, semantics);
 
@@ -89,8 +90,9 @@ fn emit_parse_body_inner(
         #behavior_asserts
         #bump_vars
         #(#init_state_vars)*
-        #ctx_init
+        #ctx_init_early
         #(#load_non_init)*
+        #ctx_init_after_non_init
         #(#init_phase)*
         #(#load_init)*
         #(#phase4)*
@@ -100,13 +102,32 @@ fn emit_parse_body_inner(
 
 // Rent context.
 
-fn emit_rent_context(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
+/// Rent context that does not depend on account field loads (`RentResolver` only).
+fn emit_rent_context_early(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
     match rent_plan {
-        RentPlan::NotNeeded => quote! {},
+        RentPlan::FetchOnce => {
+            quote! {
+                let __rent_ctx = quasar_lang::ops::OpCtx::new(
+                    // SAFETY: `__program_id` is already a valid `&Address`;
+                    // this reborrow preserves the same address while keeping
+                    // generated SBF in its cheaper shape.
+                    unsafe { &*(__program_id as *const quasar_lang::prelude::Address) },
+                    quasar_lang::ops::RentResolver::fetch_once(),
+                );
+            }
+        }
+        RentPlan::NotNeeded | RentPlan::FromSysvarField { .. } => quote! {},
+    }
+}
+
+/// Rent context built from an explicit `Sysvar<Rent>` field: must run only after
+/// that field has been loaded and validated in phase 1.
+fn emit_rent_context_after_non_init_loads(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
+    match rent_plan {
         RentPlan::FromSysvarField { field } => {
             quote! {
-                // SAFETY: the rent sysvar account was parsed into an AccountView,
-                // and Sysvar<Rent> validation is handled by the field load path.
+                // SAFETY: `Sysvar<Rent>` was loaded above, so the account is the
+                // real rent sysvar before we interpret its bytes.
                 let __rent: &quasar_lang::sysvars::rent::Rent = unsafe {
                     <quasar_lang::sysvars::rent::Rent as quasar_lang::sysvars::Sysvar>::from_bytes_unchecked(
                         #field.borrow_unchecked()
@@ -121,17 +142,7 @@ fn emit_rent_context(rent_plan: &RentPlan) -> proc_macro2::TokenStream {
                 );
             }
         }
-        RentPlan::FetchOnce => {
-            quote! {
-                let __rent_ctx = quasar_lang::ops::OpCtx::new(
-                    // SAFETY: `__program_id` is already a valid `&Address`;
-                    // this reborrow preserves the same address while keeping
-                    // generated SBF in its cheaper shape.
-                    unsafe { &*(__program_id as *const quasar_lang::prelude::Address) },
-                    quasar_lang::ops::RentResolver::fetch_once(),
-                );
-            }
-        }
+        RentPlan::NotNeeded | RentPlan::FetchOnce => quote! {},
     }
 }
 

--- a/lang/src/cpi/dyn_cpi.rs
+++ b/lang/src/cpi/dyn_cpi.rs
@@ -3,6 +3,10 @@
 //! `CpiDynamic` is the variable-length counterpart to [`super::CpiCall`].
 //! Both accounts and data are backed by `MaybeUninit` stack arrays with
 //! compile-time capacity, while the active count is tracked at runtime.
+//!
+//! Instruction data uses a `MaybeUninit` buffer: use [`CpiDynamic::set_data`] for
+//! a fully safe path, or write through [`CpiDynamic::data_mut`] and then call
+//! [`CpiDynamic::set_data_len`] under its safety contract before invoking the CPI.
 
 use {
     super::{
@@ -177,7 +181,8 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
     ///
     /// Returns a raw pointer because the buffer contents are logically
     /// uninitialized; callers must write before reading any byte.
-    /// After writing, call `set_data_len()` with the number of bytes written.
+    /// After writing the serialized bytes, call [`Self::set_data_len`] to mark the
+    /// active region (see its safety contract).
     ///
     /// # Safety
     ///
@@ -188,9 +193,16 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
         self.data.as_mut_ptr()
     }
 
-    /// Set the active data length (after writing via `data_mut()`).
+    /// Set the active instruction data length after initializing those bytes.
+    ///
+    /// # Safety
+    ///
+    /// Every byte in the range that will be read for CPI (`0..len`) must already be
+    /// initialized (for example by [`Self::set_data`] or by writes through
+    /// [`Self::data_mut`]). Otherwise [`Self::invoke`], [`Self::instruction_data`],
+    /// and similar methods may read uninitialized memory (undefined behavior).
     #[inline(always)]
-    pub fn set_data_len(&mut self, len: usize) -> Result<(), ProgramError> {
+    pub unsafe fn set_data_len(&mut self, len: usize) -> Result<(), ProgramError> {
         if unlikely(len > MAX_DATA) {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -253,8 +265,9 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
     #[inline(always)]
     fn invoke_inner(&self, signers: &[Signer]) -> ProgramResult {
         // SAFETY: accounts[0..acct_len] and cpi_accounts[0..acct_len]
-        // are initialized by push_account. data[0..data_len] written by
-        // set_data or data_mut(). MaybeUninit<[T; N]> has same layout as [T; N].
+        // are initialized by push_account. data[0..data_len] must be initialized
+        // by set_data or by data_mut writes followed by unsafe set_data_len.
+        // MaybeUninit<[T; N]> has same layout as [T; N].
         // We pass pointers with acct_len/data_len to invoke_raw, reading only
         // the initialized portion -- never assume_init() the whole array.
         let result = unsafe {
@@ -299,7 +312,7 @@ impl<'a, const MAX_ACCTS: usize, const MAX_DATA: usize> CpiDynamic<'a, MAX_ACCTS
     /// Debug accessor for instruction data (off-chain only).
     #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
     pub fn instruction_data(&self) -> &[u8] {
-        // SAFETY: data[0..data_len] was initialized by set_data or data_mut().
+        // SAFETY: `data[0..data_len]` must be initialized (same obligation as [`Self::invoke`]).
         unsafe { core::slice::from_raw_parts(self.data.as_ptr() as *const u8, self.data_len) }
     }
 }
@@ -320,8 +333,8 @@ mod tests {
         unsafe {
             let buf = &mut *cpi.data_mut();
             buf[..4].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+            cpi.set_data_len(4).unwrap();
         }
-        cpi.set_data_len(4).unwrap();
         assert_eq!(cpi.instruction_data(), &[0xAA, 0xBB, 0xCC, 0xDD]);
     }
 
@@ -370,15 +383,14 @@ mod tests {
     #[test]
     fn set_data_len_overflow_returns_error() {
         let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
-        assert!(cpi.set_data_len(5).is_err());
+        assert!(unsafe { cpi.set_data_len(5) }.is_err());
     }
 
     #[test]
     fn set_data_len_exact_capacity() {
         let mut cpi = CpiDynamic::<1, 4>::new(&PROGRAM_ID);
-        // SAFETY: We're only setting the length; invoke would read these bytes
-        // but we won't invoke; this tests the length validation path.
-        assert!(cpi.set_data_len(4).is_ok());
+        // SAFETY: Length cap check only; we never read the buffer.
+        assert!(unsafe { cpi.set_data_len(4) }.is_ok());
     }
 
     #[test]
@@ -397,8 +409,8 @@ mod tests {
             let buf = &mut *ptr;
             buf[0] = 0xBE;
             buf[1] = 0xEF;
+            cpi.set_data_len(2).unwrap();
         }
-        cpi.set_data_len(2).unwrap();
         assert_eq!(cpi.instruction_data(), &[0xBE, 0xEF]);
     }
 

--- a/lang/tests/cpi_dynamic_data.rs
+++ b/lang/tests/cpi_dynamic_data.rs
@@ -1,0 +1,16 @@
+//! Off-chain coverage for [`quasar_lang::cpi::CpiDynamic`] instruction data paths.
+//!
+//! The safe serialization entrypoint is [`CpiDynamic::set_data`]. Zero-copy writes use
+//! [`CpiDynamic::data_mut`] and then [`CpiDynamic::set_data_len`], which is `unsafe`
+//! because the caller must initialize every byte in the active range.
+
+use quasar_lang::cpi::CpiDynamic;
+use solana_address::Address;
+
+#[test]
+fn cpi_dynamic_set_data_round_trip() {
+    let program_id = Address::new_from_array([0u8; 32]);
+    let mut cpi = CpiDynamic::<0, 8>::new(&program_id);
+    cpi.set_data(&[1, 2, 3, 4]).unwrap();
+    assert_eq!(cpi.instruction_data(), &[1, 2, 3, 4]);
+}

--- a/metadata/src/instructions/create_metadata.rs
+++ b/metadata/src/instructions/create_metadata.rs
@@ -106,6 +106,10 @@ pub(crate) fn create_metadata_accounts_v3<'a>(
         offset += 1;
     }
 
-    cpi.set_data_len(offset)?;
+    // SAFETY: Every byte in `0..offset` was written above; that range becomes the
+    // active instruction data for CPI.
+    unsafe {
+        cpi.set_data_len(offset)?;
+    }
     Ok(cpi)
 }

--- a/metadata/src/instructions/update_metadata.rs
+++ b/metadata/src/instructions/update_metadata.rs
@@ -129,6 +129,10 @@ pub(super) fn update_metadata_accounts_v2<'a>(
         }
     }
 
-    cpi.set_data_len(offset)?;
+    // SAFETY: Every byte in `0..offset` was written above; that range becomes the
+    // active instruction data for CPI.
+    unsafe {
+        cpi.set_data_len(offset)?;
+    }
     Ok(cpi)
 }


### PR DESCRIPTION
hey, this addresses the three open bugs around rent parsing, CpiDynamic instruction data, and `quasar add -i`.

**#230** generated code was using `Rent::from_bytes_unchecked` on the rent sysvar slot before `Sysvar<Rent>` went through the normal load path, so the wrong short account could hit UB before `IncorrectProgramId`. the `FromSysvarField` `__rent` / `__rent_ctx` block now runs after phase 1 non-init loads.

**#229** safe `set_data_len` could mark uninitialized CPI bytes active; `invoke` and the off-chain `instruction_data` helper read that slice, which Miri flags. `set_data_len` is `unsafe` now with docs; mpl metadata builders wrap the final call where the prefix is fully written. small integration test uses the safe `set_data` path.

**#227** `quasar add -i` was emitting anchor-style lifetimes; it now matches `quasar init` with owned `Signer` / `Program<SystemProgram>`.

**breaking:** `CpiDynamic::set_data_len` is now `unsafe`; downstream callers need an `unsafe` block and must satisfy the init contract.