### PR TITLE
fix(cli): remove obsolete sbpf-linker flag

### DIFF
--- a/cli/src/init/templates.rs
+++ b/cli/src/init/templates.rs
@@ -21,7 +21,6 @@ rustflags = [
 "-C", "relocation-model=static",
 "-C", "link-arg=--disable-memory-builtins",
 "-C", "link-arg=--llvm-args=--bpf-stack-size=4096",
-"-C", "link-arg=--disable-expand-memcpy-in-order",
 "-C", "link-arg=--export=entrypoint",
 "-C", "target-cpu=v2",
 "-C", "overflow-checks=off",
@@ -112,5 +111,10 @@ mod tests {
             config["alias"]["build-bpf"].as_str(),
             Some("build -Z build-std=core,alloc --release --target bpfel-unknown-none")
         );
+    }
+
+    #[test]
+    fn upstream_config_uses_supported_linker_flags() {
+        assert!(!CARGO_CONFIG.contains("--disable-expand-memcpy-in-order"));
     }
 }


### PR DESCRIPTION
## Summary

Make generated upstream projects compatible with the published `sbpf-linker` 0.1.9 interface.

## Fix

1. Remove `--disable-expand-memcpy-in-order` from the generated linker arguments.
2. Add a focused template regression test that rejects the obsolete flag.

## Validation

- Before the fix, the fresh upstream fixture failed because `sbpf-linker` 0.1.9 no longer accepts the argument.
- `cargo install sbpf-linker --version 0.1.9 --locked` succeeded in an isolated install root.
- A fresh project generated by this branch completed `cargo +nightly-2026-03-27 build-bpf` with that isolated linker.
- The expected `target/bpfel-unknown-none/release` program artifact exists.
- The targeted template test passed.
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- The repository pre-push fmt and full-workspace clippy checks passed.
- `git diff --check`

## Deferred

Running the same build through `quasar build` remains covered by the separate linker-detection and nightly-selection issues.

Closes #407