### PR TITLE
ci: rehearse packaged quickstart workflow

### DIFF
--- a/.github/scripts/release-package-rehearsal.sh
+++ b/.github/scripts/release-package-rehearsal.sh
@@ -86,6 +86,29 @@ verify_starter() {
     || fail "$template starter manifest changed during lint/build/test"
 }
 
+verify_quickstart() {
+  local project="$rehearsal_root/quasar-release-minimal"
+  local manifest_snapshot="/tmp/quasar-release-minimal.Cargo.toml"
+
+  cd "$project"
+  quasar add -i transfer -s vault -e access
+  test -f src/instructions/transfer.rs \
+    || fail "quickstart did not create the transfer instruction"
+  test -f src/state.rs || fail "quickstart did not create the vault state"
+  test -f src/errors.rs || fail "quickstart did not create the access error"
+
+  quasar lint --update-lock
+  test -s quasar.lock.json || fail "quickstart did not write the discriminator lock"
+  quasar lint --strict --no-diff
+
+  quasar build
+  quasar test
+  quasar test -f test_init
+  quasar test --features debug
+  cmp "$manifest_snapshot" Cargo.toml \
+    || fail "quickstart changed the starter manifest"
+}
+
 verify_upstream_starter() {
   local name="quasar-release-upstream"
   local project="$rehearsal_root/$name"
@@ -138,6 +161,7 @@ grep -F 'sbpf-linker 0.1.9' <<<"$linker_version" >/dev/null \
 
 rm -rf "$rehearsal_root"/*
 verify_starter minimal
+verify_quickstart
 verify_starter full
 verify_upstream_starter
 


### PR DESCRIPTION
## Summary

Rehearse the public v0.1.0 quickstart against the packaged CLI before release.

## Fix

1. Run the combined `quasar add` command against a fresh packaged minimal starter and verify the generated instruction, state, and error files.
2. Create and validate the discriminator lock with strict no-diff linting.
3. Run the documented build, unfiltered test, filtered test, and debug-feature test commands.
4. Verify the starter manifest and packaged sources remain unchanged.

## Validation

- `bash -n .github/scripts/release-package-rehearsal.sh`
- `shellcheck .github/scripts/release-package-rehearsal.sh`
- Release policy tests: 11 passed
- Repository pre-push formatting and clippy checks
- Linux/amd64 rehearsal image build and full container run
- Fresh quickstart SBF artifact: 2.8 KB
- Minimal, full, and upstream starter rehearsals
- Profile, clean, source-integrity, cache, and credential checks

## Deferred

- Devnet deployment stays outside this gate because it requires credentials, funds, and an external cluster.
- Documentation drift enforcement is tracked separately in #428.

Closes #338