### PR TITLE
style(cli): Make client selection control obvious

### DIFF
--- a/cli/src/init/mod.rs
+++ b/cli/src/init/mod.rs
@@ -278,8 +278,18 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
             .filter(|(display, _)| !forced.contains(display))
             .collect();
 
+        let hint = format!(
+            "  {} {} {} {} {} {} {}",
+            style::dim("Use"),
+            style::prompt_accent("\u{2191}/\u{2193}"), // up/down arrow keys
+            style::dim("to move,"),
+            style::prompt_accent("space"),
+            style::dim("to select,"),
+            style::prompt_accent("enter"),
+            style::dim("to confirm"),
+        );
         let prompt = format!(
-            "Additional client languages ({} always included)",
+            "Additional client languages ({} always included):\n{hint}",
             forced.join(", ")
         );
 

--- a/cli/src/style.rs
+++ b/cli/src/style.rs
@@ -74,6 +74,15 @@ pub fn color(code: u8, s: &str) -> String {
     }
 }
 
+/// Accent text to highlight interactive prompt keywords/controls.
+pub fn prompt_accent(s: &str) -> String {
+    if use_color() {
+        format!("\x1b[33m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
 /// Format a byte size in a human-readable way.
 pub fn human_size(bytes: u64) -> String {
     if bytes < 1024 {


### PR DESCRIPTION
## Problem: It is not obvious to first time user how to do multi-select

When the user is prompted to select a client, it is not obvious to first time user how to select the client. Other single-choice prompts rely on the `enter` key to make the selection, but `enter` here does not make a selection, but to confirm selection. The user is left to experiment to figure out that `space` is what marks selection.

## Solution:  Add a selection hint line