### PR TITLE
fix(lang): zero reserved migration padding

### DIFF
--- a/lang/src/accounts/migration.rs
+++ b/lang/src/accounts/migration.rs
@@ -137,10 +137,12 @@ where
     #[inline(always)]
     fn write_target(&mut self, new_data: &To::Target) {
         let disc = <To as crate::traits::Discriminator>::DISCRIMINATOR;
+        let written_len = disc.len() + core::mem::size_of::<To::Target>();
+        let space = <To as crate::traits::Space>::SPACE;
         let data = self.__view.data_mut_ptr();
         // SAFETY: `migrate` reallocates to `To::SPACE` before calling this, and
         // `_TARGET_FITS_SPACE` proves `To::SPACE` covers the discriminator plus
-        // `To::Target`.
+        // `To::Target`, so `written_len <= space == self.__view.data_len()`.
         unsafe {
             core::ptr::copy_nonoverlapping(disc.as_ptr(), data, disc.len());
             core::ptr::copy_nonoverlapping(
@@ -148,6 +150,13 @@ where
                 data.add(disc.len()),
                 core::mem::size_of::<To::Target>(),
             );
+            // `To::SPACE` may reserve bytes beyond the discriminator + target
+            // (e.g. for future fields). Those bytes are never written above,
+            // so without this they'd retain stale `From` data left over from
+            // before the realloc when `To::SPACE <= From::SPACE`.
+            if space > written_len {
+                core::ptr::write_bytes(data.add(written_len), 0, space - written_len);
+            }
         }
     }
 

--- a/tests/programs/test-migrate/src/instructions/migrate_padded.rs
+++ b/tests/programs/test-migrate/src/instructions/migrate_padded.rs
@@ -1,0 +1,27 @@
+use {crate::state::*, quasar_derive::Accounts, quasar_lang::prelude::*};
+
+/// Regression coverage for issue #239: migrates a hand-rolled account whose
+/// `To::SPACE` reserves padding beyond `disc_len + size_of::<To::Target>()`,
+/// and whose `To::SPACE` is smaller than `From::SPACE`. Exercises the exact
+/// shrink-with-padding path `write_target` previously left dirty.
+#[derive(Accounts)]
+pub struct MigratePadded {
+    #[account(mut)]
+    pub payer: Signer,
+    pub system_program: Program<SystemProgram>,
+    pub config: Migration<PaddedSourceV1, PaddedTarget>,
+}
+
+impl MigratePadded {
+    #[inline(always)]
+    pub fn handler(&mut self, authority: Address, value: u64) -> Result<(), ProgramError> {
+        self.config.migrate(
+            &self.payer,
+            PaddedTargetData {
+                authority,
+                value: PodU64::from(value),
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/tests/programs/test-migrate/src/instructions/mod.rs
+++ b/tests/programs/test-migrate/src/instructions/mod.rs
@@ -1,2 +1,3 @@
 mod migrate_config;
-pub use migrate_config::*;
+mod migrate_padded;
+pub use {migrate_config::*, migrate_padded::*};

--- a/tests/programs/test-migrate/src/lib.rs
+++ b/tests/programs/test-migrate/src/lib.rs
@@ -17,4 +17,13 @@ mod quasar_test_migrate {
     pub fn migrate_config(ctx: Ctx<MigrateConfig>) -> Result<(), ProgramError> {
         ctx.accounts.handler()
     }
+
+    #[instruction(discriminator = 1)]
+    pub fn migrate_padded(
+        ctx: Ctx<MigratePadded>,
+        authority: Address,
+        value: u64,
+    ) -> Result<(), ProgramError> {
+        ctx.accounts.handler(authority, value)
+    }
 }

--- a/tests/programs/test-migrate/src/state.rs
+++ b/tests/programs/test-migrate/src/state.rs
@@ -12,3 +12,118 @@ pub struct ConfigV2 {
     pub value: PodU64,
     pub extra: PodU32,
 }
+
+/// Hand-rolled (non-macro) migration source used to regression-test issue
+/// #239 with source account buffers on both sides of [`PaddedTarget::SPACE`].
+#[repr(transparent)]
+pub struct PaddedSourceV1 {
+    __view: AccountView,
+}
+
+unsafe impl StaticView for PaddedSourceV1 {}
+
+impl AsAccountView for PaddedSourceV1 {
+    #[inline(always)]
+    fn to_account_view(&self) -> &AccountView {
+        &self.__view
+    }
+}
+
+impl Owner for PaddedSourceV1 {
+    const OWNER: Address = crate::ID;
+}
+
+impl Discriminator for PaddedSourceV1 {
+    const DISCRIMINATOR: &'static [u8] = &[9];
+}
+
+impl AccountLoad for PaddedSourceV1 {
+    #[inline(always)]
+    fn check(view: &AccountView) -> Result<(), ProgramError> {
+        // SAFETY: called only during account parsing, before any mutable
+        // borrow of this view is taken.
+        let data = unsafe { view.borrow_unchecked() };
+        if !data.starts_with(<Self as Discriminator>::DISCRIMINATOR) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        Ok(())
+    }
+}
+
+/// Raw `#[repr(C)]` fixed portion written by [`PaddedTarget::migrate`].
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PaddedTargetData {
+    pub authority: Address,
+    pub value: PodU64,
+}
+
+/// Migration target whose `SPACE` reserves bytes beyond the discriminator
+/// plus [`PaddedTargetData`] (a manual analogue of an account with padding
+/// reserved for future fields). Regression coverage for issue #239: those
+/// reserved bytes must come back zeroed, not carry over stale `From` data.
+#[repr(transparent)]
+pub struct PaddedTarget {
+    __view: AccountView,
+}
+
+unsafe impl StaticView for PaddedTarget {}
+
+impl AsAccountView for PaddedTarget {
+    #[inline(always)]
+    fn to_account_view(&self) -> &AccountView {
+        &self.__view
+    }
+}
+
+impl Owner for PaddedTarget {
+    const OWNER: Address = crate::ID;
+}
+
+impl Discriminator for PaddedTarget {
+    const DISCRIMINATOR: &'static [u8] = &[3];
+}
+
+impl Space for PaddedTarget {
+    const SPACE: usize =
+        1 + core::mem::size_of::<PaddedTargetData>() + PaddedTarget::RESERVED_PADDING;
+}
+
+impl PaddedTarget {
+    pub const RESERVED_PADDING: usize = 20;
+}
+
+impl Deref for PaddedTarget {
+    type Target = PaddedTargetData;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `AccountLoad::check` validates the discriminator and length
+        // before this wrapper is constructed.
+        unsafe { &*(self.__view.data_ptr().add(1) as *const PaddedTargetData) }
+    }
+}
+
+impl DerefMut for PaddedTarget {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: same as `Deref::deref`, with exclusive access to the view.
+        unsafe { &mut *(self.__view.data_mut_ptr().add(1) as *mut PaddedTargetData) }
+    }
+}
+
+impl AccountLoad for PaddedTarget {
+    #[inline(always)]
+    fn check(view: &AccountView) -> Result<(), ProgramError> {
+        // SAFETY: called only during account parsing/revalidation, never
+        // while another borrow of this view is live.
+        let data = unsafe { view.borrow_unchecked() };
+        if !data.starts_with(<Self as Discriminator>::DISCRIMINATOR) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        if data.len() < <Self as Space>::SPACE {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        Ok(())
+    }
+}

--- a/tests/suite/src/test_migrate.rs
+++ b/tests/suite/src/test_migrate.rs
@@ -90,6 +90,100 @@ fn migrate_v1_to_v2() {
     );
 }
 
+const STALE_SENTINEL: u8 = 0xAB;
+
+/// PaddedTarget: disc=3 (1) + authority (32) + value (8) = 41 bytes of real
+/// data, but `Space::SPACE` reserves 20 extra padding bytes -> 61 bytes total.
+const PADDED_TARGET_WRITTEN_LEN: usize = 41;
+const PADDED_TARGET_SIZE: usize = 61;
+
+fn padded_source_account(address: Pubkey, source_size: usize) -> quasar_svm::Account {
+    assert!(source_size >= PADDED_TARGET_WRITTEN_LEN);
+    let mut data = vec![STALE_SENTINEL; source_size];
+    data[0] = 9; // discriminator
+    raw_account(address, 1_000_000, data, quasar_test_migrate::ID)
+}
+
+fn assert_migration_zeroes_padding(source_size: usize) {
+    let mut svm = svm_migrate();
+    let payer = Pubkey::new_unique();
+    let config = Pubkey::new_unique();
+    let new_authority = Pubkey::new_unique();
+
+    let ix: Instruction = MigratePaddedInstruction {
+        payer,
+        system_program: quasar_svm::system_program::ID,
+        config,
+        authority: new_authority,
+        value: 777,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            rich_signer_account(payer),
+            padded_source_account(config, source_size),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "migrate padded target failed: {:?}\nlogs: {:?}",
+        result.raw_result,
+        result.logs
+    );
+
+    let migrated = result.account(&config).expect("config account exists");
+    assert_eq!(
+        migrated.data.len(),
+        PADDED_TARGET_SIZE,
+        "account resized to To::SPACE"
+    );
+    assert_eq!(
+        migrated.data[0], 3,
+        "discriminator updated to padded target"
+    );
+    assert_eq!(
+        &migrated.data[1..33],
+        new_authority.as_ref(),
+        "authority written"
+    );
+    assert_eq!(
+        u64::from_le_bytes(migrated.data[33..41].try_into().unwrap()),
+        777,
+        "value written"
+    );
+
+    // Issue #239: the reserved padding beyond disc + Target must be zeroed,
+    // not left holding stale bytes from the pre-migration PaddedSourceV1
+    // account.
+    let padding = &migrated.data[PADDED_TARGET_WRITTEN_LEN..PADDED_TARGET_SIZE];
+    assert!(
+        padding.iter().all(|&b| b == 0),
+        "padding beyond written target bytes must be zeroed, got {:?}",
+        padding
+    );
+    assert!(
+        !padding.contains(&STALE_SENTINEL),
+        "padding must not retain stale source data"
+    );
+}
+
+#[test]
+fn migrate_zeroes_padding_when_growing() {
+    assert_migration_zeroes_padding(PADDED_TARGET_SIZE - 10);
+}
+
+#[test]
+fn migrate_zeroes_padding_without_resizing() {
+    assert_migration_zeroes_padding(PADDED_TARGET_SIZE);
+}
+
+#[test]
+fn migrate_zeroes_padding_when_shrinking() {
+    assert_migration_zeroes_padding(PADDED_TARGET_SIZE + 20);
+}
+
 #[test]
 fn migrate_wrong_authority_fails() {
     let mut svm = svm_migrate();


### PR DESCRIPTION
## Summary

Clear reserved bytes in a migration target so stale state from the source account cannot survive the schema transition. This ports the fix from #253 onto the current v0.1.0 release stack and retains the original author.

## Fix

1. Compute the exact bytes written by the target discriminator and `To::Target`.
2. Zero the remaining range through `To::SPACE` after writing the target.
3. Exercise a hand-written target that reserves 20 bytes beyond its typed payload.
4. Prove the same boundary when migration grows the account, keeps its size unchanged, and shrinks it.

The fix is unconditional because stale bytes can remain whenever the old account overlaps the target's reserved range, regardless of the overall resize direction.

## Validation

- exact platform-tools v1.52 SBF build of `quasar-test-migrate`
- QuasarSVM migration suite: 5/5 passed
  - ordinary V1 to V2 migration
  - reserved padding while growing
  - reserved padding without resizing
  - reserved padding while shrinking
  - failed authority validation
- strict Clippy for `quasar-lang`, `quasar-test-migrate`, and `quasar-test-suite`
- repository pre-push fmt and full-workspace Clippy checks
- `git diff --check`

## Deferred

No account schema, discriminator, rent, or resize policy changes in this PR.

Closes #239
Parent: #252
