### PR TITLE
ci: pin the v0.1.0 toolchain contract

### DIFF
--- a/.github/docker/release-cli-smoke.Dockerfile
+++ b/.github/docker/release-cli-smoke.Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:slim-trixie
+FROM rust:1.92.0-slim-trixie
 
-ARG SOLANA_VERSION=stable
+ARG SOLANA_VERSION=v4.1.1
 
 ENV CARGO_TERM_COLOR=always
 ENV PATH="/opt/quasar-cli/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, 0.1.0-release]
   pull_request:
-    branches: [master]
+    branches: [master, 0.1.0-release]
   workflow_call:
     inputs:
       generated_client_smoke:
@@ -14,13 +14,24 @@ on:
         default: true
 
 env:
-  SOLANA_VERSION: stable
+  HOST_RUST_VERSION: 1.92.0
+  PROGRAM_MSRV: 1.89.0
+  SOLANA_VERSION: v4.1.1
+  NODE_VERSION: 24.18.0
+  TYPESCRIPT_VERSION: 5.9.3
+  NODE_TYPES_VERSION: 22.13.0
+  PYTHON_VERSION: 3.14.3
+  GO_VERSION: 1.25.5
+  C_COMPILER_VERSION: 18.1.3
+  CARAVEL_REV: a0a88b705bc888a7ac3e8f7e506a1e997b374b4d
+  CARGO_HACK_VERSION: 0.6.43
+  KANI_VERSION: 0.67.0
   CARGO_TERM_COLOR: always
 
 jobs:
   kani_scope:
     name: Kani Scope
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.scope.outputs.should_run }}
     steps:
@@ -53,7 +64,7 @@ jobs:
 
   generated_client_scope:
     name: Generated Client Scope
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.scope.outputs.should_run }}
     steps:
@@ -88,7 +99,7 @@ jobs:
 
   rust_fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Get nightly toolchain version
@@ -98,12 +109,17 @@ jobs:
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: rustfmt
+      - name: Print Rustfmt toolchain
+        run: |
+          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
+          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
+          rustup run "${{ steps.nightly.outputs.version }}" rustfmt --version
       - name: Run format
         run: make format
 
   rust_clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -122,12 +138,19 @@ jobs:
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: clippy
+      - name: Print Clippy toolchain
+        run: |
+          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
+          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
+          cargo +${{ steps.nightly.outputs.version }} clippy --version
       - name: Run clippy
         run: make clippy
 
   check_features:
     name: Check Features
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    env:
+      RUSTUP_TOOLCHAIN: 1.89.0
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -139,19 +162,27 @@ jobs:
           key: ${{ runner.os }}-cargo-hack-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-hack-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.PROGRAM_MSRV }}
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack
+          tool: cargo-hack@${{ env.CARGO_HACK_VERSION }}
+      - name: Print feature-check toolchain
+        run: rustc --version && cargo --version && cargo hack --version
       - name: Check all feature combinations
         run: make check-features
 
   workspace_policy:
     name: Workspace Policy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.HOST_RUST_VERSION }}
+      - name: Print workspace-policy toolchain
+        run: rustc --version && cargo --version
       - name: Verify workspace lint opt-in
         run: make check-workspace-lints
       - name: Verify workspace invariants
@@ -161,16 +192,24 @@ jobs:
 
   package:
     name: Package Manifests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    env:
+      RUSTUP_TOOLCHAIN: 1.89.0
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.PROGRAM_MSRV }}
+      - name: Verify declared MSRV
+        run: make msrv-check
+      - name: Print publication toolchain
+        run: rustc --version && cargo --version
       - name: Verify publishable crates
         run: make package-check
 
   security_audit:
     name: Dependency Security Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       checks: write
@@ -183,7 +222,7 @@ jobs:
 
   cargo_test:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Cache Solana tools
@@ -206,7 +245,11 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.HOST_RUST_VERSION }}
+      - name: Print build toolchains
+        run: rustc --version && cargo --version && solana --version && cargo-build-sbf --version
       - name: Build SBF programs
         run: make build-sbf
       - name: Test
@@ -216,7 +259,9 @@ jobs:
     name: Generated Client Smoke
     needs: generated_client_scope
     if: needs.generated_client_scope.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-18
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -230,21 +275,36 @@ jobs:
             ${{ runner.os }}-cargo-client-smoke-
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: ${{ env.GO_VERSION }}
           cache: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.HOST_RUST_VERSION }}
+      - name: Print generated-client toolchains
+        run: |
+          rustc --version
+          cargo --version
+          node --version
+          npm --version
+          python --version
+          go version
+          "$CC" --version | head -1 | tee /tmp/quasar-cc-version
+          grep -F "version $C_COMPILER_VERSION" /tmp/quasar-cc-version
+          echo "TypeScript ${{ env.TYPESCRIPT_VERSION }}"
+          echo "@types/node ${{ env.NODE_TYPES_VERSION }}"
+          echo "Caravel ${{ env.CARAVEL_REV }}"
       - name: Run generated client smoke test
         run: make generated-client-smoke
 
   miri:
     name: Miri (Tree Borrows)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -263,6 +323,11 @@ jobs:
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: miri
+      - name: Print Miri toolchain
+        run: |
+          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
+          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
+          cargo +${{ steps.nightly.outputs.version }} miri --version
       - name: Run Miri tests
         run: make test-miri
 
@@ -270,7 +335,7 @@ jobs:
     name: Kani (${{ matrix.crate }})
     needs: kani_scope
     if: needs.kani_scope.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -292,12 +357,15 @@ jobs:
       - name: Verify ${{ matrix.crate }}
         uses: model-checking/kani-github-action@v1
         with:
+          kani-version: ${{ env.KANI_VERSION }}
           command: cargo kani -p ${{ matrix.crate }}
+      - name: Print Kani toolchain
+        run: cargo kani --version
 
   cu_benchmark_pr:
     name: CU Benchmark Guard (PR)
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
@@ -325,7 +393,12 @@ jobs:
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-bench-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.HOST_RUST_VERSION }}
+
+      - name: Print benchmark toolchains
+        run: rustc --version && cargo --version && solana --version && cargo-build-sbf --version
 
       - name: Preserve benchmark harness
         run: |
@@ -444,7 +517,7 @@ jobs:
   check_if_pr_commit:
     name: Detect merged PR push
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read
@@ -470,7 +543,7 @@ jobs:
     name: CU Benchmark Guard (Push)
     needs: [check_if_pr_commit]
     if: github.event_name == 'push' && needs.check_if_pr_commit.outputs.skip_bench != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -497,7 +570,12 @@ jobs:
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-bench-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.HOST_RUST_VERSION }}
+
+      - name: Print benchmark toolchains
+        run: rustc --version && cargo --version && solana --version && cargo-build-sbf --version
 
       - name: Capture base metrics
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,7 +22,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'fuzz'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,11 +45,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
+      - name: Print fuzz toolchain
+        run: |
+          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
+          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +${{ steps.nightly.outputs.version }} install cargo-fuzz --locked
       - name: Fuzz ${{ matrix.target }} (300s)
         working-directory: lang
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=300
+        run: cargo +${{ steps.nightly.outputs.version }} fuzz run ${{ matrix.target }} -- -max_total_time=300
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     tags: ["v*"]
 
 env:
-  SOLANA_VERSION: stable
+  KANI_VERSION: 0.67.0
+  PROGRAM_MSRV: 1.89.0
+  SOLANA_VERSION: v4.1.1
   CARGO_TERM_COLOR: always
 
 permissions:
@@ -24,7 +26,7 @@ jobs:
   # ── Miri: verify unsafe soundness under Tree Borrows ──
   miri:
     name: Miri (Tree Borrows)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -43,13 +45,18 @@ jobs:
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: miri
+      - name: Print Miri toolchain
+        run: |
+          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
+          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
+          cargo +${{ steps.nightly.outputs.version }} miri --version
       - name: Run Miri tests
         run: make test-miri
 
   # ── Kani: formal verification of proof harnesses ──
   kani:
     name: Kani (${{ matrix.crate }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -71,13 +78,16 @@ jobs:
       - name: Verify ${{ matrix.crate }}
         uses: model-checking/kani-github-action@v1
         with:
+          kani-version: ${{ env.KANI_VERSION }}
           command: cargo kani -p ${{ matrix.crate }}
+      - name: Print Kani toolchain
+        run: cargo kani --version
 
   # ── CLI smoke: verify a fresh Solana project before publishing a tag ──
   release-cli-smoke:
     name: Release CLI Smoke
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -97,11 +107,18 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: [ci, miri, kani, release-cli-smoke]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    env:
+      RUSTUP_TOOLCHAIN: 1.89.0
     environment: crates-io
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.PROGRAM_MSRV }}
+
+      - name: Print publication toolchain
+        run: rustc --version && cargo --version
 
       - name: Validate release tag
         run: |
@@ -192,7 +209,7 @@ jobs:
   github-release:
     name: GitHub Release
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/toolchain-compatibility.yml
+++ b/.github/workflows/toolchain-compatibility.yml
@@ -1,0 +1,23 @@
+name: Toolchain Compatibility
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  latest-stable-rust:
+    name: Latest stable Rust (non-blocking)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Print compatibility toolchain
+        run: rustc +stable --version && cargo +stable --version
+      - name: Check host tests against latest stable Rust
+        run: cargo +stable test -p quasar-lang -p quasar-derive --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ exclude = []
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/blueshift-gg/quasar"
 authors = ["Leonardo Donatacci <leo@blueshift.gg>", "Dean Little <dean@blueshift.gg>"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /usr/bin/env bash
 # Keep rustfmt, Clippy, and Miri deterministic across local and CI runs.
 NIGHTLY_TOOLCHAIN := nightly-2026-03-27
 KANI_VERSION := 0.67.0
+PROGRAM_MSRV := 1.89.0
 # platform-tools v1.52 ships Cargo 1.89 which supports Cargo.lock v4.
 # v1.51 ships Cargo 1.84 which does not, causing "duplicate lang item" errors.
 PLATFORM_TOOLS := v1.52
@@ -26,15 +27,33 @@ PUBLISH_PACKAGES := quasar-schema quasar-idl-schema quasar-profile \
 	solana-compiler-builtins quasar-derive quasar-idl quasar-lang \
 	quasar-spl quasar-metadata quasar-cli
 
+# Resolve first-release internal dependencies while checking package manifests.
+# These patches are command-local and never enter the published archives.
+PACKAGE_PATCHES := \
+	--config 'patch.crates-io.quasar-schema.path="schema"' \
+	--config 'patch.crates-io.quasar-idl-schema.path="idl/schema"' \
+	--config 'patch.crates-io.quasar-profile.path="profile"' \
+	--config 'patch.crates-io.solana-compiler-builtins.path="solana-compiler-builtins"' \
+	--config 'patch.crates-io.quasar-derive.path="derive"' \
+	--config 'patch.crates-io.quasar-idl.path="idl"' \
+	--config 'patch.crates-io.quasar-lang.path="lang"' \
+	--config 'patch.crates-io.quasar-spl.path="spl"' \
+	--config 'patch.crates-io.quasar-metadata.path="metadata"'
+
 .PHONY: format format-fix clippy clippy-fix check-features check-workspace-lints \
 	check-runtime-panics check-workspace-invariants build build-sbf test test-bless \
 	bench-cu bench-tracked compare-tracked test-miri test-miri-strict test-all \
 	nightly-version generated-client-smoke kani help-kani check-kani kani-lang \
-	kani-spl kani-metadata package-check audit
+	kani-spl kani-metadata msrv-check package-check audit
 
 # Print the nightly toolchain version for CI
 nightly-version:
 	@echo $(NIGHTLY_TOOLCHAIN)
+
+msrv-check:
+	@cargo +$(PROGRAM_MSRV) check \
+		$(foreach package,$(PUBLISH_PACKAGES),-p $(package)) \
+		--all-features --locked
 
 help-kani:
 	@echo "Local Kani verification is optional."
@@ -205,8 +224,10 @@ generated-client-smoke:
 	@cargo test -p quasar-cli --test generated_clients_smoke -- --nocapture --test-threads=1
 
 package-check:
-	@cargo package $(foreach package,$(PUBLISH_PACKAGES),-p $(package)) \
-		--locked --allow-dirty
+	@# First-release internal dependencies are not on crates.io yet. `msrv-check`
+	@# compiles the source graph; #283 rehearses the packaged graph locally.
+	@cargo package --quiet $(foreach package,$(PUBLISH_PACKAGES),-p $(package)) \
+		--locked --allow-dirty --no-verify $(PACKAGE_PATCHES)
 
 audit:
 	@command -v cargo-audit >/dev/null 2>&1 || { \

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-cli"
 description = "CLI for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/cli/tests/generated_clients_smoke.rs
+++ b/cli/tests/generated_clients_smoke.rs
@@ -215,6 +215,10 @@ static inline bool find_program_address(
 }
 
 fn compile_typescript_client(client_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let typescript_version = std::env::var("TYPESCRIPT_VERSION").unwrap_or_else(|_| "5.9.3".into());
+    let node_types_version =
+        std::env::var("NODE_TYPES_VERSION").unwrap_or_else(|_| "22.13.0".into());
+
     fs::write(
         client_dir.join("tsconfig.json"),
         r#"{
@@ -239,8 +243,8 @@ fn compile_typescript_client(client_dir: &Path) -> Result<(), Box<dyn Error>> {
             .arg("--ignore-scripts")
             .arg("--no-audit")
             .arg("--no-fund")
-            .arg("typescript")
-            .arg("@types/node")
+            .arg(format!("typescript@{typescript_version}"))
+            .arg(format!("@types/node@{node_types_version}"))
             .current_dir(client_dir),
     )?;
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-derive"
 description = "Proc macros for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/idl/Cargo.toml
+++ b/idl/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-idl"
 description = "IDL generator for the Quasar Solana framework with discriminator collision detection"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/idl/schema/Cargo.toml
+++ b/idl/schema/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-idl-schema"
 description = "Public IDL JSON schema types for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-lang"
 description = "Zero-copy Solana program framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-metadata"
 description = "Metaplex Token Metadata integration for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/profile/Cargo.toml
+++ b/profile/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-profile"
 description = "SBF binary profiler for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Newest stable compiler that matches the committed trybuild diagnostics.
+channel = "1.92.0"
+profile = "minimal"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-schema"
 description = "Shared schema types for Quasar interfaces"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/solana-compiler-builtins/Cargo.toml
+++ b/solana-compiler-builtins/Cargo.toml
@@ -2,6 +2,7 @@
 name = "solana-compiler-builtins"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "Compiler runtime builtins required by Quasar SBF programs"
 repository.workspace = true

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -3,6 +3,7 @@ name = "quasar-spl"
 description = "SPL Token program CPI and zero-copy account types for the Quasar Solana framework"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Closes #255. This is stacked on #248, which must land on `0.1.0-release`
first.

Required CI was following floating Rust, Agave, and generated-client toolchains.
That let a clean rerun change trybuild output without any source change, and it
left the release compiler contract implicit. This PR makes the release path
deterministic while keeping newer-toolchain drift visible in a separate,
non-blocking workflow.

No trybuild golden is re-blessed in this change.

## 1. Pin the compiler that owns host diagnostics

**Symptom.** PR #248's `Build & Test` job moved to Rust 1.97 and failed eight
trybuild cases even though the source and committed diagnostics had not changed.

**Mechanism.** Required jobs installed `stable`, so Rust diagnostic rendering
was an undeclared input to the test suite.

**Fix.** `rust-toolchain.toml` pins host builds to Rust 1.92.0, the newest
stable compiler that matches every committed trybuild fixture. The boundary was
checked explicitly: 1.93 changes one fixture, 1.94 changes four, and 1.95/1.97
change eight. Required host jobs now install and print 1.92.0.

## 2. Declare and prove the program/publication MSRV

platform-tools v1.52 ships Rust/Cargo 1.89.0. All ten public crates now inherit
`rust-version = "1.89"`, and `make msrv-check` compiles the complete
publication graph with Rust 1.89.0 and all features enabled.

The package-manifest gate now resolves first-release internal dependencies
through command-local crates.io patches. Those patches never enter an archive;
the gate packages all ten crates without pretending they already exist on
crates.io. The full packaged-artifact rehearsal remains #283.

## 3. Pin every required release tool

Required CI now uses exact versions for:

- Agave/Solana CLI v4.1.1 and platform-tools v1.52
- Node 24.18.0, TypeScript 5.9.3, and @types/node 22.13.0
- Python 3.14.3 and Go 1.25.5
- clang 18.1.3 on the pinned Ubuntu 24.04 runner
- cargo-hack 0.6.43 and Kani 0.67.0
- Caravel commit `a0a88b705bc888a7ac3e8f7e506a1e997b374b4d`

The release smoke image also pins Rust 1.92.0 and Agave v4.1.1. Each required
job prints the effective tools it consumes, so a runner mismatch is visible in
the log. CI is enabled for both `master` and `0.1.0-release`.

## 4. Keep compatibility drift visible but non-blocking

A separate weekly/manual `Toolchain Compatibility` workflow runs the host
suite with explicit `+stable`. Its job is `continue-on-error`, is never called
by the release workflow, and cannot change or block a release run.

## Validation

- Rust 1.92.0 host suite: 72 unit tests plus all derive/lang trybuild and host
  tests passed; no diagnostic fixture changed.
- Rust 1.89.0: all 280 feature combinations passed.
- Rust 1.89.0: all ten publishable crates passed `msrv-check` and
  `package-check`.
- Generated-client smoke: 8/8 passed with the pinned TypeScript packages.
- `make format`, `make clippy`, workspace lint/invariant/panic checks, and
  the pre-push hook passed.
- All GitHub workflows passed actionlint 1.7.7.
- The pinned Rust Docker tag and Python runtime are available from their
  upstream distributions.

## Deferred

- Action SHA pinning and least-privilege release permissions remain #281.
- The clean-container, archive-only no-publish rehearsal remains #283.
- Executing generated clients against their real dependency stacks remains
  #273.
