### PR TITLE
fix(cli): scope upstream build-std to BPF

### DIFF
--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -13,10 +13,7 @@ node_modules
 .DS_Store
 ";
 
-pub(super) const CARGO_CONFIG: &str = r#"[unstable]
-build-std = ["core", "alloc"]
-
-[target.bpfel-unknown-none]
+pub(super) const CARGO_CONFIG: &str = r#"[target.bpfel-unknown-none]
 rustflags = [
 "--cfg", "feature=\"mem_unaligned\"",
 "-C", "linker=sbpf-linker",
@@ -30,7 +27,7 @@ rustflags = [
 "-C", "overflow-checks=off",
 ]
 [alias]
-build-bpf = "build --release --target bpfel-unknown-none"
+build-bpf = "build -Z build-std=core,alloc --release --target bpfel-unknown-none"
 "#;
 
 pub(super) const INSTRUCTIONS_MOD: &str = r#"mod initialize;
@@ -101,3 +98,19 @@ pub(super) const TS_TEST_TSCONFIG: &str = r#"{
   "include": ["tests/*.test.ts"]
 }
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::CARGO_CONFIG;
+
+    #[test]
+    fn upstream_build_std_is_scoped_to_the_bpf_alias() {
+        let config: toml::Value = CARGO_CONFIG.parse().expect("valid generated Cargo config");
+
+        assert!(config.get("unstable").is_none());
+        assert_eq!(
+            config["alias"]["build-bpf"].as_str(),
+            Some("build -Z build-std=core,alloc --release --target bpfel-unknown-none")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Keep upstream `build-std` configuration out of Quasar host-side commands.

## Fix

1. Remove the global generated `[unstable] build-std` table.
2. Put `-Z build-std=core,alloc` on the generated `build-bpf` alias.
3. Parse the template in a unit test and assert both sides of that boundary.

## Validation

- Before the fix, `cargo +nightly-2026-03-27 test --features idl-build` in a generated upstream project failed with duplicate `core` and `alloc` lang items.
- A fresh project generated by this branch contains no global `[unstable]` table.
- The same fresh fixture ran both host IDL tests successfully on `nightly-2026-03-27`.
- The targeted template test passed.
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- The repository pre-push fmt and full-workspace clippy checks passed.
- `git diff --check`

## Deferred

The final link remains covered by the separate sbpf-linker compatibility issues.

Closes #406