### PR TITLE
fix(cli): correct sbpf-linker recovery command

### DIFF
--- a/cli/src/build_lockfile.rs
+++ b/cli/src/build_lockfile.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{error::CliError, style},
+    crate::{error::CliError, style, toolchain},
     serde::Deserialize,
     std::{
         collections::HashSet,
@@ -96,9 +96,7 @@ pub(super) fn ensure_lockfile(sp: &indicatif::ProgressBar) -> Result<(), CliErro
 }
 
 pub(super) fn missing_sbpf_linker() -> CliError {
-    CliError::message(
-        "sbpf-linker not found on PATH.\n\n  Install platform-tools first:\n    git clone https://github.com/anza-xyz/platform-tools\n    cd platform-tools\n    cargo install-with-gallery",
-    )
+    CliError::message(toolchain::MISSING_SBPF_LINKER_MESSAGE)
 }
 
 fn workspace_manifest_paths() -> Result<Vec<PathBuf>, String> {

--- a/cli/src/init/mod.rs
+++ b/cli/src/init/mod.rs
@@ -130,9 +130,7 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
 
     // For upstream: sbpf-linker must be installed
     if matches!(toolchain, Toolchain::Upstream) && !toolchain::has_sbpf_linker() {
-        return Err(CliError::message(
-            "sbpf-linker not found.\n\n  Install platform-tools first:\n    git clone https://github.com/anza-xyz/platform-tools\n    cd platform-tools\n    cargo install-with-gallery",
-        ));
+        return Err(CliError::message(toolchain::MISSING_SBPF_LINKER_MESSAGE));
     }
 
     let lang_default = match test_language_override

--- a/cli/src/toolchain.rs
+++ b/cli/src/toolchain.rs
@@ -1,5 +1,9 @@
 use std::process::Command;
 
+/// Actionable recovery guidance shared by every upstream build entry point.
+pub const MISSING_SBPF_LINKER_MESSAGE: &str =
+    "sbpf-linker not found on PATH.\n\n  Install it from crates.io:\n    cargo install sbpf-linker";
+
 /// Check whether sbpf-linker is reachable on PATH.
 pub fn has_sbpf_linker() -> bool {
     Command::new("sbpf-linker")
@@ -44,4 +48,18 @@ fn parse_tools_version(s: &str) -> u32 {
     let s = s.strip_prefix('v').unwrap_or(s);
     let (major, minor) = s.split_once('.').unwrap_or(("0", "0"));
     major.parse::<u32>().unwrap_or(0) * 100 + minor.parse::<u32>().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MISSING_SBPF_LINKER_MESSAGE;
+
+    #[test]
+    fn missing_linker_message_uses_the_published_crate() {
+        assert_eq!(
+            MISSING_SBPF_LINKER_MESSAGE,
+            "sbpf-linker not found on PATH.\n\n  Install it from crates.io:\n    cargo install \
+             sbpf-linker"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Make both upstream-toolchain recovery paths point to the published `sbpf-linker` crate.

## Fix

1. Replace the invalid Anza platform-tools checkout and `cargo install-with-gallery` instructions with `cargo install sbpf-linker`.
2. Share one recovery message between `quasar init` and `quasar build` so the two paths cannot drift.
3. Add a unit test for the exact actionable message.

## Validation

- The published `sbpf-linker` 0.1.9 crate README documents `cargo install sbpf-linker`.
- Anza platform-tools v1.52 does not define `cargo install-with-gallery`.
- A PATH-isolated `quasar init --toolchain upstream` probe returns the corrected command before creating a project.
- `cargo test -p quasar-cli --lib`: 48 passed.
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- The repository pre-push fmt and full-workspace clippy checks passed.
- `git diff --check`

## Deferred

The separate upstream nightly and build-command contract remains under audit.

Closes #404