### PR TITLE
fix(cli): pin sbpf-linker recovery version

### DIFF
--- a/cli/src/toolchain.rs
+++ b/cli/src/toolchain.rs
@@ -1,8 +1,9 @@
 use std::process::Command;
 
 /// Actionable recovery guidance shared by every upstream build entry point.
-pub const MISSING_SBPF_LINKER_MESSAGE: &str =
-    "sbpf-linker not found on PATH.\n\n  Install it from crates.io:\n    cargo install sbpf-linker";
+pub const MISSING_SBPF_LINKER_MESSAGE: &str = "sbpf-linker not found on PATH.\n\n  Install it \
+                                               from crates.io:\n    cargo install sbpf-linker \
+                                               --version 0.1.9 --locked";
 
 /// Nightly toolchain used to compile upstream BPF programs for v0.1.0.
 pub const UPSTREAM_NIGHTLY_TOOLCHAIN: &str = "nightly-2026-03-27";
@@ -65,7 +66,7 @@ mod tests {
         assert_eq!(
             MISSING_SBPF_LINKER_MESSAGE,
             "sbpf-linker not found on PATH.\n\n  Install it from crates.io:\n    cargo install \
-             sbpf-linker"
+             sbpf-linker --version 0.1.9 --locked"
         );
     }
 


### PR DESCRIPTION
## Summary

Pin every CLI linker-recovery path to the validated v0.1.0 linker.

## Fix

1. Change the shared command to `cargo install sbpf-linker --version 0.1.9 --locked`.
2. Extend the exact-message regression test to cover the version and lockfile flags.

## Validation

- The pinned command installed `sbpf-linker 0.1.9` successfully in an isolated root.
- That isolated binary completed the upstream fixture build on `nightly-2026-03-27`.
- The exact recovery-message test passed.
- `cargo clippy -p quasar-cli --all-targets -- -D warnings`
- The repository pre-push nightly-fmt and full-workspace clippy checks passed.
- `git diff --check`

## Deferred

The matching public installation-page pin is isolated in issue #413.

Closes #412