### PR TITLE
ci: pin scheduled cargo-fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -54,30 +54,35 @@ jobs:
         target: ${{ fromJSON(needs.fuzz_inventory.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
+      - name: Get pinned tool versions
+        id: versions
+        run: |
+          echo "nightly=$(make nightly-version)" >> "$GITHUB_OUTPUT"
+          echo "cargo_fuzz=$(make cargo-fuzz-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-fuzz-registry-v1-${{ hashFiles('lang/fuzz/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-fuzz-registry-v1-${{ steps.versions.outputs.cargo_fuzz }}-${{ hashFiles('lang/fuzz/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-fuzz-registry-v1-
-      - name: Get nightly toolchain version
-        id: nightly
-        run: echo "version=$(make nightly-version)" >> "$GITHUB_OUTPUT"
+            ${{ runner.os }}-cargo-fuzz-registry-v1-${{ steps.versions.outputs.cargo_fuzz }}-
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ steps.nightly.outputs.version }}
+          toolchain: ${{ steps.versions.outputs.nightly }}
+      - name: Install pinned cargo-fuzz
+        run: >-
+          cargo +${{ steps.versions.outputs.nightly }} install cargo-fuzz
+          --version ${{ steps.versions.outputs.cargo_fuzz }} --locked
       - name: Print fuzz toolchain
         run: |
-          rustup run "${{ steps.nightly.outputs.version }}" rustc --version
-          rustup run "${{ steps.nightly.outputs.version }}" cargo --version
-      - name: Install cargo-fuzz
-        run: cargo +${{ steps.nightly.outputs.version }} install cargo-fuzz --locked
+          rustup run "${{ steps.versions.outputs.nightly }}" rustc --version
+          rustup run "${{ steps.versions.outputs.nightly }}" cargo --version
+          cargo fuzz --version
       - name: Fuzz ${{ matrix.target }} (300s)
         working-directory: lang
-        run: cargo +${{ steps.nightly.outputs.version }} fuzz run ${{ matrix.target }} -- -max_total_time=300
+        run: cargo +${{ steps.versions.outputs.nightly }} fuzz run ${{ matrix.target }} -- -max_total_time=300
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Required fuzz-target compilation uses the repository's exact `cargo-fuzz` contract, but scheduled, manual, and label-triggered fuzz execution still installs the latest registry release. The same Quasar commit can therefore execute under different fuzz-runner behavior over time.

This PR changes only the long-running workflow's tool selection:

- reads both the nightly and `cargo-fuzz` versions from the Makefile contract;
- installs exact `cargo-fuzz` 0.13.2 with `--locked`;
- keys the registry cache by that selected version; and
- prints the effective `cargo fuzz --version` before running each target.

Target inventory, cache ownership, fuzz duration, triggers, and artifact handling are unchanged.

## Validation

- `make cargo-fuzz-version` — `0.13.2`
- YAML parse of `.github/workflows/fuzz.yml`
- Repository pre-push fmt and full-workspace Clippy gate
- `git diff --check`

## Release stack

- Target: `0.1.0-release`
- Follows #343, which removes orphaned installed binaries from fuzz caches.
- One-workflow atomic review commit: `9636d9fd`.

Closes #342