### PR TITLE
fix(cli): print effective test commands

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -139,30 +139,19 @@ fn run_test_cmd(
     show_output: bool,
     verbose: bool,
 ) -> CliResult {
-    let mut cmd = Command::new(&test_cmd.program);
-    cmd.args(test_command_args(test_cmd, filter, show_output));
+    let command = effective_test_command(test_cmd, filter, show_output);
+    run_command(&command, verbose)
+}
 
-    eprintln!(
-        "  {}",
-        style::step(&format!("Running {}...", test_cmd.display()))
-    );
-    if verbose {
-        eprintln!("  {}", style::dim(&format!("$ {}", test_cmd.display())));
-    }
-
-    let status = cmd.status();
-
-    match status {
-        Ok(s) if s.success() => Ok(()),
-        Ok(s) => Err(CliError::process_failure(
-            format!("{} failed", test_cmd.display()),
-            s.code().unwrap_or(1),
-        )),
-        Err(e) => Err(CliError::message(format!(
-            "failed to run {}: {e}",
-            test_cmd.display()
-        ))),
-    }
+fn effective_test_command(
+    test_cmd: &CommandSpec,
+    filter: Option<&str>,
+    show_output: bool,
+) -> CommandSpec {
+    CommandSpec::new(
+        test_cmd.program.clone(),
+        test_command_args(test_cmd, filter, show_output),
+    )
 }
 
 fn test_command_args(
@@ -275,11 +264,30 @@ mod tests {
     }
 
     #[test]
+    fn effective_cargo_test_command_includes_runtime_arguments() {
+        let cmd = CommandSpec::new("cargo", ["test", "tests::", "--", "--nocapture"]);
+        let command = effective_test_command(&cmd, Some("my_test"), true);
+
+        assert_eq!(
+            command.display(),
+            "cargo test tests::my_test -- --show-output --nocapture"
+        );
+    }
+
+    #[test]
     fn non_cargo_filter_uses_t_flag() {
         let cmd = CommandSpec::new("npx", ["vitest", "run"]);
         let args = test_command_args(&cmd, Some("my_test"), true);
 
         assert_eq!(args, vec!["vitest", "run", "-t", "my_test"]);
+    }
+
+    #[test]
+    fn effective_non_cargo_test_command_includes_runtime_filter() {
+        let cmd = CommandSpec::new("npx", ["vitest", "run"]);
+        let command = effective_test_command(&cmd, Some("my_test"), true);
+
+        assert_eq!(command.display(), "npx vitest run -t my_test");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make test diagnostics show the exact command Quasar executes after applying runtime filters and output flags.

## Fix

1. Resolve the effective test command once from the configured command, filter, and `--show-output` flag.
2. Reuse the existing command runner for execution, progress output, verbose output, spawn errors, and process failures.
3. Cover the rendered Cargo and Vitest commands.

## Validation

- `cargo test -p quasar-cli --lib`: 57 passed
- `cargo +nightly-2026-03-27 clippy -p quasar-cli --all-targets -- -D warnings`
- `make format`
- Repository pre-push formatting and workspace clippy checks
- Fresh generated starter: `quasar test --no-build --filter test_init --show-output --verbose` printed `cargo test tests::test_init -- --show-output` and passed exactly one matching test

## Deferred

- Test-filter semantics are handled separately by #425.
- Quickstart documentation drift is tracked in #428.

Closes #430