### PR TITLE
fix(cli): scope generated Rust test filters

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -176,12 +176,21 @@ fn test_command_args(
         let mut separator = args.iter().position(|arg| arg == "--");
 
         if let Some(pattern) = filter {
-            match separator {
-                Some(index) => {
-                    args.insert(index, pattern.to_string());
-                    separator = Some(index + 1);
+            let command_arg_end = separator.unwrap_or(args.len());
+            if let Some(index) = args[..command_arg_end]
+                .iter()
+                .position(|arg| arg == "tests::")
+            {
+                let pattern = pattern.strip_prefix("tests::").unwrap_or(pattern);
+                args[index].push_str(pattern);
+            } else {
+                match separator {
+                    Some(index) => {
+                        args.insert(index, pattern.to_string());
+                        separator = Some(index + 1);
+                    }
+                    None => args.push(pattern.to_string()),
                 }
-                None => args.push(pattern.to_string()),
             }
         }
 
@@ -214,14 +223,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cargo_filter_is_inserted_before_existing_separator() {
+    fn cargo_filter_is_combined_with_generated_scope() {
         let cmd = CommandSpec::new("cargo", ["test", "tests::", "--", "--nocapture"]);
         let args = test_command_args(&cmd, Some("my_test"), false);
 
-        assert_eq!(
-            args,
-            vec!["test", "tests::", "my_test", "--", "--nocapture"]
-        );
+        assert_eq!(args, vec!["test", "tests::my_test", "--", "--nocapture"]);
+    }
+
+    #[test]
+    fn fully_scoped_cargo_filter_is_not_duplicated() {
+        let cmd = CommandSpec::new("cargo", ["test", "tests::"]);
+        let args = test_command_args(&cmd, Some("tests::my_test"), false);
+
+        assert_eq!(args, vec!["test", "tests::my_test"]);
+    }
+
+    #[test]
+    fn cargo_filter_without_generated_scope_is_appended() {
+        let cmd = CommandSpec::new("cargo", ["test", "--lib"]);
+        let args = test_command_args(&cmd, Some("my_test"), false);
+
+        assert_eq!(args, vec!["test", "--lib", "my_test"]);
     }
 
     #[test]
@@ -244,8 +266,7 @@ mod tests {
             args,
             vec![
                 "test",
-                "tests::",
-                "my_test",
+                "tests::my_test",
                 "--",
                 "--show-output",
                 "--nocapture"


### PR DESCRIPTION
## Summary

Make the documented Rust test filter work in freshly generated Quasar projects.

## Fix

1. Detect the generated Cargo test scope `tests::`.
2. Combine it with the requested filter as one Cargo positional argument, for example `tests::test_init`.
3. Preserve fully scoped filters, unfiltered commands, commands without the generated scope, and existing test-binary argument ordering.

## Validation

- `cargo +nightly-2026-03-27 fmt --all -- --check`
- `cargo test -p quasar-cli --lib` (55 passed)
- `cargo clippy -p quasar-cli --all-targets --all-features -- -D warnings`
- Fresh generated Rust starter using packaged v0.1.0 crate sources:
  - `quasar build` emitted a 2.5 KB SBF artifact
  - `quasar test --no-build --filter test_init --show-output --verbose`
  - selected and passed only `tests::test_initialize`
- pre-push fmt and workspace clippy checks

## Deferred

The quickstart discriminator-lock step is tracked by #426. Cross-repository quickstart regression coverage remains tracked by #338.

Closes #425
Parent: #252