### PR TITLE
ci: stop caching cargo-fuzz without metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,10 +396,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-fuzz-${{ steps.versions.outputs.cargo_fuzz }}-${{ hashFiles('lang/fuzz/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-fuzz-registry-v1-${{ steps.versions.outputs.cargo_fuzz }}-${{ hashFiles('lang/fuzz/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-fuzz-${{ steps.versions.outputs.cargo_fuzz }}-
+            ${{ runner.os }}-cargo-fuzz-registry-v1-${{ steps.versions.outputs.cargo_fuzz }}-
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.versions.outputs.nightly }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -60,10 +60,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ~/.cargo/bin/
-          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('lang/fuzz/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-fuzz-registry-v1-${{ hashFiles('lang/fuzz/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-fuzz-
+            ${{ runner.os }}-cargo-fuzz-registry-v1-
       - name: Get nightly toolchain version
         id: nightly
         run: echo "version=$(make nightly-version)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The required and long-running fuzz jobs cache `~/.cargo/bin/` but not Cargo's install metadata. After a cache hit, `cargo install cargo-fuzz` sees an orphaned binary and exits before any target builds or runs. Pull-request fuzz run 29263621696 reproduced the failure independently in all three target jobs.

This PR fixes only that cache contract:

- removes `~/.cargo/bin/` from both fuzz cache path lists;
- preserves registry, crate, and Git dependency caches; and
- moves both jobs to a new `cargo-fuzz-registry-v1` namespace so existing poisoned archives cannot be restored by key.

The selected cargo-fuzz version and the five-minute fuzz duration are unchanged. Pinning the long-running workflow is tracked separately by #342.

## Validation

- Reproduced: `binary cargo-fuzz already exists in destination` on cache restore
- YAML parse of required CI and long-running fuzz workflows
- No `~/.cargo/bin/` cache path remains in either workflow
- Both cache keys use the new registry-only namespace
- Repository pre-push fmt and full-workspace Clippy gate
- `git diff --check`

## Release stack

- Target: `0.1.0-release`
- Follows #320, which derives the scheduled target inventory.
- Two-workflow atomic review commit: `7c951522`.

Closes #341