### PR TITLE
fix(lang): validate CPI return data before decode

### DIFF
--- a/lang/src/cpi/mod.rs
+++ b/lang/src/cpi/mod.rs
@@ -205,6 +205,10 @@ impl CpiReturn {
         }
         // SAFETY: The previous copy initialized every byte of `T::Zc`.
         let zc = unsafe { zc.assume_init() };
+        // Return data is untrusted: validate before `from_zc`, whose
+        // contract assumes a validated companion (e.g. enum `from_zc` calls
+        // `unreachable_unchecked` on undeclared discriminants).
+        T::validate_zc(&zc)?;
         Ok(T::from_zc(&zc))
     }
 }
@@ -634,6 +638,58 @@ mod tests {
         let zc = <ReturnPayload as InstructionArg>::to_zc(&payload);
         let ret = return_with_data([2u8; 32], zc_bytes::<ReturnPayload>(&zc));
         assert_eq!(ret.decode::<ReturnPayload>().unwrap(), payload);
+    }
+
+    #[test]
+    fn decode_rejects_invalid_bool() {
+        let ret = return_with_data([1u8; 32], &[2u8]);
+        assert_eq!(
+            ret.decode::<bool>(),
+            Err(ProgramError::InvalidInstructionData)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_invalid_option_tag() {
+        let mut bytes = std::vec![0u8; core::mem::size_of::<<Option<u64> as InstructionArg>::Zc>()];
+        bytes[0] = 2;
+        let ret = return_with_data([1u8; 32], &bytes);
+        assert_eq!(
+            ret.decode::<Option<u64>>(),
+            Err(ProgramError::InvalidInstructionData)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_invalid_nested_struct_field() {
+        let payload = ReturnPayload {
+            amount: 55,
+            flag: true,
+        };
+        let zc = <ReturnPayload as InstructionArg>::to_zc(&payload);
+        let mut bytes = zc_bytes::<ReturnPayload>(&zc).to_vec();
+        *bytes.last_mut().unwrap() = 2;
+        let ret = return_with_data([1u8; 32], &bytes);
+        assert_eq!(
+            ret.decode::<ReturnPayload>(),
+            Err(ProgramError::InvalidInstructionData)
+        );
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, QuasarSerialize)]
+    #[repr(u8)]
+    enum Status {
+        Active = 1,
+        Closed = 2,
+    }
+
+    #[test]
+    fn decode_rejects_undeclared_enum_discriminant() {
+        let ret = return_with_data([1u8; 32], &[9u8]);
+        assert_eq!(
+            ret.decode::<Status>(),
+            Err(ProgramError::InvalidInstructionData)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Treat CPI return bytes as untrusted before converting their zero-copy representation into a Rust value. This ports the fix from #245 onto the current v0.1.0 release stack and retains the original author.

## Fix

1. Keep the existing exact-size copy into `T::Zc`.
2. Call `T::validate_zc` before `T::from_zc`, whose contract assumes that constrained representations have already been checked.
3. Pin the boundary with invalid bool, option, nested struct, and enum cases, plus valid primitive and derived-struct round trips.

Without this validation, an undeclared derived-enum discriminant can reach `unreachable_unchecked`, making malformed CPI return data undefined behavior.

## Validation

- `cargo test -p quasar-lang --all-features`
  - 58 library tests
  - all compile-fail and compile-pass fixtures
  - 105 host Miri-harness tests
  - all remaining quasar-lang integration tests
- strict-provenance Miri on all six CPI decode tests
- Kani harness `cpi_return_decode_copy_in_bounds`: 2/2 properties passed
- strict Clippy for `quasar-lang`
- repository pre-push fmt and full-workspace Clippy checks
- `git diff --check`

## Deferred

No wire format or valid-value behavior changes in this PR.

Closes #238
Parent: #252
