### PR TITLE
fix(lang): reject account self-close

### DIFF
--- a/lang/src/ops/close.rs
+++ b/lang/src/ops/close.rs
@@ -13,6 +13,9 @@ use {
 ///
 /// The discriminator is cleared first so any later failure leaves the account
 /// unusable as typed program state.
+///
+/// Returns [`ProgramError::InvalidArgument`] if `destination` is the same
+/// account as `account`.
 #[inline(always)]
 pub fn close_account(
     account: &mut AccountView,
@@ -21,6 +24,16 @@ pub fn close_account(
 ) -> ProgramResult {
     if crate::utils::hint::unlikely(!destination.is_writable()) {
         return Err(ProgramError::Immutable);
+    }
+    // A self-close sums the drained lamports back into the same account and
+    // then zeroes them, destroying the balance (`UnbalancedInstruction`). A
+    // duplicate meta shares one backing account, so reject by pointer identity
+    // before any mutation leaves the account in a partially-closed state.
+    if crate::utils::hint::unlikely(core::ptr::eq(
+        account.account_ptr(),
+        destination.account_ptr(),
+    )) {
+        return Err(ProgramError::InvalidArgument);
     }
     // SAFETY: Callers only close accounts that have already passed the normal
     // account load path, so the discriminator prefix is present and writable.

--- a/lang/tests/miri.rs
+++ b/lang/tests/miri.rs
@@ -2113,6 +2113,32 @@ fn ops_close_rejects_lamport_overflow() {
 }
 
 #[test]
+fn ops_close_rejects_self_close() {
+    let data_len = 16usize;
+    let mut buf = AccountBuffer::new(data_len);
+    buf.init(
+        [1u8; 32],
+        TEST_OWNER.to_bytes(),
+        1_000_000,
+        data_len as u64,
+        false,
+        true,
+    );
+
+    let mut src_view = unsafe { buf.view() };
+    let self_view = unsafe { AccountView::new_unchecked(buf.raw()) };
+
+    let account =
+        unsafe { Account::<TestCloseableType>::from_account_view_unchecked_mut(&mut src_view) };
+    let result = account.close(&self_view);
+
+    assert_eq!(result, Err(ProgramError::InvalidArgument));
+    assert_eq!(self_view.lamports(), 1_000_000);
+    assert_eq!(self_view.data_len(), data_len);
+    assert!(self_view.owned_by(&TEST_OWNER));
+}
+
+#[test]
 fn ops_borrow_unchecked_mut_write_then_read_via_data_ptr() {
     let mut buf = AccountBuffer::new(16);
     buf.init([1u8; 32], [0u8; 32], 100, 16, false, true);


### PR DESCRIPTION
## Summary

`close_account` didn't verify that the destination differs from the account
being closed. On a self-close the lamports get summed back into the account and
then zeroed, so the balance is destroyed and the transaction aborts with
`UnbalancedInstruction`.

This rejects the self-close before any mutation with a single backing-pointer
compare (`core::ptr::eq` on `account_ptr()`), returning
`ProgramError::InvalidArgument`. A duplicate account passed twice shares one
runtime account, so identity is one pointer compare. The check runs before the
discriminator is zeroed, so a rejected close leaves the account untouched.

It's reachable via the public `Account::close` method (`escrow.close(&escrow)`)
and any duplicate-account meta.

Closes #240

## Verification

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo +nightly clippy -p quasar-lang --all-features --all-targets -- -D warnings`
- `TRYBUILD=overwrite cargo test -p quasar-lang --all-features` (adds `ops_close_rejects_self_close`)
- `MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" cargo +nightly miri test -p quasar-lang --test miri ops_close`
- `scripts/bench-tracked-programs.sh compare master`

No CU or size regressions; escrow size -312 bytes, TAKE -10 / MAKE -8 / REFUND -1 CU, all else unchanged.
