### PR TITLE
fix(cli): pin upstream build nightly

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -94,11 +94,10 @@ fn run_once(debug: bool, verbose: bool, features: Option<&str>) -> CliResult {
             return Err(missing_sbpf_linker());
         }
 
-        let mut cmd = Command::new("cargo");
+        let mut cmd = upstream_build_command();
         if debug {
             cmd.env("RUSTFLAGS", "-C link-arg=--btf -C debuginfo=2");
         }
-        cmd.arg("build-bpf");
         if scoped {
             cmd.args(["--manifest-path", &manifest.to_string_lossy()]);
         }
@@ -285,9 +284,8 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
 
         // Use CARGO_ENCODED_RUSTFLAGS (0x1f-separated) which takes priority
         let encoded = all_flags.join("\x1f");
-        let mut cmd = Command::new("cargo");
+        let mut cmd = upstream_build_command();
         cmd.env("CARGO_ENCODED_RUSTFLAGS", encoded);
-        cmd.arg("build-bpf");
         if scoped {
             cmd.args(["--manifest-path", &manifest.to_string_lossy()]);
         }
@@ -355,6 +353,14 @@ pub fn profile_build() -> Result<PathBuf, crate::error::CliError> {
 
 fn run_watch(debug: bool, verbose: bool, features: Option<String>) -> ! {
     watch_loop(|| run_once(debug, verbose, features.as_deref()))
+}
+
+fn upstream_build_command() -> Command {
+    let mut command = Command::new("cargo");
+    command
+        .arg(format!("+{}", toolchain::UPSTREAM_NIGHTLY_TOOLCHAIN))
+        .arg("build-bpf");
+    command
 }
 
 fn run_build_command(cmd: &mut Command, verbose: bool) -> std::io::Result<BuildResult> {
@@ -431,7 +437,7 @@ fn size_entry_matches(line: &str, key: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_size_entry, size_entry_matches};
+    use super::{parse_size_entry, size_entry_matches, upstream_build_command};
 
     #[test]
     fn size_entry_match_is_exact_even_for_prefix_paths() {
@@ -449,5 +455,13 @@ mod tests {
 
         assert_eq!(parse_size_entry(line, key), Some(1234));
         assert!(size_entry_matches(line, key));
+    }
+
+    #[test]
+    fn upstream_build_uses_the_release_nightly() {
+        let command = upstream_build_command();
+        let args: Vec<_> = command.get_args().collect();
+
+        assert_eq!(args, ["+nightly-2026-03-27", "build-bpf"]);
     }
 }

--- a/cli/src/init/mod.rs
+++ b/cli/src/init/mod.rs
@@ -113,13 +113,16 @@ pub fn run(cmd: crate::InitCommand) -> CliResult {
     let toolchain_idx = if skip_prompts {
         toolchain_default
     } else {
-        let toolchain_items = &[
-            "solana    (cargo build-sbf)",
-            "upstream  (cargo +nightly build-bpf)",
+        let toolchain_items = [
+            "solana    (cargo build-sbf)".to_string(),
+            format!(
+                "upstream  (cargo +{} build-bpf)",
+                toolchain::UPSTREAM_NIGHTLY_TOOLCHAIN
+            ),
         ];
         Select::with_theme(&theme)
             .with_prompt("Toolchain")
-            .items(toolchain_items)
+            .items(&toolchain_items)
             .default(toolchain_default)
             .interact()?
     };

--- a/cli/src/toolchain.rs
+++ b/cli/src/toolchain.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 pub const MISSING_SBPF_LINKER_MESSAGE: &str =
     "sbpf-linker not found on PATH.\n\n  Install it from crates.io:\n    cargo install sbpf-linker";
 
+/// Nightly toolchain used to compile upstream BPF programs for v0.1.0.
+pub const UPSTREAM_NIGHTLY_TOOLCHAIN: &str = "nightly-2026-03-27";
+
 /// Check whether sbpf-linker is reachable on PATH.
 pub fn has_sbpf_linker() -> bool {
     command_is_reachable(Command::new("sbpf-linker").arg("--version"))


### PR DESCRIPTION
## Summary

Make upstream builds independent of the user default Rust toolchain.

## Fix

1. Define `nightly-2026-03-27` as the v0.1.0 upstream build toolchain.
2. Route normal and debug builds through one `cargo +nightly-2026-03-27 build-bpf` command constructor.
3. Show the exact nightly in the interactive toolchain choice.
4. Test the constructed command arguments.

## Validation

- The release Makefile pins the same `nightly-2026-03-27` toolchain.
- The command-construction test passed.
- With `RUSTUP_TOOLCHAIN=1.92.0` forcing a stable default, `quasar build --verbose` generated the IDL and then compiled the BPF program with the release nightly.
- The full CLI path completed successfully with isolated `sbpf-linker` 0.1.9 and produced the expected program artifact.
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- The repository pre-push fmt and full-workspace clippy checks passed.
- `git diff --check`

## Deferred

Clean-environment installation of the pinned nightly and `rust-src` remains in the documentation and CI issues.

Closes #409