### PR TITLE
fix(lang): validate CPI return data before decode

### DIFF
--- a/lang/src/cpi/mod.rs
+++ b/lang/src/cpi/mod.rs
@@ -197,6 +197,10 @@ impl CpiReturn {
         }
         // SAFETY: The previous copy initialized every byte of `T::Zc`.
         let zc = unsafe { zc.assume_init() };
+        // Return data is untrusted: validate before `from_zc`, whose
+        // contract assumes a validated companion (e.g. enum `from_zc` calls
+        // `unreachable_unchecked` on undeclared discriminants).
+        T::validate_zc(&zc)?;
         Ok(T::from_zc(&zc))
     }
 }
@@ -589,6 +593,23 @@ mod tests {
         let zc = <ReturnPayload as InstructionArg>::to_zc(&payload);
         let ret = return_with_data([2u8; 32], zc_bytes::<ReturnPayload>(&zc));
         assert_eq!(ret.decode::<ReturnPayload>().unwrap(), payload);
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, QuasarSerialize)]
+    #[repr(u8)]
+    enum Status {
+        Active = 1,
+        Closed = 2,
+    }
+
+    #[test]
+    fn decode_rejects_undeclared_enum_discriminant() {
+        let ret = return_with_data([1u8; 32], &[9u8]);
+        let result = ret.decode::<Status>();
+        assert!(
+            result.is_err(),
+            "undeclared discriminant must be rejected, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`CpiReturn::decode` copied untrusted return bytes into the zero-copy companion
and called `from_zc` without first calling `validate_zc`. `from_zc`'s contract
assumes a validated companion: for enum `InstructionArg` types it reaches
`core::hint::unreachable_unchecked()` on an undeclared discriminant, so decoding
crafted return data was undefined behavior (Miri reports "entering unreachable
code").

Validate before `from_zc`, matching the documented invariant (see the
`Option::from_zc` SAFETY note) and the instruction-parse path.

Primitive companions like `PodBool` are unaffected since they convert via
`!= 0` and never form an invalid bit pattern; the soundness hole is the enum
`unreachable_unchecked` path.

Closes #238

## Verification

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo +nightly clippy -p quasar-lang --all-features --all-targets -- -D warnings`
- `cargo test -p quasar-lang --all-features` (adds `decode_rejects_undeclared_enum_discriminant`)
- `MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-symbolic-alignment-check" cargo +nightly miri test -p quasar-lang --lib cpi` (reproduces the UB before the fix, clean after)
- `scripts/bench-tracked-programs.sh compare master`

No tracked program decodes CPI return data, so all CU and size deltas are zero.
