### PR TITLE
ci: rehearse packaged upstream builds

### DIFF
--- a/.github/docker/release-package-rehearsal.Dockerfile
+++ b/.github/docker/release-package-rehearsal.Dockerfile
@@ -42,17 +42,21 @@ FROM base AS rehearsal
 ARG SOLANA_VERSION=v4.1.1
 ARG SOLANA_LINUX_SHA256
 
-ENV CARGO_HOME=/home/quasar/.cargo
 ENV CARGO_TERM_COLOR=always
-ENV HOME=/home/quasar
-ENV PATH="/opt/quasar-cli/bin:/opt/solana/active_release/bin:/usr/local/cargo/bin:${PATH}"
+ENV PATH="/opt/quasar-cli/bin:/opt/sbpf-linker/bin:/opt/solana/active_release/bin:/usr/local/cargo/bin:${PATH}"
 
 COPY scripts/install-solana-tools.sh /usr/local/bin/install-solana-tools
 
 RUN HOME=/root XDG_CACHE_HOME=/root/.cache \
         install-solana-tools "${SOLANA_VERSION}" "${SOLANA_LINUX_SHA256}" /opt/solana \
     && cargo-build-sbf --version \
+    && rustup toolchain install nightly-2026-03-27 --profile minimal --component rust-src \
+    && HOME=/root CARGO_HOME=/usr/local/cargo cargo install \
+        sbpf-linker --version 0.1.9 --locked --root /opt/sbpf-linker \
     && rm -rf /root/.cache/quasar/solana
+
+ENV CARGO_HOME=/home/quasar/.cargo
+ENV HOME=/home/quasar
 
 COPY --from=packager /opt/quasar-cli /opt/quasar-cli
 COPY --from=packager /opt/quasar-release-rehearsal /opt/quasar-release-rehearsal

--- a/.github/scripts/release-package-rehearsal.sh
+++ b/.github/scripts/release-package-rehearsal.sh
@@ -86,6 +86,34 @@ verify_starter() {
     || fail "$template starter manifest changed during lint/build/test"
 }
 
+verify_upstream_starter() {
+  local name="quasar-release-upstream"
+  local project="$rehearsal_root/$name"
+  local manifest_snapshot="/tmp/$name.Cargo.toml"
+
+  cd "$rehearsal_root"
+  quasar init "$name" \
+    --yes \
+    --no-git \
+    --test-language none \
+    --template minimal \
+    --toolchain upstream
+
+  cd "$project"
+  cp Cargo.toml "$manifest_snapshot"
+  grep -Fx 'quasar-lang = "=0.1.0"' Cargo.toml >/dev/null \
+    || fail "upstream starter does not use the packaged quasar-lang version"
+  if grep -Eq 'quasar-lang = .*\b(path|git|branch)\b' Cargo.toml; then
+    fail "upstream starter contains a source override"
+  fi
+
+  RUSTUP_TOOLCHAIN=1.92.0 quasar build
+  find target/bpfel-unknown-none/release -maxdepth 1 -type f -name '*.so' -print -quit \
+    | grep -q . || fail "upstream starter did not emit a program artifact"
+  cmp "$manifest_snapshot" Cargo.toml \
+    || fail "upstream starter manifest changed during build"
+}
+
 [[ ! -e /workspace/quasar ]] || fail "source checkout is present in the runtime image"
 [[ "$(find "$package_root/archives" -type f -name '*.crate' | wc -l | tr -d ' ')" -eq 10 ]] \
   || fail "expected ten package archives"
@@ -100,9 +128,18 @@ fi
 assert_no_credentials
 fingerprint_package_sources "$source_fingerprint_before"
 
+rustc +nightly-2026-03-27 --version
+rustup component list --toolchain nightly-2026-03-27 \
+  | grep -Fx 'rust-src (installed)' \
+  || fail "release nightly rust-src component is not installed"
+linker_version="$(sbpf-linker --version 2>&1 || true)"
+grep -F 'sbpf-linker 0.1.9' <<<"$linker_version" >/dev/null \
+  || fail "sbpf-linker 0.1.9 is not installed"
+
 rm -rf "$rehearsal_root"/*
 verify_starter minimal
 verify_starter full
+verify_upstream_starter
 
 cd "$rehearsal_root/quasar-release-minimal"
 readonly manifest_snapshot="/tmp/quasar-release-minimal.Cargo.toml"


### PR DESCRIPTION
## Summary

Make the release-package rehearsal prove that a packaged Quasar CLI can build a fresh upstream starter in the same isolated environment used for the Solana starter checks.

## Fix

1. Install the release-pinned `nightly-2026-03-27` toolchain with `rust-src` and `sbpf-linker 0.1.9` in the rehearsal image.
2. Generate a minimal upstream project with the packaged CLI, keep stable Rust as the caller default, run `quasar build`, and require a real `.so` artifact.
3. Verify the upstream manifest remains pinned to packaged `quasar-lang = "=0.1.0"` with no source override or build-time mutation.
4. Assert the exact nightly, `rust-src`, and linker versions before any starter is exercised.

## Validation

- `docker build --platform linux/amd64 ...`
- `docker run --rm --platform linux/amd64 quasar-release-package-rehearsal:issue-415`
  - minimal Solana starter: lint, build, and test passed
  - full Solana starter: lint, build, and test passed
  - upstream starter: packaged `quasar build` emitted a 1.7 KB program artifact
  - profiler, clean, source immutability, empty cache, and credential checks passed
- `bash -n .github/scripts/release-package-rehearsal.sh`
- `shellcheck .github/scripts/release-package-rehearsal.sh`
- `python3 scripts/check-release-dependencies.py`
- `python3 scripts/tests/test_release_dependency_policy.py` (11 passed)
- `cargo +nightly-2026-03-27 fmt --all -- --check`
- pre-push fmt and clippy checks

## Deferred

Publishing crates or images remains part of the coordinated v0.1.0 release and is not performed by this PR.

Closes #415
Parent: #252