### PR TITLE
feat(test): #[quasar_test] on-chain unit tests with self-deriving clients

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,8 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Publish quasar-test
-        run: scripts/publish-crate.sh quasar-test "$QUASAR_VERSION"
+      - name: Publish quasar-test-derive
+        run: scripts/publish-crate.sh quasar-test-derive "$QUASAR_VERSION"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -138,7 +138,7 @@ jobs:
           scripts/wait-for-crate.sh quasar-schema "$QUASAR_VERSION"
           scripts/wait-for-crate.sh quasar-idl-schema "$QUASAR_VERSION"
           scripts/wait-for-crate.sh quasar-profile "$QUASAR_VERSION"
-          scripts/wait-for-crate.sh quasar-test "$QUASAR_VERSION"
+          scripts/wait-for-crate.sh quasar-test-derive "$QUASAR_VERSION"
           scripts/wait-for-crate.sh solana-compiler-builtins "$QUASAR_VERSION"
 
       # Tier 1: proc macros and IDL generator.
@@ -172,6 +172,11 @@ jobs:
         run: scripts/wait-for-crate.sh quasar-lang "$QUASAR_VERSION"
 
       # Tier 3: runtime integrations.
+      - name: Publish quasar-test
+        run: scripts/publish-crate.sh quasar-test "$QUASAR_VERSION"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Publish quasar-spl
         run: scripts/publish-crate.sh quasar-spl "$QUASAR_VERSION"
         env:
@@ -185,6 +190,7 @@ jobs:
       - name: Wait for final tier
         run: |
           scripts/wait-for-crate.sh quasar-cli "$QUASAR_VERSION"
+          scripts/wait-for-crate.sh quasar-test "$QUASAR_VERSION"
           scripts/wait-for-crate.sh quasar-spl "$QUASAR_VERSION"
           scripts/wait-for-crate.sh quasar-metadata "$QUASAR_VERSION"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,12 +2081,9 @@ dependencies = [
 name = "quasar-escrow"
 version = "0.1.0"
 dependencies = [
- "quasar-escrow-client",
  "quasar-lang",
  "quasar-spl",
- "quasar-svm 0.1.0 (git+https://github.com/blueshift-gg/quasar-svm)",
- "spl-token-interface",
- "wincode 0.4.9",
+ "quasar-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,8 +2292,19 @@ dependencies = [
 name = "quasar-test"
 version = "0.1.0"
 dependencies = [
+ "quasar-lang",
  "quasar-svm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasar-test-derive",
  "spl-token",
+]
+
+[[package]]
+name = "quasar-test-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2342,6 +2353,7 @@ version = "0.1.0"
 dependencies = [
  "quasar-derive",
  "quasar-lang",
+ "quasar-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["lang", "derive", "spl", "metadata", "idl", "idl/schema", "schema", "profile", "testing", "solana-compiler-builtins", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli"]
+members = ["lang", "derive", "spl", "metadata", "idl", "idl/schema", "schema", "profile", "testing", "testing/derive", "solana-compiler-builtins", "examples/*", "examples/*/client", "tests/programs/*", "tests/suite", "cli"]
 exclude = []
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ SBF_ALL := $(SBF_EXAMPLES) $(SBF_TEST_PROGRAMS)
 
 # Public crates in dependency order. Keep this list aligned with the release
 # workflow; `package-check` proves the complete publication graph packages.
-PUBLISH_PACKAGES := quasar-schema quasar-idl-schema quasar-profile quasar-test \
-	solana-compiler-builtins quasar-derive quasar-idl quasar-lang \
-	quasar-spl quasar-metadata quasar-cli
+PUBLISH_PACKAGES := quasar-schema quasar-idl-schema quasar-profile \
+	quasar-test-derive solana-compiler-builtins quasar-derive quasar-idl \
+	quasar-lang quasar-test quasar-spl quasar-metadata quasar-cli
 
 # Publishable crates whose ordinary host tests can run without the generated
 # client toolchains. The CLI smoke target is delegated below because it needs
@@ -333,7 +333,7 @@ check-license-policy:
 
 check-package-metadata:
 	@metadata="$$(cargo metadata --locked --no-deps --format-version 1)"; \
-	allowed_categories='["api-bindings","command-line-utilities","data-structures","development-tools","development-tools::procedural-macro-helpers","development-tools::profiling","embedded","no-std","rust-patterns"]'; \
+	allowed_categories='["api-bindings","command-line-utilities","data-structures","development-tools","development-tools::procedural-macro-helpers","development-tools::profiling","development-tools::testing","embedded","no-std","rust-patterns"]'; \
 	errors="$$(jq -r \
 	  --arg homepage 'https://quasar-lang.com' \
 	  --arg repository 'https://github.com/blueshift-gg/quasar' \

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ and their clients are not published.
 | `quasar-schema` | `schema/` | Shared schema types for Quasar interfaces |
 | `quasar-spl` | `spl/` | SPL Token program CPI and zero-copy account types for the Quasar Solana framework |
 | `quasar-test` | `testing/` | Project-aware QuasarSVM testing utilities for Quasar programs |
+| `quasar-test-derive` | `testing/derive/` | Attribute macros for quasar-test |
 | `solana-compiler-builtins` | `solana-compiler-builtins/` | Compiler runtime builtins required by Quasar SBF programs |
 <!-- published-crate-inventory:end -->
 

--- a/api-baselines/v0.1.0/profiles.tsv
+++ b/api-baselines/v0.1.0/profiles.tsv
@@ -3,6 +3,7 @@ quasar-schema	default	quasar-schema.txt
 quasar-idl-schema	default	quasar-idl-schema.txt
 quasar-profile	default	quasar-profile.txt
 quasar-test	default	quasar-test.txt
+quasar-test-derive	proc-macro	quasar-test-derive.txt
 solana-compiler-builtins	default	solana-compiler-builtins.txt
 quasar-derive	proc-macro	quasar-derive.txt
 quasar-idl	default	quasar-idl.txt

--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -1526,7 +1526,7 @@ impl core::marker::UnsafeUnpin for quasar_lang::idl_build::TypeFragment
 impl core::panic::unwind_safe::RefUnwindSafe for quasar_lang::idl_build::TypeFragment
 impl core::panic::unwind_safe::UnwindSafe for quasar_lang::idl_build::TypeFragment
 pub fn quasar_lang::idl_build::address_to_base58(&solana_address::Address) -> alloc::string::String
-pub fn quasar_lang::idl_build::behavior_resolver(core::option::Option<quasar_lang::account_behavior::BehaviorIdlResolver>, &[(&str, &str)]) -> core::option::Option<quasar_idl_schema::account::IdlResolver>
+pub fn quasar_lang::idl_build::behavior_resolver(core::option::Option<quasar_lang::account_behavior::BehaviorIdlResolver>, &[(&str, &str)], &[&str]) -> core::option::Option<quasar_idl_schema::account::IdlResolver>
 pub fn quasar_lang::idl_build::build_idl(&str, &str, &str, &str) -> quasar_idl_schema::root::Idl
 pub fn quasar_lang::idl_build::one_behavior_resolver<const N: usize>(&str, [core::option::Option<quasar_idl_schema::account::IdlResolver>; N]) -> core::option::Option<quasar_idl_schema::account::IdlResolver>
 pub fn quasar_lang::idl_build::s(&str) -> alloc::string::String

--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -1953,6 +1953,7 @@ pub trait quasar_lang::prelude::internal::Discriminator
 pub const quasar_lang::prelude::internal::Discriminator::BUMP_OFFSET: core::option::Option<usize>
 pub const quasar_lang::prelude::internal::Discriminator::DISCRIMINATOR: &'static [u8]
 pub trait quasar_lang::prelude::internal::HasSeeds
+pub type quasar_lang::prelude::internal::HasSeeds::WithBump<'seed>
 pub const quasar_lang::prelude::internal::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::prelude::internal::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::prelude::internal::HasSeeds::SEED_PREFIX: &'static [u8]
@@ -3089,6 +3090,7 @@ pub const quasar_lang::prelude::Event::DISCRIMINATOR: &'static [u8]
 pub fn quasar_lang::prelude::Event::emit(&self, impl core::ops::function::FnOnce(&[u8]) -> core::result::Result<(), solana_program_error::ProgramError>) -> core::result::Result<(), solana_program_error::ProgramError>
 pub fn quasar_lang::prelude::Event::write_data(&self, &mut [u8])
 pub trait quasar_lang::prelude::HasSeeds
+pub type quasar_lang::prelude::HasSeeds::WithBump<'seed>
 pub const quasar_lang::prelude::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::prelude::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::prelude::HasSeeds::SEED_PREFIX: &'static [u8]
@@ -3357,6 +3359,7 @@ pub const quasar_lang::traits::Event::DISCRIMINATOR: &'static [u8]
 pub fn quasar_lang::traits::Event::emit(&self, impl core::ops::function::FnOnce(&[u8]) -> core::result::Result<(), solana_program_error::ProgramError>) -> core::result::Result<(), solana_program_error::ProgramError>
 pub fn quasar_lang::traits::Event::write_data(&self, &mut [u8])
 pub trait quasar_lang::traits::HasSeeds
+pub type quasar_lang::traits::HasSeeds::WithBump<'seed>
 pub const quasar_lang::traits::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::traits::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::traits::HasSeeds::SEED_PREFIX: &'static [u8]

--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -3386,6 +3386,8 @@ pub fn quasar_lang::accounts::AccountsArray<T, N>::parse(&'input mut [solana_acc
 pub fn quasar_lang::accounts::AccountsArray<T, N>::parse_with_instruction_data(&'input mut [solana_account_view::AccountView], &[u8], &solana_address::Address) -> core::result::Result<(Self, Self::Bumps), solana_program_error::ProgramError>
 pub trait quasar_lang::traits::ProgramInterface
 pub fn quasar_lang::traits::ProgramInterface::matches(&solana_address::Address) -> bool
+pub trait quasar_lang::traits::SeedSlices
+pub fn quasar_lang::traits::SeedSlices::with_slices<R>(&self, impl core::ops::function::FnOnce(&[&[u8]]) -> R) -> R
 pub trait quasar_lang::traits::Space
 pub const quasar_lang::traits::Space::SPACE: usize
 impl<T: quasar_lang::traits::Space> quasar_lang::traits::Space for quasar_lang::accounts::Account<T>

--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -3390,6 +3390,8 @@ pub fn quasar_lang::accounts::AccountsArray<T, N>::parse(&'input mut [solana_acc
 pub fn quasar_lang::accounts::AccountsArray<T, N>::parse_with_instruction_data(&'input mut [solana_account_view::AccountView], &[u8], &solana_address::Address) -> core::result::Result<(Self, Self::Bumps), solana_program_error::ProgramError>
 pub trait quasar_lang::traits::ProgramInterface
 pub fn quasar_lang::traits::ProgramInterface::matches(&solana_address::Address) -> bool
+pub trait quasar_lang::traits::SeedParam<const INDEX: usize>
+pub type quasar_lang::traits::SeedParam::Ty
 pub trait quasar_lang::traits::SeedSlices
 pub fn quasar_lang::traits::SeedSlices::with_slices<R>(&self, impl core::ops::function::FnOnce(&[&[u8]]) -> R) -> R
 pub trait quasar_lang::traits::Space

--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -1410,6 +1410,8 @@ pub quasar_lang::error::QuasarError::RemainingAccountsOverflow = 3015
 pub quasar_lang::error::QuasarError::ReturnDataFromWrongProgram = 3018
 impl core::convert::From<quasar_lang::error::QuasarError> for solana_program_error::ProgramError
 pub fn solana_program_error::ProgramError::from(quasar_lang::error::QuasarError) -> Self
+impl core::convert::From<quasar_lang::error::QuasarError> for u32
+pub fn u32::from(quasar_lang::error::QuasarError) -> Self
 impl core::convert::TryFrom<u32> for quasar_lang::error::QuasarError
 pub type quasar_lang::error::QuasarError::Error = solana_program_error::ProgramError
 pub fn quasar_lang::error::QuasarError::try_from(u32) -> core::result::Result<Self, Self::Error>
@@ -2245,6 +2247,8 @@ pub quasar_lang::prelude::QuasarError::RemainingAccountsOverflow = 3015
 pub quasar_lang::prelude::QuasarError::ReturnDataFromWrongProgram = 3018
 impl core::convert::From<quasar_lang::error::QuasarError> for solana_program_error::ProgramError
 pub fn solana_program_error::ProgramError::from(quasar_lang::error::QuasarError) -> Self
+impl core::convert::From<quasar_lang::error::QuasarError> for u32
+pub fn u32::from(quasar_lang::error::QuasarError) -> Self
 impl core::convert::TryFrom<u32> for quasar_lang::error::QuasarError
 pub type quasar_lang::error::QuasarError::Error = solana_program_error::ProgramError
 pub fn quasar_lang::error::QuasarError::try_from(u32) -> core::result::Result<Self, Self::Error>

--- a/api-baselines/v0.1.0/quasar-lang.txt
+++ b/api-baselines/v0.1.0/quasar-lang.txt
@@ -1852,6 +1852,7 @@ pub trait quasar_lang::prelude::internal::Discriminator
 pub const quasar_lang::prelude::internal::Discriminator::BUMP_OFFSET: core::option::Option<usize>
 pub const quasar_lang::prelude::internal::Discriminator::DISCRIMINATOR: &'static [u8]
 pub trait quasar_lang::prelude::internal::HasSeeds
+pub type quasar_lang::prelude::internal::HasSeeds::WithBump<'seed>
 pub const quasar_lang::prelude::internal::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::prelude::internal::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::prelude::internal::HasSeeds::SEED_PREFIX: &'static [u8]
@@ -2988,6 +2989,7 @@ pub const quasar_lang::prelude::Event::DISCRIMINATOR: &'static [u8]
 pub fn quasar_lang::prelude::Event::emit(&self, impl core::ops::function::FnOnce(&[u8]) -> core::result::Result<(), solana_program_error::ProgramError>) -> core::result::Result<(), solana_program_error::ProgramError>
 pub fn quasar_lang::prelude::Event::write_data(&self, &mut [u8])
 pub trait quasar_lang::prelude::HasSeeds
+pub type quasar_lang::prelude::HasSeeds::WithBump<'seed>
 pub const quasar_lang::prelude::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::prelude::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::prelude::HasSeeds::SEED_PREFIX: &'static [u8]
@@ -3256,6 +3258,7 @@ pub const quasar_lang::traits::Event::DISCRIMINATOR: &'static [u8]
 pub fn quasar_lang::traits::Event::emit(&self, impl core::ops::function::FnOnce(&[u8]) -> core::result::Result<(), solana_program_error::ProgramError>) -> core::result::Result<(), solana_program_error::ProgramError>
 pub fn quasar_lang::traits::Event::write_data(&self, &mut [u8])
 pub trait quasar_lang::traits::HasSeeds
+pub type quasar_lang::traits::HasSeeds::WithBump<'seed>
 pub const quasar_lang::traits::HasSeeds::HAS_SEED_PREFIX: bool
 pub const quasar_lang::traits::HasSeeds::SEED_DYNAMIC_COUNT: usize
 pub const quasar_lang::traits::HasSeeds::SEED_PREFIX: &'static [u8]

--- a/api-baselines/v0.1.0/quasar-lang.txt
+++ b/api-baselines/v0.1.0/quasar-lang.txt
@@ -1410,6 +1410,8 @@ pub quasar_lang::error::QuasarError::RemainingAccountsOverflow = 3015
 pub quasar_lang::error::QuasarError::ReturnDataFromWrongProgram = 3018
 impl core::convert::From<quasar_lang::error::QuasarError> for solana_program_error::ProgramError
 pub fn solana_program_error::ProgramError::from(quasar_lang::error::QuasarError) -> Self
+impl core::convert::From<quasar_lang::error::QuasarError> for u32
+pub fn u32::from(quasar_lang::error::QuasarError) -> Self
 impl core::convert::TryFrom<u32> for quasar_lang::error::QuasarError
 pub type quasar_lang::error::QuasarError::Error = solana_program_error::ProgramError
 pub fn quasar_lang::error::QuasarError::try_from(u32) -> core::result::Result<Self, Self::Error>
@@ -2144,6 +2146,8 @@ pub quasar_lang::prelude::QuasarError::RemainingAccountsOverflow = 3015
 pub quasar_lang::prelude::QuasarError::ReturnDataFromWrongProgram = 3018
 impl core::convert::From<quasar_lang::error::QuasarError> for solana_program_error::ProgramError
 pub fn solana_program_error::ProgramError::from(quasar_lang::error::QuasarError) -> Self
+impl core::convert::From<quasar_lang::error::QuasarError> for u32
+pub fn u32::from(quasar_lang::error::QuasarError) -> Self
 impl core::convert::TryFrom<u32> for quasar_lang::error::QuasarError
 pub type quasar_lang::error::QuasarError::Error = solana_program_error::ProgramError
 pub fn quasar_lang::error::QuasarError::try_from(u32) -> core::result::Result<Self, Self::Error>

--- a/api-baselines/v0.1.0/quasar-lang.txt
+++ b/api-baselines/v0.1.0/quasar-lang.txt
@@ -3285,6 +3285,8 @@ pub fn quasar_lang::accounts::AccountsArray<T, N>::parse(&'input mut [solana_acc
 pub fn quasar_lang::accounts::AccountsArray<T, N>::parse_with_instruction_data(&'input mut [solana_account_view::AccountView], &[u8], &solana_address::Address) -> core::result::Result<(Self, Self::Bumps), solana_program_error::ProgramError>
 pub trait quasar_lang::traits::ProgramInterface
 pub fn quasar_lang::traits::ProgramInterface::matches(&solana_address::Address) -> bool
+pub trait quasar_lang::traits::SeedSlices
+pub fn quasar_lang::traits::SeedSlices::with_slices<R>(&self, impl core::ops::function::FnOnce(&[&[u8]]) -> R) -> R
 pub trait quasar_lang::traits::Space
 pub const quasar_lang::traits::Space::SPACE: usize
 impl<T: quasar_lang::traits::Space> quasar_lang::traits::Space for quasar_lang::accounts::Account<T>

--- a/api-baselines/v0.1.0/quasar-lang.txt
+++ b/api-baselines/v0.1.0/quasar-lang.txt
@@ -3289,6 +3289,8 @@ pub fn quasar_lang::accounts::AccountsArray<T, N>::parse(&'input mut [solana_acc
 pub fn quasar_lang::accounts::AccountsArray<T, N>::parse_with_instruction_data(&'input mut [solana_account_view::AccountView], &[u8], &solana_address::Address) -> core::result::Result<(Self, Self::Bumps), solana_program_error::ProgramError>
 pub trait quasar_lang::traits::ProgramInterface
 pub fn quasar_lang::traits::ProgramInterface::matches(&solana_address::Address) -> bool
+pub trait quasar_lang::traits::SeedParam<const INDEX: usize>
+pub type quasar_lang::traits::SeedParam::Ty
 pub trait quasar_lang::traits::SeedSlices
 pub fn quasar_lang::traits::SeedSlices::with_slices<R>(&self, impl core::ops::function::FnOnce(&[&[u8]]) -> R) -> R
 pub trait quasar_lang::traits::Space

--- a/api-baselines/v0.1.0/quasar-spl.txt
+++ b/api-baselines/v0.1.0/quasar-spl.txt
@@ -83,6 +83,7 @@ impl core::marker::Unpin for quasar_spl::accounts::associated_token::Behavior
 impl core::marker::UnsafeUnpin for quasar_spl::accounts::associated_token::Behavior
 impl core::panic::unwind_safe::RefUnwindSafe for quasar_spl::accounts::associated_token::Behavior
 impl core::panic::unwind_safe::UnwindSafe for quasar_spl::accounts::associated_token::Behavior
+pub fn quasar_spl::accounts::associated_token::client_address(&solana_address::Address, &solana_address::Address, core::option::Option<&solana_address::Address>) -> solana_address::Address
 pub mod quasar_spl::accounts::mint
 pub enum quasar_spl::accounts::mint::FreezeAuthorityArg<'a>
 pub quasar_spl::accounts::mint::FreezeAuthorityArg::AssertEquals(&'a solana_account_view::AccountView)
@@ -435,6 +436,7 @@ impl core::marker::Unpin for quasar_spl::accounts::associated_token::Behavior
 impl core::marker::UnsafeUnpin for quasar_spl::accounts::associated_token::Behavior
 impl core::panic::unwind_safe::RefUnwindSafe for quasar_spl::accounts::associated_token::Behavior
 impl core::panic::unwind_safe::UnwindSafe for quasar_spl::accounts::associated_token::Behavior
+pub fn quasar_spl::prelude::associated_token::client_address(&solana_address::Address, &solana_address::Address, core::option::Option<&solana_address::Address>) -> solana_address::Address
 pub mod quasar_spl::prelude::mint
 pub enum quasar_spl::prelude::mint::FreezeAuthorityArg<'a>
 pub quasar_spl::prelude::mint::FreezeAuthorityArg::AssertEquals(&'a solana_account_view::AccountView)

--- a/api-baselines/v0.1.0/quasar-test-derive.txt
+++ b/api-baselines/v0.1.0/quasar-test-derive.txt
@@ -1,0 +1,1 @@
+proc-macro attr quasar_test_derive::quasar_test

--- a/api-baselines/v0.1.0/quasar-test.txt
+++ b/api-baselines/v0.1.0/quasar-test.txt
@@ -31,6 +31,7 @@ pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_ad
 pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
 pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::from_program_path_with_config(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::fund(&mut self, solana_address::Address, u64) -> solana_address::Address
@@ -160,6 +161,7 @@ pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_ad
 pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
 pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::from_program_path_with_config(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::fund(&mut self, solana_address::Address, u64) -> solana_address::Address

--- a/api-baselines/v0.1.0/quasar-test.txt
+++ b/api-baselines/v0.1.0/quasar-test.txt
@@ -4,6 +4,7 @@ pub use quasar_test::Pubkey
 pub use quasar_test::QuasarSvm
 pub use quasar_test::QuasarSvmConfig
 pub use quasar_test::quasar_svm
+pub use quasar_test::quasar_test
 pub mod quasar_test::fixtures
 pub fn quasar_test::fixtures::associated_token_account(solana_address::Address, solana_address::Address, u64) -> quasar_svm::Account
 pub fn quasar_test::fixtures::empty_account(solana_address::Address) -> quasar_svm::Account
@@ -20,7 +21,8 @@ pub use quasar_test::prelude::Instruction
 pub use quasar_test::prelude::ProgramError
 pub use quasar_test::prelude::Pubkey
 pub use quasar_test::prelude::QuasarSvmConfig
-pub macro quasar_test::prelude::quasar_test!
+pub use quasar_test::prelude::quasar_test
+pub use quasar_test::prelude::system_program
 pub struct quasar_test::prelude::QuasarTest
 impl quasar_test::QuasarTest
 pub fn quasar_test::QuasarTest::actor(&mut self) -> solana_address::Address
@@ -37,14 +39,20 @@ pub fn quasar_test::QuasarTest::mint(&mut self, solana_address::Address) -> sola
 pub fn quasar_test::QuasarTest::mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
 pub fn quasar_test::QuasarTest::mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::new(impl core::convert::Into<solana_address::Address>) -> Self
+pub fn quasar_test::QuasarTest::new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> Self
 pub fn quasar_test::QuasarTest::new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> Self
+pub fn quasar_test::QuasarTest::pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
+pub fn quasar_test::QuasarTest::pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
+pub fn quasar_test::QuasarTest::program_id(&self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::program_path(&self) -> &std::path::Path
+pub fn quasar_test::QuasarTest::read<T>(&self, solana_address::Address) -> quasar_test::Snapshot<T> where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + zeropod::traits::ZcValidate + core::marker::Copy
 pub fn quasar_test::QuasarTest::send(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::send_with(&mut self, impl core::convert::Into<solana_instruction::Instruction>, impl core::iter::traits::collect::IntoIterator<Item = quasar_svm::Account>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::simulate(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::ProjectError>
+pub fn quasar_test::QuasarTest::try_new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::try_new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::with_account(self, quasar_svm::Account) -> Self
 pub fn quasar_test::QuasarTest::with_airdrop(self, &solana_address::Address, u64) -> Self
@@ -53,6 +61,7 @@ pub fn quasar_test::QuasarTest::with_create_account(self, &solana_address::Addre
 pub fn quasar_test::QuasarTest::with_program(self, &solana_address::Address, &[u8]) -> Self
 pub fn quasar_test::QuasarTest::with_program_loader(self, &solana_address::Address, &solana_address::Address, &[u8]) -> Self
 pub fn quasar_test::QuasarTest::with_slot(self, u64) -> Self
+pub fn quasar_test::QuasarTest::write<T>(&mut self, solana_address::Address, <T as core::ops::deref::Deref>::Target) -> solana_address::Address where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + core::marker::Copy
 impl core::ops::deref::Deref for quasar_test::QuasarTest
 pub type quasar_test::QuasarTest::Target = quasar_svm::svm::QuasarSvm
 pub fn quasar_test::QuasarTest::deref(&self) -> &Self::Target
@@ -65,6 +74,20 @@ impl core::marker::Unpin for quasar_test::QuasarTest
 impl core::marker::UnsafeUnpin for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::RefUnwindSafe for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::UnwindSafe for quasar_test::QuasarTest
+pub struct quasar_test::prelude::Snapshot<T: core::ops::deref::Deref> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+impl<T: core::ops::deref::Deref> quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+pub fn quasar_test::Snapshot<T>::address(&self) -> solana_address::Address
+pub fn quasar_test::Snapshot<T>::lamports(&self) -> u64
+impl<T: core::ops::deref::Deref> core::ops::deref::Deref for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+pub type quasar_test::Snapshot<T>::Target = <T as core::ops::deref::Deref>::Target
+pub fn quasar_test::Snapshot<T>::deref(&self) -> &Self::Target
+impl<T> core::marker::Freeze for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Freeze
+impl<T> core::marker::Send for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Send
+impl<T> core::marker::Sync for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Sync
+impl<T> core::marker::Unpin for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::UnwindSafe
 pub trait quasar_test::prelude::ExecutionResultExt
 pub fn quasar_test::prelude::ExecutionResultExt::assert_compute_units_below(&self, u64)
 pub fn quasar_test::prelude::ExecutionResultExt::assert_custom_error<E>(&self, E) where E: core::convert::Into<u32>
@@ -97,7 +120,6 @@ pub fn quasar_svm::svm::ExecutionResult::lamports(&self, &solana_address::Addres
 pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
-pub macro quasar_test::quasar_test!
 #[non_exhaustive] pub enum quasar_test::ProjectError
 pub quasar_test::ProjectError::AmbiguousPrograms
 pub quasar_test::ProjectError::AmbiguousPrograms::deploy: std::path::PathBuf
@@ -140,14 +162,20 @@ pub fn quasar_test::QuasarTest::mint(&mut self, solana_address::Address) -> sola
 pub fn quasar_test::QuasarTest::mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
 pub fn quasar_test::QuasarTest::mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::new(impl core::convert::Into<solana_address::Address>) -> Self
+pub fn quasar_test::QuasarTest::new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> Self
 pub fn quasar_test::QuasarTest::new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> Self
+pub fn quasar_test::QuasarTest::pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
+pub fn quasar_test::QuasarTest::pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
+pub fn quasar_test::QuasarTest::program_id(&self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::program_path(&self) -> &std::path::Path
+pub fn quasar_test::QuasarTest::read<T>(&self, solana_address::Address) -> quasar_test::Snapshot<T> where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + zeropod::traits::ZcValidate + core::marker::Copy
 pub fn quasar_test::QuasarTest::send(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::send_with(&mut self, impl core::convert::Into<solana_instruction::Instruction>, impl core::iter::traits::collect::IntoIterator<Item = quasar_svm::Account>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::simulate(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::ProjectError>
+pub fn quasar_test::QuasarTest::try_new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::try_new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::with_account(self, quasar_svm::Account) -> Self
 pub fn quasar_test::QuasarTest::with_airdrop(self, &solana_address::Address, u64) -> Self
@@ -156,6 +184,7 @@ pub fn quasar_test::QuasarTest::with_create_account(self, &solana_address::Addre
 pub fn quasar_test::QuasarTest::with_program(self, &solana_address::Address, &[u8]) -> Self
 pub fn quasar_test::QuasarTest::with_program_loader(self, &solana_address::Address, &solana_address::Address, &[u8]) -> Self
 pub fn quasar_test::QuasarTest::with_slot(self, u64) -> Self
+pub fn quasar_test::QuasarTest::write<T>(&mut self, solana_address::Address, <T as core::ops::deref::Deref>::Target) -> solana_address::Address where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + core::marker::Copy
 impl core::ops::deref::Deref for quasar_test::QuasarTest
 pub type quasar_test::QuasarTest::Target = quasar_svm::svm::QuasarSvm
 pub fn quasar_test::QuasarTest::deref(&self) -> &Self::Target
@@ -168,6 +197,20 @@ impl core::marker::Unpin for quasar_test::QuasarTest
 impl core::marker::UnsafeUnpin for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::RefUnwindSafe for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::UnwindSafe for quasar_test::QuasarTest
+pub struct quasar_test::Snapshot<T: core::ops::deref::Deref> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+impl<T: core::ops::deref::Deref> quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+pub fn quasar_test::Snapshot<T>::address(&self) -> solana_address::Address
+pub fn quasar_test::Snapshot<T>::lamports(&self) -> u64
+impl<T: core::ops::deref::Deref> core::ops::deref::Deref for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
+pub type quasar_test::Snapshot<T>::Target = <T as core::ops::deref::Deref>::Target
+pub fn quasar_test::Snapshot<T>::deref(&self) -> &Self::Target
+impl<T> core::marker::Freeze for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Freeze
+impl<T> core::marker::Send for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Send
+impl<T> core::marker::Sync for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Sync
+impl<T> core::marker::Unpin for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::UnwindSafe
 pub const quasar_test::DEFAULT_ACTOR_LAMPORTS: u64
 pub const quasar_test::PROGRAM_PATH_ENV: &str
 pub trait quasar_test::ExecutionResultExt
@@ -203,3 +246,4 @@ pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Add
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
 pub fn quasar_test::resolve_program_path() -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>
+pub fn quasar_test::resolve_program_path_named(&str) -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>

--- a/api-baselines/v0.1.0/quasar-test.txt
+++ b/api-baselines/v0.1.0/quasar-test.txt
@@ -120,6 +120,12 @@ pub fn quasar_svm::svm::ExecutionResult::lamports(&self, &solana_address::Addres
 pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
+pub trait quasar_test::prelude::InstructionExt: core::marker::Sized
+pub fn quasar_test::prelude::InstructionExt::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
+pub fn quasar_test::prelude::InstructionExt::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
+impl<T: core::convert::Into<solana_instruction::Instruction>> quasar_test::InstructionExt for T
+pub fn T::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
+pub fn T::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
 #[non_exhaustive] pub enum quasar_test::ProjectError
 pub quasar_test::ProjectError::AmbiguousPrograms
 pub quasar_test::ProjectError::AmbiguousPrograms::deploy: std::path::PathBuf
@@ -245,5 +251,11 @@ pub fn quasar_svm::svm::ExecutionResult::lamports(&self, &solana_address::Addres
 pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
+pub trait quasar_test::InstructionExt: core::marker::Sized
+pub fn quasar_test::InstructionExt::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
+pub fn quasar_test::InstructionExt::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
+impl<T: core::convert::Into<solana_instruction::Instruction>> quasar_test::InstructionExt for T
+pub fn T::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
+pub fn T::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
 pub fn quasar_test::resolve_program_path() -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>
 pub fn quasar_test::resolve_program_path_named(&str) -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>

--- a/api-baselines/v0.1.0/quasar-test.txt
+++ b/api-baselines/v0.1.0/quasar-test.txt
@@ -21,6 +21,9 @@ pub use quasar_test::prelude::Instruction
 pub use quasar_test::prelude::ProgramError
 pub use quasar_test::prelude::Pubkey
 pub use quasar_test::prelude::QuasarSvmConfig
+pub use quasar_test::prelude::SPL_ASSOCIATED_TOKEN_PROGRAM_ID
+pub use quasar_test::prelude::SPL_TOKEN_2022_PROGRAM_ID
+pub use quasar_test::prelude::SPL_TOKEN_PROGRAM_ID
 pub use quasar_test::prelude::quasar_test
 pub use quasar_test::prelude::system_program
 pub struct quasar_test::prelude::QuasarTest
@@ -30,6 +33,7 @@ pub fn quasar_test::QuasarTest::actor_at(&mut self, solana_address::Address) -> 
 pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
 pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::ata_address(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
 pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
 pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>
@@ -160,6 +164,7 @@ pub fn quasar_test::QuasarTest::actor_at(&mut self, solana_address::Address) -> 
 pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
 pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::ata_address(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
 pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
 pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -658,67 +658,42 @@ fn test_initialize() {{
 "#
             )
         }
-        (RustFramework::QuasarSVM, Template::Minimal) => r#"use quasar_test::prelude::*;
+        (RustFramework::QuasarSVM, Template::Minimal) => {
+            r#"use {crate::cpi::InitializeInstruction, quasar_test::prelude::*};
 
-fn initialize_instruction(payer: Pubkey) -> Instruction {
-    Instruction {
-        program_id: crate::ID,
-        accounts: vec![
-            AccountMeta::new_readonly(payer, true),
-        ],
-        data: vec![0],
-    }
-}
-
-quasar_test! {
-    fn test_initialize(q) {
-        let payer = q.actor();
-        q.send(initialize_instruction(payer)).succeeds();
-    }
+#[quasar_test]
+fn initialize(q: &mut QuasarTest) {
+    let payer = q.actor();
+    q.send(InitializeInstruction { payer }).succeeds();
 }
 "#
-        .to_string(),
-        (RustFramework::QuasarSVM, Template::Full) => r#"use quasar_test::prelude::*;
+            .to_string()
+        }
+        (RustFramework::QuasarSVM, Template::Full) => r#"use {
+    crate::{cpi::InitializeInstruction, state::MyAccount},
+    quasar_test::prelude::*,
+};
 
 const VALUE: u64 = 42;
-const MY_ACCOUNT_SIZE: usize = 107;
 
-fn initialize_instruction(payer: Pubkey, my_account: Pubkey) -> Instruction {
-    let mut data = vec![0];
-    data.extend_from_slice(&VALUE.to_le_bytes());
-    Instruction {
-        program_id: crate::ID,
-        accounts: vec![
-            AccountMeta::new(payer, true),
-            AccountMeta::new(my_account, false),
-            AccountMeta::new_readonly(
-                quasar_test::quasar_svm::system_program::ID,
-                false,
-            ),
-        ],
-        data,
-    }
-}
+#[quasar_test]
+fn initialize(q: &mut QuasarTest) {
+    let payer = q.actor();
+    let (my_account, bump) = q.pda_with_bump(MyAccount::seeds(&payer));
 
-quasar_test! {
-    fn test_initialize(q) {
-        let payer = q.actor();
-        let (my_account, bump) =
-            Pubkey::find_program_address(&[b"my-account", payer.as_ref()], &crate::ID);
-        q.empty(my_account);
+    q.send(InitializeInstruction {
+        payer,
+        my_account,
+        system_program: system_program::ID,
+        value: VALUE,
+    })
+    .succeeds();
 
-        let result = q.send(initialize_instruction(payer, my_account));
-        result.succeeds();
-        let stored = result.account(&my_account).expect("initialized state account");
-        assert_eq!(stored.owner, crate::ID);
-        assert_eq!(stored.data.len(), MY_ACCOUNT_SIZE);
-        assert_eq!(stored.data[0], 1, "discriminator");
-        assert_eq!(stored.data[1], 1, "version");
-        assert_eq!(&stored.data[2..34], payer.as_ref(), "authority");
-        assert_eq!(&stored.data[34..42], &VALUE.to_le_bytes(), "value");
-        assert_eq!(stored.data[42], bump, "bump");
-        assert!(stored.data[43..].iter().all(|byte| *byte == 0), "reserved");
-    }
+    let state = q.read::<MyAccount>(my_account);
+    assert_eq!(state.version, 1);
+    assert_eq!(state.authority, payer);
+    assert_eq!(state.value, VALUE);
+    assert_eq!(state.bump, bump);
 }
 "#
         .to_string(),
@@ -1051,7 +1026,8 @@ mod tests {
 
     #[test]
     fn full_templates_generate_stateful_tests_without_changing_minimal_tests() {
-        for framework in [RustFramework::Mollusk, RustFramework::QuasarSVM] {
+        {
+            let framework = RustFramework::Mollusk;
             let full = generate_tests_rs("demo", framework, Template::Full, Toolchain::Solana);
             assert!(full.contains("my-account"));
             assert!(full.contains("MY_ACCOUNT_SIZE"));
@@ -1061,13 +1037,23 @@ mod tests {
                 generate_tests_rs("demo", framework, Template::Minimal, Toolchain::Solana);
             assert!(!minimal.contains("my-account"));
             assert!(!minimal.contains("MY_ACCOUNT_SIZE"));
+        }
 
-            if matches!(framework, RustFramework::QuasarSVM) {
-                assert!(full.contains("quasar_test!"));
-                assert!(full.contains("q.send("));
-                assert!(!full.contains("fixtures::"));
-                assert!(minimal.contains("let payer = q.actor();"));
-            }
+        {
+            let framework = RustFramework::QuasarSVM;
+            let full = generate_tests_rs("demo", framework, Template::Full, Toolchain::Solana);
+            assert!(full.contains("#[quasar_test]"));
+            assert!(full.contains("q.pda_with_bump(MyAccount::seeds(&payer))"));
+            assert!(full.contains("q.send(InitializeInstruction {"));
+            assert!(full.contains("q.read::<MyAccount>(my_account)"));
+            assert!(!full.contains("fixtures::"));
+            assert!(!full.contains("data["), "no raw-byte state assertions");
+
+            let minimal =
+                generate_tests_rs("demo", framework, Template::Minimal, Toolchain::Solana);
+            assert!(minimal.contains("#[quasar_test]"));
+            assert!(minimal.contains("let payer = q.actor();"));
+            assert!(!minimal.contains("MyAccount"));
         }
 
         for sdk in [TypeScriptSdk::Kit, TypeScriptSdk::Web3js] {

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -681,13 +681,7 @@ fn initialize(q: &mut QuasarTest) {
     let payer = q.actor();
     let (my_account, bump) = q.pda_with_bump(MyAccount::seeds(&payer));
 
-    q.send(InitializeInstruction {
-        payer,
-        my_account,
-        system_program: system_program::ID,
-        value: VALUE,
-    })
-    .succeeds();
+    q.send(InitializeInstruction { payer, value: VALUE }).succeeds();
 
     let state = q.read::<MyAccount>(my_account);
     assert_eq!(state.version, 1);

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_basic_mut_signer.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_basic_mut_signer.rs
@@ -331,38 +331,39 @@ mod __basic_accounts_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, pub rent : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
+            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
             ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.rent, false),]; let data
-            = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
-            $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+            ::serialize_arg(& ix. $arg_name));)* _data };
+            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+            } } }
         };
         (
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             compact
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, pub rent : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
+            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
             ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.rent, false),]; let data
-            = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
-            $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix
-            . $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
+            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
+            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
             $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
             $crate::ID, accounts, data, } } }
         };
@@ -371,18 +372,18 @@ mod __basic_accounts_client_macro {
             remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, pub rent : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
+            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
             ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.rent, false),]; accounts
-            .extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
             _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
             accounts, data, } } }
@@ -392,18 +393,18 @@ mod __basic_accounts_client_macro {
             compact, remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, pub rent : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
+            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
             ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.rent, false),]; accounts
-            .extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
             $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
@@ -411,6 +412,13 @@ mod __basic_accounts_client_macro {
             $crate::ID, accounts, data, } } }
         };
     }
+}
+#[allow(non_upper_case_globals)]
+impl BasicAccounts {
+    #[doc(hidden)]
+    pub const __QUASAR_FIXED_ADDRESS_system_program: ::quasar_lang::prelude::Address = <SystemProgram as ::quasar_lang::traits::Id>::ID;
+    #[doc(hidden)]
+    pub const __QUASAR_FIXED_ADDRESS_rent: ::quasar_lang::prelude::Address = <Rent as ::quasar_lang::sysvars::Sysvar>::ID;
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_behavior_group.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_behavior_group.rs
@@ -370,7 +370,7 @@ mod __use_custom_behavior_client_macro {
     ::quasar_lang::idl_build::one_behavior_resolver("data",
     [::quasar_lang::idl_build::behavior_resolver(< min_value::Behavior as
     ::quasar_lang::account_behavior::AccountBehavior < Account < MyData > >>
-    ::IDL_RESOLVER, & [],)],).unwrap_or_else(|| {
+    ::IDL_RESOLVER, & [], & ["data"],)],).unwrap_or_else(|| {
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {} }), docs :
     ::quasar_lang::idl_build::Vec::new(), }],) })
 }

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_behavior_group.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_behavior_group.rs
@@ -298,8 +298,8 @@ mod __use_custom_behavior_client_macro {
         ) => {
             pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
             $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
             false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
@@ -313,8 +313,8 @@ mod __use_custom_behavior_client_macro {
         ) => {
             pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
             $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
             false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
@@ -330,8 +330,8 @@ mod __use_custom_behavior_client_macro {
             pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
             $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
             false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
             = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
@@ -346,8 +346,8 @@ mod __use_custom_behavior_client_macro {
             pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
             $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
             false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
             = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_close.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_close.rs
@@ -289,9 +289,10 @@ mod __close_accounts_client_macro {
         ) => {
             pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
             pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+            } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
             ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = {
             let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
             $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
@@ -304,9 +305,10 @@ mod __close_accounts_client_macro {
         ) => {
             pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
             pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+            } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
             ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = {
             let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
             $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix
@@ -323,8 +325,8 @@ mod __close_accounts_client_macro {
             pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
             ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts
             .extend(ix.remaining_accounts); let data = { let mut _data =
@@ -341,8 +343,8 @@ mod __close_accounts_client_macro {
             pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
             ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts
             .extend(ix.remaining_accounts); let data = { let mut _data =

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_composite.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_composite.rs
@@ -300,8 +300,9 @@ mod __uses_account_array_client_macro {
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
             pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
@@ -316,8 +317,9 @@ mod __uses_account_array_client_macro {
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
             pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
@@ -334,12 +336,13 @@ mod __uses_account_array_client_macro {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
             pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
             remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix
-            .payer, true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
+            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
+            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
             _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
             accounts, data, } } }
@@ -351,12 +354,13 @@ mod __uses_account_array_client_macro {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
             pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
             remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix
-            .payer, true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
+            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
+            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
             $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_dup.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_dup.rs
@@ -248,9 +248,10 @@ mod __header_dup_readonly_client_macro {
         ) => {
             pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
             destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
+            impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
             false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
@@ -264,9 +265,10 @@ mod __header_dup_readonly_client_macro {
         ) => {
             pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
             destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
+            impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
             false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
@@ -283,8 +285,8 @@ mod __header_dup_readonly_client_macro {
             destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
             false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
@@ -301,8 +303,8 @@ mod __header_dup_readonly_client_macro {
             destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
             false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_init_payer.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_init_payer.rs
@@ -8,7 +8,7 @@ impl InitEscrow {
     pub fn escrow_signer<'__quasar_seed>(
         &'__quasar_seed self,
         bumps: &'__quasar_seed InitEscrowBumps,
-    ) -> impl ::quasar_lang::cpi::CpiSignerSeeds + '__quasar_seed {
+    ) -> <Escrow as ::quasar_lang::traits::HasSeeds>::WithBump<'__quasar_seed> {
         let payer = &self.payer;
         let escrow = &self.escrow;
         let system_program = &self.system_program;

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_init_payer.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_init_payer.rs
@@ -379,15 +379,15 @@ mod __init_escrow_client_macro {
         (
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
         ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            escrow : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
-            $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
+            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+            $arg_name : $arg_ty,)* } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
             $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.escrow, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+            ix.payer, & $crate::ID), false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
             ::serialize_arg(& ix. $arg_name));)* _data };
             ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
@@ -397,15 +397,15 @@ mod __init_escrow_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             compact
         ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            escrow : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
-            $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
+            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+            $arg_name : $arg_ty,)* } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
             $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.escrow, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+            ix.payer, & $crate::ID), false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
             > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
             as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
@@ -416,17 +416,17 @@ mod __init_escrow_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             remaining
         ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            escrow : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new(ix.escrow, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+            ix.payer, & $crate::ID), false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
             _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
             accounts, data, } } }
@@ -435,23 +435,39 @@ mod __init_escrow_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             compact, remaining
         ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            escrow : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new(ix.escrow, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+            ix.payer, & $crate::ID), false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
             $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
             $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
             $crate::ID, accounts, data, } } }
         };
+    }
+}
+#[allow(non_upper_case_globals)]
+impl InitEscrow {
+    #[doc(hidden)]
+    pub const __QUASAR_FIXED_ADDRESS_system_program: ::quasar_lang::prelude::Address = <SystemProgram as ::quasar_lang::traits::Id>::ID;
+}
+impl InitEscrow {
+    #[doc(hidden)]
+    #[inline]
+    pub fn __quasar_pda_escrow(
+        payer: &::quasar_lang::prelude::Address,
+        program_id: &::quasar_lang::prelude::Address,
+    ) -> ::quasar_lang::prelude::Address {
+        let seeds = <Escrow>::seeds(payer);
+        ::quasar_lang::pda::find_program_address_const(&seeds.as_slices(), program_id).0
     }
 }
 #[cfg(feature = "idl-build")]

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_ix_args_dynamic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_ix_args_dynamic.rs
@@ -254,8 +254,8 @@ mod __two_dyn_client_macro {
         ) => {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
@@ -269,8 +269,8 @@ mod __two_dyn_client_macro {
         ) => {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
@@ -286,8 +286,8 @@ mod __two_dyn_client_macro {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =
             ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
@@ -302,8 +302,8 @@ mod __two_dyn_client_macro {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =
             ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_ix_args_fixed.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_ix_args_fixed.rs
@@ -257,8 +257,8 @@ mod __ix_args_fixed_client_macro {
         ) => {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
@@ -272,8 +272,8 @@ mod __ix_args_fixed_client_macro {
         ) => {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
@@ -289,8 +289,8 @@ mod __ix_args_fixed_client_macro {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =
             ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
@@ -305,8 +305,8 @@ mod __ix_args_fixed_client_macro {
             pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
             $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =
             ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_optional.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_optional.rs
@@ -282,13 +282,14 @@ mod __optional_accounts_client_macro {
         ) => {
             pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
             pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix
-            .authority, true), ::quasar_lang::client::AccountMeta::new_readonly(ix
-            .config, false),]; let data = { let mut _data = ::alloc::vec![$($disc),*];
-            $(_data.extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg
-            > ::serialize_arg(& ix. $arg_name));)* _data };
+            impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
+            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+            ::serialize_arg(& ix. $arg_name));)* _data };
             ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
             } } }
         };
@@ -298,15 +299,15 @@ mod __optional_accounts_client_macro {
         ) => {
             pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
             pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let accounts
-            = ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix
-            .authority, true), ::quasar_lang::client::AccountMeta::new_readonly(ix
-            .config, false),]; let data = { let mut _data = ::alloc::vec![$($disc),*];
-            $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
+            impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
+            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
+            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
+            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
             $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
             $crate::ID, accounts, data, } } }
         };
@@ -318,8 +319,8 @@ mod __optional_accounts_client_macro {
             pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =
@@ -336,8 +337,8 @@ mod __optional_accounts_client_macro {
             pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
             pub remaining_accounts : ::alloc::vec::Vec <
             ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
             true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
             accounts.extend(ix.remaining_accounts); let data = { let mut _data =

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_realloc.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/accounts_realloc.rs
@@ -316,14 +316,14 @@ mod __realloc_accounts_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
-            $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
             ::serialize_arg(& ix. $arg_name));)* _data };
             ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
@@ -334,14 +334,14 @@ mod __realloc_accounts_client_macro {
             compact
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
-            $struct_name > for ::quasar_lang::client::Instruction { fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+            From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let accounts =
             ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
             ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
             .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
             > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
             as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
@@ -353,16 +353,16 @@ mod __realloc_accounts_client_macro {
             remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
             remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+            ::quasar_lang::client::AccountMeta::new(ix.data, false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
             _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
             accounts, data, } } }
@@ -372,16 +372,16 @@ mod __realloc_accounts_client_macro {
             compact, remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, pub system_program :
-            ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
             remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction { fn
-            from(ix : $struct_name) -> ::quasar_lang::client::Instruction { let mut
-            accounts = ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.system_program, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+            #[allow(unused_variables)] fn from(ix : $struct_name) ->
+            ::quasar_lang::client::Instruction { let mut accounts =
+            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+            ::quasar_lang::client::AccountMeta::new(ix.data, false),
+            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
+            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
             $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
@@ -389,6 +389,11 @@ mod __realloc_accounts_client_macro {
             $crate::ID, accounts, data, } } }
         };
     }
+}
+#[allow(non_upper_case_globals)]
+impl ReallocAccounts {
+    #[doc(hidden)]
+    pub const __QUASAR_FIXED_ADDRESS_system_program: ::quasar_lang::prelude::Address = <SystemProgram as ::quasar_lang::traits::Id>::ID;
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/error_code_basic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/error_code_basic.rs
@@ -10,6 +10,12 @@ impl From<TestError> for ::quasar_lang::__solana_program_error::ProgramError {
         ::quasar_lang::__solana_program_error::ProgramError::Custom(e as u32)
     }
 }
+impl From<TestError> for u32 {
+    #[inline(always)]
+    fn from(e: TestError) -> Self {
+        e as u32
+    }
+}
 impl TryFrom<u32> for TestError {
     type Error = ::quasar_lang::__solana_program_error::ProgramError;
     #[inline(always)]

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
@@ -59,6 +59,20 @@ impl<'__quasar_seed> VaultPdaSeedSetWithBump<'__quasar_seed> {
     pub fn as_slices(&self) -> [&[u8]; 3usize] {
         [b"vault", self.inner._authority.as_ref(), &self._bump]
     }
+    /// Materialize the signer-seed array once.
+    ///
+    /// `invoke_signed(&set)` rebuilds the array on every call (the
+    /// pointer escapes into the syscall, so the rebuild cannot be
+    /// elided). Bind this before signing several CPIs to pay the
+    /// construction cost once.
+    #[inline(always)]
+    pub fn signer_seeds(&self) -> [::quasar_lang::cpi::Seed<'_>; 3usize] {
+        [
+            ::quasar_lang::cpi::Seed::from(b"vault"),
+            ::quasar_lang::cpi::Seed::from(self.inner._authority.as_ref()),
+            ::quasar_lang::cpi::Seed::from(&self._bump),
+        ]
+    }
 }
 impl<'__quasar_seed> ::quasar_lang::cpi::CpiSignerSeeds
 for VaultPdaSeedSetWithBump<'__quasar_seed> {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
@@ -35,6 +35,13 @@ impl<'__quasar_seed> VaultPdaSeedSet<'__quasar_seed> {
         [b"vault", self._authority.as_ref()]
     }
 }
+impl<'__quasar_seed> ::quasar_lang::traits::SeedSlices
+for VaultPdaSeedSet<'__quasar_seed> {
+    #[inline(always)]
+    fn with_slices<R>(&self, f: impl FnOnce(&[&[u8]]) -> R) -> R {
+        f(&self.as_slices())
+    }
+}
 impl<'__quasar_seed> VaultPdaSeedSetWithBump<'__quasar_seed> {
     #[inline(always)]
     pub fn as_slices(&self) -> [&[u8]; 3usize] {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
@@ -2,6 +2,7 @@ impl ::quasar_lang::traits::HasSeeds for VaultPda {
     const HAS_SEED_PREFIX: bool = true;
     const SEED_PREFIX: &'static [u8] = &[118u8, 97u8, 117u8, 108u8, 116u8];
     const SEED_DYNAMIC_COUNT: usize = 1usize;
+    type WithBump<'__quasar_seed> = VaultPdaSeedSetWithBump<'__quasar_seed>;
 }
 /// Zero-copy seed storage (without bump).
 pub struct VaultPdaSeedSet<'__quasar_seed> {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/seeds_basic.rs
@@ -21,6 +21,18 @@ impl VaultPda {
             _authority: authority,
         }
     }
+    /// Derive this PDA's canonical address from owned seed values.
+    #[inline]
+    pub fn find_address(
+        authority: ::quasar_lang::prelude::Address,
+        program_id: &::quasar_lang::prelude::Address,
+    ) -> ::quasar_lang::prelude::Address {
+        let seeds = Self::seeds(&authority);
+        ::quasar_lang::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+    }
+}
+impl ::quasar_lang::traits::SeedParam<0usize> for VaultPda {
+    type Ty = ::quasar_lang::prelude::Address;
 }
 impl<'__quasar_seed> VaultPdaSeedSet<'__quasar_seed> {
     #[inline(always)]

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -590,6 +590,11 @@ fn emit_idl_accounts_meta(
                 quote! { #krate::idl_build::__reexport::IdlResolver::Input {} }
             } else {
                 let field_ty = &fp.effective_ty;
+                let field_names: Vec<String> = plan
+                    .fields
+                    .iter()
+                    .map(|other| crate::helpers::snake_to_camel(&other.ident.to_string()))
+                    .collect();
                 let candidates = fp.behaviors.iter().map(|behavior| {
                     let path = &behavior.path;
                     let args = behavior.idl_account_args.iter().map(|arg| {
@@ -601,6 +606,7 @@ fn emit_idl_accounts_meta(
                         #krate::idl_build::behavior_resolver(
                             <#path::Behavior as #krate::account_behavior::AccountBehavior<#field_ty>>::IDL_RESOLVER,
                             &[#(#args),*],
+                            &[#(#field_names),*],
                         )
                     }
                 });

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -382,11 +382,14 @@ fn emit_pda_address_fns(
                     let authority = source_arg(authority);
                     let mint = source_arg(mint);
                     let token_program = match token_program {
-                        Some(field) => {
+                        crate::client_macro::BehaviorProgramArg::Fixed(field) => {
                             let const_ident = crate::client_macro::fixed_address_const(field);
                             quote! { Some(&Self::#const_ident) }
                         }
-                        None => quote! { None },
+                        crate::client_macro::BehaviorProgramArg::Field(field) => {
+                            quote! { Some(#field) }
+                        }
+                        crate::client_macro::BehaviorProgramArg::Default => quote! { None },
                     };
                     quote! { #behavior_path::client_address(#authority, #mint, #token_program) }
                 }
@@ -794,6 +797,7 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
             let field_name = &fp.ident;
             let signer_helper = fp.signer_helper.as_ref()?;
             let addr_expr = &signer_helper.addr_expr;
+            let set_ty = &signer_helper.set_ty;
             let method_name = format_ident!("{}_signer", field_name);
             if has_instruction_args {
                 Some(quote! {
@@ -804,7 +808,7 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
                         bumps: &'__quasar_seed #bumps_name,
                         data: &'__quasar_seed [u8],
                     ) -> Result<
-                        impl #krate::cpi::CpiSignerSeeds + '__quasar_seed,
+                        <#set_ty as #krate::traits::HasSeeds>::WithBump<'__quasar_seed>,
                         #krate::prelude::ProgramError,
                     > {
                         let __ix_data = data;
@@ -820,7 +824,7 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
                     pub fn #method_name<'__quasar_seed>(
                         &'__quasar_seed self,
                         bumps: &'__quasar_seed #bumps_name,
-                    ) -> impl #krate::cpi::CpiSignerSeeds + '__quasar_seed {
+                    ) -> <#set_ty as #krate::traits::HasSeeds>::WithBump<'__quasar_seed> {
                         #(#field_refs)*
                         #addr_expr.with_bump(bumps.#field_name)
                     }

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -301,71 +301,97 @@ fn emit_pda_address_fns(
     ty_generics: &proc_macro2::TokenStream,
     where_clause: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+    use crate::client_macro::{
+        derivation_roots, direct_derived_deps, field_derivation, DeriveRoot, FieldDerivation,
+        SeedSource,
+    };
     let krate = crate::krate::lang_path();
+    let source_arg = |source: &SeedSource| match source {
+        // Plain accounts and Address args are `&Address` parameters; derived
+        // accounts are `let` locals holding an owned `Address`.
+        SeedSource::PlainAccount(i) | SeedSource::ArgRef(i) => quote! { #i },
+        SeedSource::DerivedAccount(i) => quote! { &#i },
+        SeedSource::ArgValue(i, _) => quote! { #i },
+        SeedSource::Const(expr) => quote! { #expr },
+    };
     let fns: Vec<proc_macro2::TokenStream> = plan
         .fields
         .iter()
         .filter_map(|field| {
-            use crate::client_macro::DerivedSeed;
-            let (account_ty, seeds) = crate::client_macro::client_derivable_pda(plan, field)?;
+            let derivation = field_derivation(plan, field, &mut Vec::new())?;
             let fn_ident = crate::client_macro::pda_address_fn(&field.ident);
-            let params: Vec<proc_macro2::TokenStream> = seeds
-                .iter()
-                .filter_map(|seed| match seed {
-                    DerivedSeed::AccountRef(base) => {
-                        Some(quote! { #base: &#krate::prelude::Address })
+            let roots = derivation_roots(plan, &derivation);
+            let params = roots.iter().map(|root| match root {
+                DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) => {
+                    quote! { #i: &#krate::prelude::Address }
+                }
+                DeriveRoot::ArgValue(i, ty) => quote! { #i: #ty },
+            });
+            // Chained derivations: materialize each directly-read derived
+            // field by calling its own fn with the shared root parameters.
+            let deps = direct_derived_deps(&derivation);
+            let lets = deps.iter().map(|dep| {
+                let dep_field = plan
+                    .fields
+                    .iter()
+                    .find(|other| other.ident == **dep)
+                    .expect("derived dep exists");
+                let dep_derivation = field_derivation(plan, dep_field, &mut Vec::new())
+                    .expect("derived dep re-resolves");
+                let dep_fn = crate::client_macro::pda_address_fn(dep);
+                let dep_args = derivation_roots(plan, &dep_derivation)
+                    .into_iter()
+                    .map(|root| {
+                        let ident = root.ident();
+                        quote! { #ident }
+                    });
+                quote! { let #dep = Self::#dep_fn(#(#dep_args,)* program_id); }
+            });
+            let tail = match &derivation {
+                FieldDerivation::Pda { account_ty, seeds } => {
+                    let args = seeds.iter().map(source_arg);
+                    quote! {
+                        let seeds = <#account_ty>::seeds(#(#args),*);
+                        #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
                     }
-                    DerivedSeed::ArgRef(name) => Some(quote! { #name: &#krate::prelude::Address }),
-                    DerivedSeed::ArgValue(name, ty) => Some(quote! { #name: #ty }),
-                    DerivedSeed::Const(_) => None,
-                })
-                .collect();
-            let args: Vec<proc_macro2::TokenStream> = seeds
-                .iter()
-                .map(|seed| match seed {
-                    DerivedSeed::AccountRef(base) => quote! { #base },
-                    DerivedSeed::ArgRef(name) => quote! { #name },
-                    DerivedSeed::ArgValue(name, _) => quote! { #name },
-                    DerivedSeed::Const(expr) => quote! { #expr },
-                })
-                .collect();
+                }
+                FieldDerivation::Ata {
+                    behavior_path,
+                    authority,
+                    mint,
+                    token_program,
+                } => {
+                    let authority = source_arg(authority);
+                    let mint = source_arg(mint);
+                    let token_program = match token_program {
+                        Some(field) => {
+                            let const_ident = crate::client_macro::fixed_address_const(field);
+                            quote! { Some(&Self::#const_ident) }
+                        }
+                        None => quote! { None },
+                    };
+                    quote! { #behavior_path::client_address(#authority, #mint, #token_program) }
+                }
+            };
+            // A leaf ATA never reads `program_id`; chained and PDA forms do.
+            let program_param =
+                if deps.is_empty() && matches!(derivation, FieldDerivation::Ata { .. }) {
+                    quote! { _program_id: &#krate::prelude::Address }
+                } else {
+                    quote! { program_id: &#krate::prelude::Address }
+                };
             Some(quote! {
                 #[doc(hidden)]
                 #[inline]
                 pub fn #fn_ident(
                     #(#params,)*
-                    program_id: &#krate::prelude::Address,
+                    #program_param,
                 ) -> #krate::prelude::Address {
-                    let seeds = <#account_ty>::seeds(#(#args),*);
-                    #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+                    #(#lets)*
+                    #tail
                 }
             })
         })
-        .chain(plan.fields.iter().filter_map(|field| {
-            let ata = crate::client_macro::client_derivable_ata(plan, field)?;
-            let fn_ident = crate::client_macro::pda_address_fn(&field.ident);
-            let path = ata.behavior_path;
-            let authority = ata.authority;
-            let mint = ata.mint;
-            let token_program = match ata.token_program {
-                Some(field) => {
-                    let const_ident = crate::client_macro::fixed_address_const(field);
-                    quote! { Some(&Self::#const_ident) }
-                }
-                None => quote! { None },
-            };
-            Some(quote! {
-                #[doc(hidden)]
-                #[inline]
-                pub fn #fn_ident(
-                    #authority: &#krate::prelude::Address,
-                    #mint: &#krate::prelude::Address,
-                    _program_id: &#krate::prelude::Address,
-                ) -> #krate::prelude::Address {
-                    #path::client_address(#authority, #mint, #token_program)
-                }
-            })
-        }))
         .collect();
     if fns.is_empty() {
         return quote! {};

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -313,6 +313,15 @@ fn emit_pda_address_fns(
         SeedSource::DerivedAccount(i) => quote! { &#i },
         SeedSource::ArgValue(i, _) => quote! { #i },
         SeedSource::Const(expr) => quote! { #expr },
+        SeedSource::FieldValue { .. } => unreachable!("FieldValue routes through find_address"),
+    };
+    // `find_address` takes every seed by value.
+    let owned_source_arg = |source: &SeedSource| match source {
+        SeedSource::PlainAccount(i) | SeedSource::ArgRef(i) => quote! { *#i },
+        SeedSource::DerivedAccount(i) => quote! { #i },
+        SeedSource::ArgValue(i, _) => quote! { #i },
+        SeedSource::FieldValue { input, .. } => quote! { #input },
+        SeedSource::Const(_) => unreachable!("Const excluded when FieldValue present"),
     };
     let fns: Vec<proc_macro2::TokenStream> = plan
         .fields
@@ -326,6 +335,7 @@ fn emit_pda_address_fns(
                     quote! { #i: &#krate::prelude::Address }
                 }
                 DeriveRoot::ArgValue(i, ty) => quote! { #i: #ty },
+                DeriveRoot::SeedInput { input, alias } => quote! { #input: #alias },
             });
             // Chained derivations: materialize each directly-read derived
             // field by calling its own fn with the shared root parameters.
@@ -349,10 +359,18 @@ fn emit_pda_address_fns(
             });
             let tail = match &derivation {
                 FieldDerivation::Pda { account_ty, seeds } => {
-                    let args = seeds.iter().map(source_arg);
-                    quote! {
-                        let seeds = <#account_ty>::seeds(#(#args),*);
-                        #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+                    if seeds
+                        .iter()
+                        .any(|seed| matches!(seed, SeedSource::FieldValue { .. }))
+                    {
+                        let args = seeds.iter().map(owned_source_arg);
+                        quote! { <#account_ty>::find_address(#(#args,)* program_id) }
+                    } else {
+                        let args = seeds.iter().map(source_arg);
+                        quote! {
+                            let seeds = <#account_ty>::seeds(#(#args),*);
+                            #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+                        }
                     }
                 }
                 FieldDerivation::Ata {

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -163,6 +163,20 @@ pub(crate) fn derive_accounts_inner(input: proc_macro2::TokenStream) -> proc_mac
         &ty_generics_ts,
         &where_clause_ts,
     );
+    let fixed_address_impl = emit_fixed_address_constants(
+        name,
+        &typed_plan,
+        &impl_generics_ts,
+        &ty_generics_ts,
+        &where_clause_ts,
+    );
+    let pda_address_impl = emit_pda_address_fns(
+        name,
+        &typed_plan,
+        &impl_generics_ts,
+        &ty_generics_ts,
+        &where_clause_ts,
+    );
 
     // IDL accounts meta fragment (feature-gated behind `idl-build`)
     let idl_accounts_meta = emit_idl_accounts_meta(name, &typed_plan);
@@ -209,6 +223,8 @@ pub(crate) fn derive_accounts_inner(input: proc_macro2::TokenStream) -> proc_mac
     quote::quote! {
         #main_output
         #signer_meta_impl
+        #fixed_address_impl
+        #pda_address_impl
         #idl_accounts_meta
         #idl_validation_meta
         #event_cpi_impl
@@ -236,6 +252,98 @@ fn emit_account_signer_constants(
         impl #impl_generics #name #ty_generics #where_clause {
             #[doc(hidden)]
             pub const __QUASAR_ACCOUNT_SIGNERS: [bool; #count] = [#(#signers),*];
+        }
+    }
+}
+
+/// Resolve `Program<T>`/`Sysvar<T>` canonical addresses where those types are
+/// in scope. The exported client macro reads them through the accounts type
+/// (same mechanism as `__QUASAR_ACCOUNT_SIGNERS`), so its instruction struct
+/// can drop the fields entirely.
+fn emit_fixed_address_constants(
+    name: &syn::Ident,
+    plan: &resolve::specs::AccountsPlanTyped,
+    impl_generics: &proc_macro2::TokenStream,
+    ty_generics: &proc_macro2::TokenStream,
+    where_clause: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let krate = crate::krate::lang_path();
+    let consts: Vec<proc_macro2::TokenStream> = plan
+        .fields
+        .iter()
+        .filter_map(|field| {
+            let expr = crate::client_macro::fixed_address_expr(field)?;
+            let ident = crate::client_macro::fixed_address_const(&field.ident);
+            Some(quote! {
+                #[doc(hidden)]
+                pub const #ident: #krate::prelude::Address = #expr;
+            })
+        })
+        .collect();
+    if consts.is_empty() {
+        return quote! {};
+    }
+    quote! {
+        #[allow(non_upper_case_globals)]
+        impl #impl_generics #name #ty_generics #where_clause {
+            #(#consts)*
+        }
+    }
+}
+
+/// Resolve typed-seeds PDA addresses where the seed types are in scope. The
+/// exported client macro calls these through the accounts type, so its
+/// instruction struct can drop every client-derivable PDA field.
+fn emit_pda_address_fns(
+    name: &syn::Ident,
+    plan: &resolve::specs::AccountsPlanTyped,
+    impl_generics: &proc_macro2::TokenStream,
+    ty_generics: &proc_macro2::TokenStream,
+    where_clause: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let krate = crate::krate::lang_path();
+    let fns: Vec<proc_macro2::TokenStream> = plan
+        .fields
+        .iter()
+        .filter_map(|field| {
+            let (account_ty, seeds) = crate::client_macro::client_derivable_pda(plan, field)?;
+            let fn_ident = crate::client_macro::pda_address_fn(&field.ident);
+            let params: Vec<proc_macro2::TokenStream> = seeds
+                .iter()
+                .filter_map(|seed| match seed {
+                    resolve::specs::IdlSeedPlan::AccountAddr { base } => {
+                        Some(quote! { #base: &#krate::prelude::Address })
+                    }
+                    _ => None,
+                })
+                .collect();
+            let args: Vec<proc_macro2::TokenStream> = seeds
+                .iter()
+                .map(|seed| match seed {
+                    resolve::specs::IdlSeedPlan::AccountAddr { base } => quote! { #base },
+                    resolve::specs::IdlSeedPlan::Const { expr } => quote! { #expr },
+                    _ => unreachable!("client_derivable_pda rejects other seed plans"),
+                })
+                .collect();
+            Some(quote! {
+                #[doc(hidden)]
+                #[inline]
+                pub fn #fn_ident(
+                    #(#params,)*
+                    program_id: &#krate::prelude::Address,
+                ) -> #krate::prelude::Address {
+                    let seeds = <#account_ty>::seeds(#(#args),*);
+                    #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+                }
+            })
+        })
+        .collect();
+    if fns.is_empty() {
+        return quote! {};
+    }
+    quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            #(#fns)*
         }
     }
 }

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -306,23 +306,27 @@ fn emit_pda_address_fns(
         .fields
         .iter()
         .filter_map(|field| {
+            use crate::client_macro::DerivedSeed;
             let (account_ty, seeds) = crate::client_macro::client_derivable_pda(plan, field)?;
             let fn_ident = crate::client_macro::pda_address_fn(&field.ident);
             let params: Vec<proc_macro2::TokenStream> = seeds
                 .iter()
                 .filter_map(|seed| match seed {
-                    resolve::specs::IdlSeedPlan::AccountAddr { base } => {
+                    DerivedSeed::AccountRef(base) => {
                         Some(quote! { #base: &#krate::prelude::Address })
                     }
-                    _ => None,
+                    DerivedSeed::ArgRef(name) => Some(quote! { #name: &#krate::prelude::Address }),
+                    DerivedSeed::ArgValue(name, ty) => Some(quote! { #name: #ty }),
+                    DerivedSeed::Const(_) => None,
                 })
                 .collect();
             let args: Vec<proc_macro2::TokenStream> = seeds
                 .iter()
                 .map(|seed| match seed {
-                    resolve::specs::IdlSeedPlan::AccountAddr { base } => quote! { #base },
-                    resolve::specs::IdlSeedPlan::Const { expr } => quote! { #expr },
-                    _ => unreachable!("client_derivable_pda rejects other seed plans"),
+                    DerivedSeed::AccountRef(base) => quote! { #base },
+                    DerivedSeed::ArgRef(name) => quote! { #name },
+                    DerivedSeed::ArgValue(name, _) => quote! { #name },
+                    DerivedSeed::Const(expr) => quote! { #expr },
                 })
                 .collect();
             Some(quote! {
@@ -337,6 +341,31 @@ fn emit_pda_address_fns(
                 }
             })
         })
+        .chain(plan.fields.iter().filter_map(|field| {
+            let ata = crate::client_macro::client_derivable_ata(plan, field)?;
+            let fn_ident = crate::client_macro::pda_address_fn(&field.ident);
+            let path = ata.behavior_path;
+            let authority = ata.authority;
+            let mint = ata.mint;
+            let token_program = match ata.token_program {
+                Some(field) => {
+                    let const_ident = crate::client_macro::fixed_address_const(field);
+                    quote! { Some(&Self::#const_ident) }
+                }
+                None => quote! { None },
+            };
+            Some(quote! {
+                #[doc(hidden)]
+                #[inline]
+                pub fn #fn_ident(
+                    #authority: &#krate::prelude::Address,
+                    #mint: &#krate::prelude::Address,
+                    _program_id: &#krate::prelude::Address,
+                ) -> #krate::prelude::Address {
+                    #path::client_address(#authority, #mint, #token_program)
+                }
+            })
+        }))
         .collect();
     if fns.is_empty() {
         return quote! {};

--- a/derive/src/accounts/resolve/lower.rs
+++ b/derive/src/accounts/resolve/lower.rs
@@ -342,6 +342,21 @@ fn resolve_seed_ref(expr: &Expr, scope: &SeedScope) -> SeedRef {
         }
     }
 
+    // `field.accessor()` — a no-arg zero-copy accessor reading stored data
+    // off an account field, equivalent to the `field.member` form below.
+    if let Expr::MethodCall(call) = expr {
+        if call.args.is_empty() && call.method != "address" {
+            if let Some(base) = single_ident(&call.receiver) {
+                if scope.field_with_inner.contains(&base.to_string()) {
+                    return SeedRef::AccountField {
+                        base,
+                        path: call.method.to_string(),
+                    };
+                }
+            }
+        }
+    }
+
     // `field.member` (possibly nested) read off an account field that carries an
     // inner type; without an inner type the IDL cannot name the account, so it
     // degrades to `Const` exactly as the old resolver did.

--- a/derive/src/accounts/resolve/planner.rs
+++ b/derive/src/accounts/resolve/planner.rs
@@ -317,11 +317,12 @@ fn plan_signer_helper(sem: &FieldSemantics) -> Option<SignerHelperPlan> {
         return None;
     }
     let addr = sem.address.as_ref()?;
-    if !matches!(addr.kind, AddressKind::Seeds { .. }) {
+    let AddressKind::Seeds { account_ty, .. } = &addr.kind else {
         return None;
-    }
+    };
     Some(SignerHelperPlan {
         addr_expr: addr.expr.clone(),
+        set_ty: account_ty.clone(),
     })
 }
 

--- a/derive/src/accounts/resolve/planner.rs
+++ b/derive/src/accounts/resolve/planner.rs
@@ -201,6 +201,7 @@ fn plan_field(
                     BehaviorArgValue::FieldRef(field) => Some(BehaviorIdlAccountArg {
                         key: arg.key.to_string(),
                         field: crate::helpers::snake_to_camel(&field.to_string()),
+                        field_ident: field.clone(),
                     }),
                     BehaviorArgValue::Some(_)
                     | BehaviorArgValue::None

--- a/derive/src/accounts/resolve/specs.rs
+++ b/derive/src/accounts/resolve/specs.rs
@@ -229,6 +229,9 @@ pub(crate) enum IdlSeedPlan {
 /// `FieldPlan::ident`.
 pub(crate) struct SignerHelperPlan {
     pub addr_expr: Expr,
+    /// The seeds-owning account type; the helper returns its concrete
+    /// `HasSeeds::WithBump` set so callers reach `signer_seeds`.
+    pub set_ty: Path,
 }
 
 /// Instruction-wide rent resolution.

--- a/derive/src/accounts/resolve/specs.rs
+++ b/derive/src/accounts/resolve/specs.rs
@@ -117,7 +117,10 @@ pub(crate) struct BehaviorGroupRef {
 
 pub(crate) struct BehaviorIdlAccountArg {
     pub key: String,
+    /// camelCase field name for IDL resolution.
     pub field: String,
+    /// The referenced field's original identifier, for client codegen.
+    pub field_ident: Ident,
 }
 
 /// Plain program account init (no behavior: system program create +

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -15,6 +15,9 @@ struct AccountDescriptor {
     /// accounts have exactly one canonical address, so the client fills it
     /// in and the instruction struct drops the field.
     fixed_address: Option<TokenStream>,
+    /// Synthetic typed inputs replacing a derived field whose seeds read
+    /// stored account data: `(input ident, definition-site type tokens)`.
+    seed_inputs: Vec<(syn::Ident, TokenStream)>,
 }
 
 pub fn generate_accounts_macro(
@@ -26,10 +29,29 @@ pub fn generate_accounts_macro(
     let descriptors = describe_accounts(name, generics, plan);
     let macro_name = format_ident!("__{}_instruction", pascal_to_snake(&name.to_string()));
     let module_name = format_ident!("__{}_client_macro", pascal_to_snake(&name.to_string()));
-    let account_fields: Vec<_> = descriptors.iter().map(emit_account_field).collect();
+    let account_fields: Vec<_> = descriptors
+        .iter()
+        .map(|descriptor| emit_account_field(name, descriptor))
+        .collect();
     let account_metas: Vec<_> = descriptors.iter().map(emit_account_meta).collect();
+    let seed_input_aliases: Vec<_> = descriptors
+        .iter()
+        .flat_map(|descriptor| {
+            descriptor.seed_inputs.iter().map(|(input, alias)| {
+                let realias = seed_input_realias(name, &descriptor.name, input);
+                quote! {
+                    #[doc(hidden)]
+                    #[allow(unexpected_cfgs)]
+                    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+                    pub type #realias = #alias;
+                }
+            })
+        })
+        .collect();
 
     quote! {
+        #(#seed_input_aliases)*
+
         #[doc(hidden)]
         #[allow(unexpected_cfgs)]
         mod #module_name {
@@ -171,13 +193,36 @@ pub fn generate_accounts_macro(
     }
 }
 
-fn emit_account_field(descriptor: &AccountDescriptor) -> TokenStream {
+fn emit_account_field(name: &syn::Ident, descriptor: &AccountDescriptor) -> TokenStream {
     if descriptor.fixed_address.is_some() {
-        return TokenStream::new();
+        // A derived field whose seeds read stored account data is replaced by
+        // typed inputs carrying those values (via definition-site re-aliases,
+        // so the type resolves inside the cpi module).
+        let inputs = descriptor.seed_inputs.iter().map(|(input, _)| {
+            let realias = seed_input_realias(name, &descriptor.name, input);
+            quote! { pub #input: #realias, }
+        });
+        return quote! { #(#inputs)* };
     }
     let krate = crate::krate::lang_path();
     let ident = &descriptor.name;
     quote! { pub #ident: #krate::prelude::Address, }
+}
+
+/// The definition-site re-alias for one synthetic seed input, scoped by the
+/// accounts struct so sibling structs with identical fields don't collide in
+/// the program module's glob imports.
+fn seed_input_realias(
+    accounts_struct: &syn::Ident,
+    field: &syn::Ident,
+    input: &syn::Ident,
+) -> syn::Ident {
+    format_ident!(
+        "__QuasarSeedInput{}{}{}",
+        accounts_struct,
+        crate::helpers::snake_to_camel(&field.to_string()),
+        crate::helpers::snake_to_camel(&input.to_string())
+    )
 }
 
 fn emit_account_meta(descriptor: &AccountDescriptor) -> TokenStream {
@@ -218,17 +263,27 @@ fn describe_accounts(
         .iter()
         .enumerate()
         .map(|(index, fp)| {
+            let mut seed_inputs: Vec<(syn::Ident, TokenStream)> = Vec::new();
             let fixed_address = if fixed_address_expr(fp).is_some() {
                 let const_ident = fixed_address_const(&fp.ident);
                 Some(quote! { #account_type::#const_ident })
             } else if let Some(derivation) = field_derivation(plan, fp, &mut Vec::new()) {
                 let fn_ident = pda_address_fn(&fp.ident);
-                let args = derivation_roots(plan, &derivation)
-                    .into_iter()
-                    .map(|root| match root {
-                        DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) => quote! { &ix.#i },
-                        DeriveRoot::ArgValue(i, _) => quote! { ix.#i },
-                    });
+                let roots = derivation_roots(plan, &derivation);
+                seed_inputs = roots
+                    .iter()
+                    .filter_map(|root| match root {
+                        DeriveRoot::SeedInput { input, alias } => {
+                            Some((input.clone(), alias.clone()))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let args = roots.iter().map(|root| match root {
+                    DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) => quote! { &ix.#i },
+                    DeriveRoot::ArgValue(i, _) => quote! { ix.#i },
+                    DeriveRoot::SeedInput { input, .. } => quote! { ix.#input },
+                });
                 Some(quote! { #account_type::#fn_ident(#(#args,)* &$crate::ID) })
             } else {
                 None
@@ -243,6 +298,7 @@ fn describe_accounts(
                     quote! { #signer }
                 },
                 fixed_address,
+                seed_inputs,
             }
         })
         .collect()
@@ -261,6 +317,16 @@ pub(crate) enum SeedSource<'p> {
     ArgValue(&'p syn::Ident, &'p syn::Type),
     /// A constant expression, resolvable at the definition site.
     Const(&'p syn::Expr),
+    /// A value read from another account's stored data on-chain; the client
+    /// takes it as a typed input field and derives with it (the same
+    /// convention as the standalone IDL clients).
+    FieldValue {
+        /// The synthetic instruction-struct input, `{base}_{path}_seed`.
+        input: syn::Ident,
+        /// Type tokens naming the parameter's owned form through
+        /// `SeedParam<INDEX>`, valid wherever the account type resolves.
+        alias: TokenStream,
+    },
 }
 
 /// A field's client-side address derivation, when one exists.
@@ -300,7 +366,7 @@ pub(crate) fn field_derivation<'p>(
     let derivation = (|| {
         if let Some(IdlResolverPlan::Pda { account_ty, seeds }) = fp.idl_resolver.as_ref() {
             let mut classified = Vec::with_capacity(seeds.len());
-            for seed in seeds {
+            for (index, seed) in seeds.iter().enumerate() {
                 classified.push(match seed {
                     IdlSeedPlan::AccountAddr { base } => account_source(plan, base, stack)?,
                     IdlSeedPlan::Const { expr } => SeedSource::Const(expr),
@@ -313,8 +379,23 @@ pub(crate) fn field_derivation<'p>(
                             return None;
                         }
                     }
-                    IdlSeedPlan::AccountField { .. } => return None,
+                    IdlSeedPlan::AccountField { base, field, .. } => SeedSource::FieldValue {
+                        input: seed_input_ident(base, field),
+                        alias: seed_alias_path(account_ty, index),
+                    },
                 });
+            }
+            // `find_address` (the owned-value path FieldValue requires) cannot
+            // take a Const expr of unknown ownedness.
+            let has_field_value = classified
+                .iter()
+                .any(|seed| matches!(seed, SeedSource::FieldValue { .. }));
+            if has_field_value
+                && classified
+                    .iter()
+                    .any(|seed| matches!(seed, SeedSource::Const(_)))
+            {
+                return None;
             }
             return Some(FieldDerivation::Pda {
                 account_ty,
@@ -359,6 +440,22 @@ pub(crate) fn field_derivation<'p>(
     derivation
 }
 
+/// The synthetic client input carrying a stored-data seed value.
+fn seed_input_ident(base: &syn::Ident, path: &str) -> syn::Ident {
+    let sanitized: String = path
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect();
+    format_ident!("{}_{}_seed", base, sanitized)
+}
+
+/// The owned seed-parameter type, named through the `SeedParam` trait so it
+/// resolves wherever the account type does.
+fn seed_alias_path(account_ty: &syn::Path, index: usize) -> TokenStream {
+    let krate = crate::krate::lang_path();
+    quote! { <#account_ty as #krate::traits::SeedParam<#index>>::Ty }
+}
+
 fn find_field<'p>(
     plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
     ident: &syn::Ident,
@@ -389,12 +486,18 @@ pub(crate) enum DeriveRoot<'p> {
     Account(&'p syn::Ident),
     ArgRef(&'p syn::Ident),
     ArgValue(&'p syn::Ident, &'p syn::Type),
+    /// A stored-data seed value: a synthetic owned input field.
+    SeedInput {
+        input: syn::Ident,
+        alias: TokenStream,
+    },
 }
 
 impl<'p> DeriveRoot<'p> {
-    pub(crate) fn ident(&self) -> &'p syn::Ident {
+    pub(crate) fn ident(&self) -> &syn::Ident {
         match self {
             DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) | DeriveRoot::ArgValue(i, _) => i,
+            DeriveRoot::SeedInput { input, .. } => input,
         }
     }
 }
@@ -434,6 +537,14 @@ fn collect_roots<'p>(
             let nested =
                 field_derivation(plan, field, &mut Vec::new()).expect("derived field re-resolves");
             collect_roots(plan, &nested, roots);
+        }
+        SeedSource::FieldValue { input, alias } => {
+            if !roots.iter().any(|seen| seen.ident() == input) {
+                roots.push(DeriveRoot::SeedInput {
+                    input: input.clone(),
+                    alias: alias.clone(),
+                });
+            }
         }
         SeedSource::Const(_) => {}
     };

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -11,6 +11,10 @@ struct AccountDescriptor {
     name: syn::Ident,
     writable: bool,
     signer: TokenStream,
+    /// Const address expression for `Program<T>`/`Sysvar<T>` fields. These
+    /// accounts have exactly one canonical address, so the client fills it
+    /// in and the instruction struct drops the field.
+    fixed_address: Option<TokenStream>,
 }
 
 pub fn generate_accounts_macro(
@@ -39,6 +43,7 @@ pub fn generate_accounts_macro(
                 }
 
                 impl From<$struct_name> for #krate::client::Instruction {
+                    #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
                         let accounts = ::alloc::vec![
                             #(#account_metas)*
@@ -67,6 +72,7 @@ pub fn generate_accounts_macro(
                 }
 
                 impl From<$struct_name> for #krate::client::Instruction {
+                    #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
                         let accounts = ::alloc::vec![
                             #(#account_metas)*
@@ -101,6 +107,7 @@ pub fn generate_accounts_macro(
                 }
 
                 impl From<$struct_name> for #krate::client::Instruction {
+                    #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
                         let mut accounts = ::alloc::vec![
                             #(#account_metas)*
@@ -131,6 +138,7 @@ pub fn generate_accounts_macro(
                 }
 
                 impl From<$struct_name> for #krate::client::Instruction {
+                    #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
                         let mut accounts = ::alloc::vec![
                             #(#account_metas)*
@@ -164,6 +172,9 @@ pub fn generate_accounts_macro(
 }
 
 fn emit_account_field(descriptor: &AccountDescriptor) -> TokenStream {
+    if descriptor.fixed_address.is_some() {
+        return TokenStream::new();
+    }
     let krate = crate::krate::lang_path();
     let ident = &descriptor.name;
     quote! { pub #ident: #krate::prelude::Address, }
@@ -173,13 +184,17 @@ fn emit_account_meta(descriptor: &AccountDescriptor) -> TokenStream {
     let krate = crate::krate::lang_path();
     let ident = &descriptor.name;
     let signer = &descriptor.signer;
+    let address = match &descriptor.fixed_address {
+        Some(fixed) => fixed.clone(),
+        None => quote! { ix.#ident },
+    };
     if descriptor.writable {
         quote! {
-            #krate::client::AccountMeta::new(ix.#ident, #signer),
+            #krate::client::AccountMeta::new(#address, #signer),
         }
     } else {
         quote! {
-            #krate::client::AccountMeta::new_readonly(ix.#ident, #signer),
+            #krate::client::AccountMeta::new_readonly(#address, #signer),
         }
     }
 }
@@ -190,24 +205,99 @@ fn describe_accounts(
     plan: &crate::accounts::resolve::specs::AccountsPlanTyped,
 ) -> Vec<AccountDescriptor> {
     let static_lifetimes = generics.lifetimes().map(|_| quote! { 'static });
+    // The macro only expands inside the generated `cpi` module, whose parent
+    // is the `#[program]` module. `super::` reaches the accounts struct even
+    // when a client struct in `cpi` shadows its name.
     let account_type = if generics.lifetimes().next().is_some() {
-        quote! { #name::<#(#static_lifetimes),*> }
+        quote! { super::#name::<#(#static_lifetimes),*> }
     } else {
-        quote! { #name }
+        quote! { super::#name }
     };
 
     plan.fields
         .iter()
         .enumerate()
-        .map(|(index, fp)| AccountDescriptor {
-            name: fp.ident.clone(),
-            writable: fp.writable,
-            signer: if fp.behavior_init_signer {
-                quote! { #account_type::__QUASAR_ACCOUNT_SIGNERS[#index] }
+        .map(|(index, fp)| {
+            let fixed_address = if fixed_address_expr(fp).is_some() {
+                let const_ident = fixed_address_const(&fp.ident);
+                Some(quote! { #account_type::#const_ident })
+            } else if let Some((_, seeds)) = client_derivable_pda(plan, fp) {
+                let fn_ident = pda_address_fn(&fp.ident);
+                let args = seeds.iter().filter_map(|seed| match seed {
+                    crate::accounts::resolve::specs::IdlSeedPlan::AccountAddr { base } => {
+                        Some(quote! { &ix.#base })
+                    }
+                    _ => None,
+                });
+                Some(quote! { #account_type::#fn_ident(#(#args,)* &$crate::ID) })
             } else {
-                let signer = fp.signer;
-                quote! { #signer }
-            },
+                None
+            };
+            AccountDescriptor {
+                name: fp.ident.clone(),
+                writable: fp.writable,
+                signer: if fp.behavior_init_signer {
+                    quote! { #account_type::__QUASAR_ACCOUNT_SIGNERS[#index] }
+                } else {
+                    let signer = fp.signer;
+                    quote! { #signer }
+                },
+                fixed_address,
+            }
         })
         .collect()
+}
+
+/// A PDA field the client can derive: every seed is either the address of a
+/// plain (non-derived) account field or a constant expression.
+pub(crate) fn client_derivable_pda<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    fp: &'p crate::accounts::resolve::specs::FieldPlan,
+) -> Option<(
+    &'p syn::Path,
+    &'p [crate::accounts::resolve::specs::IdlSeedPlan],
+)> {
+    use crate::accounts::resolve::specs::{IdlResolverPlan, IdlSeedPlan};
+    let IdlResolverPlan::Pda { account_ty, seeds } = fp.idl_resolver.as_ref()? else {
+        return None;
+    };
+    let plain_field = |base: &syn::Ident| {
+        plan.fields.iter().any(|other| {
+            other.ident == *base
+                && fixed_address_expr(other).is_none()
+                && !matches!(other.idl_resolver, Some(IdlResolverPlan::Pda { .. }))
+        })
+    };
+    let derivable = seeds.iter().all(|seed| match seed {
+        IdlSeedPlan::AccountAddr { base } => plain_field(base),
+        IdlSeedPlan::Const { .. } => true,
+        IdlSeedPlan::AccountField { .. } | IdlSeedPlan::IxArg { .. } => false,
+    });
+    derivable.then_some((account_ty, seeds.as_slice()))
+}
+
+/// The hidden associated fn deriving one PDA field's address.
+pub(crate) fn pda_address_fn(field: &syn::Ident) -> syn::Ident {
+    format_ident!("__quasar_pda_{}", field)
+}
+
+/// The canonical-address expression for a `Program<T>`/`Sysvar<T>` field,
+/// valid where the accounts struct (and `T`) is in scope.
+pub(crate) fn fixed_address_expr(
+    fp: &crate::accounts::resolve::specs::FieldPlan,
+) -> Option<TokenStream> {
+    use crate::accounts::resolve::specs::{FixedAddressSource, IdlResolverPlan};
+    let krate = crate::krate::lang_path();
+    match fp.idl_resolver.as_ref()? {
+        IdlResolverPlan::FixedAddress { inner_ty, source } => Some(match source {
+            FixedAddressSource::Program => quote! { <#inner_ty as #krate::traits::Id>::ID },
+            FixedAddressSource::Sysvar => quote! { <#inner_ty as #krate::sysvars::Sysvar>::ID },
+        }),
+        IdlResolverPlan::Pda { .. } => None,
+    }
+}
+
+/// The hidden associated const carrying one field's canonical address.
+pub(crate) fn fixed_address_const(field: &syn::Ident) -> syn::Ident {
+    format_ident!("__QUASAR_FIXED_ADDRESS_{}", field)
 }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -357,8 +357,19 @@ pub(crate) enum FieldDerivation<'p> {
         behavior_path: &'p syn::Path,
         authority: SeedSource<'p>,
         mint: SeedSource<'p>,
-        token_program: Option<&'p syn::Ident>,
+        token_program: BehaviorProgramArg<'p>,
     },
+}
+
+/// Where an ATA derivation's token program comes from.
+pub(crate) enum BehaviorProgramArg<'p> {
+    /// A `Program<T>` field: its canonical const.
+    Fixed(&'p syn::Ident),
+    /// A plain field (e.g. `Interface<TokenInterface>`): the caller-supplied
+    /// value, read off the instruction struct at build time.
+    Field(&'p syn::Ident),
+    /// No mapping: the behavior's default (SPL Token).
+    Default,
 }
 
 pub(crate) fn field_derivation<'p>(
@@ -430,12 +441,20 @@ pub(crate) fn field_derivation<'p>(
             Some(field)
                 if find_field(plan, field).is_some_and(|f| fixed_address_expr(f).is_some()) =>
             {
-                Some(field)
+                BehaviorProgramArg::Fixed(field)
             }
-            // An explicit token program the client cannot resolve statically
-            // (e.g. an interface field) keeps the ATA field.
+            // An interface or otherwise caller-chosen token program stays an
+            // input field; the derivation reads its value at build time.
+            Some(field)
+                if matches!(
+                    account_source(plan, field, stack)?,
+                    SeedSource::PlainAccount(_)
+                ) =>
+            {
+                BehaviorProgramArg::Field(field)
+            }
             Some(_) => return None,
-            None => None,
+            None => BehaviorProgramArg::Default,
         };
         Some(FieldDerivation::Ata {
             behavior_path: &group.path,
@@ -563,10 +582,18 @@ fn collect_roots<'p>(
             }
         }
         FieldDerivation::Ata {
-            authority, mint, ..
+            authority,
+            mint,
+            token_program,
+            ..
         } => {
             source(authority, roots);
             source(mint, roots);
+            if let BehaviorProgramArg::Field(ident) = token_program {
+                if !roots.iter().any(|seen| seen.ident() == *ident) {
+                    roots.push(DeriveRoot::Account(ident));
+                }
+            }
         }
     }
 }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -224,12 +224,17 @@ fn describe_accounts(
             } else if let Some((_, seeds)) = client_derivable_pda(plan, fp) {
                 let fn_ident = pda_address_fn(&fp.ident);
                 let args = seeds.iter().filter_map(|seed| match seed {
-                    crate::accounts::resolve::specs::IdlSeedPlan::AccountAddr { base } => {
-                        Some(quote! { &ix.#base })
-                    }
-                    _ => None,
+                    DerivedSeed::AccountRef(base) => Some(quote! { &ix.#base }),
+                    DerivedSeed::ArgRef(name) => Some(quote! { &ix.#name }),
+                    DerivedSeed::ArgValue(name, _) => Some(quote! { ix.#name }),
+                    DerivedSeed::Const(_) => None,
                 });
                 Some(quote! { #account_type::#fn_ident(#(#args,)* &$crate::ID) })
+            } else if let Some(ata) = client_derivable_ata(plan, fp) {
+                let fn_ident = pda_address_fn(&fp.ident);
+                let authority = ata.authority;
+                let mint = ata.mint;
+                Some(quote! { #account_type::#fn_ident(&ix.#authority, &ix.#mint, &$crate::ID) })
             } else {
                 None
             };
@@ -253,10 +258,7 @@ fn describe_accounts(
 pub(crate) fn client_derivable_pda<'p>(
     plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
     fp: &'p crate::accounts::resolve::specs::FieldPlan,
-) -> Option<(
-    &'p syn::Path,
-    &'p [crate::accounts::resolve::specs::IdlSeedPlan],
-)> {
+) -> Option<(&'p syn::Path, Vec<DerivedSeed<'p>>)> {
     use crate::accounts::resolve::specs::{IdlResolverPlan, IdlSeedPlan};
     let IdlResolverPlan::Pda { account_ty, seeds } = fp.idl_resolver.as_ref()? else {
         return None;
@@ -268,17 +270,121 @@ pub(crate) fn client_derivable_pda<'p>(
                 && !matches!(other.idl_resolver, Some(IdlResolverPlan::Pda { .. }))
         })
     };
-    let derivable = seeds.iter().all(|seed| match seed {
-        IdlSeedPlan::AccountAddr { base } => plain_field(base),
-        IdlSeedPlan::Const { .. } => true,
-        IdlSeedPlan::AccountField { .. } | IdlSeedPlan::IxArg { .. } => false,
-    });
-    derivable.then_some((account_ty, seeds.as_slice()))
+    let mut classified = Vec::with_capacity(seeds.len());
+    for seed in seeds {
+        classified.push(match seed {
+            IdlSeedPlan::AccountAddr { base } if plain_field(base) => DerivedSeed::AccountRef(base),
+            IdlSeedPlan::Const { expr } => DerivedSeed::Const(expr),
+            IdlSeedPlan::IxArg { name, ty } => {
+                if is_address_type(ty) {
+                    DerivedSeed::ArgRef(name)
+                } else if is_value_seed_type(ty) {
+                    DerivedSeed::ArgValue(name, ty)
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        });
+    }
+    Some((account_ty, classified))
+}
+
+/// One client-resolvable seed of a derived PDA field.
+pub(crate) enum DerivedSeed<'p> {
+    /// The address of another (plain) account field: passed as `&ix.base`.
+    AccountRef(&'p syn::Ident),
+    /// An `Address`-typed instruction arg: passed as `&ix.name`.
+    ArgRef(&'p syn::Ident),
+    /// A by-value primitive instruction arg: passed as `ix.name`.
+    ArgValue(&'p syn::Ident, &'p syn::Type),
+    /// A constant expression, baked in at the definition site.
+    Const(&'p syn::Expr),
+}
+
+fn is_address_type(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Path(p) if p.path.is_ident("Address"))
+}
+
+/// Seed arg types `T::seeds` takes by value: the integer set and `[u8; N]`.
+fn is_value_seed_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(p) => ["u8", "u16", "u32", "u64"]
+            .iter()
+            .any(|name| p.path.is_ident(name)),
+        syn::Type::Array(array) => {
+            matches!(array.elem.as_ref(), syn::Type::Path(p) if p.path.is_ident("u8"))
+        }
+        _ => false,
+    }
 }
 
 /// The hidden associated fn deriving one PDA field's address.
 pub(crate) fn pda_address_fn(field: &syn::Ident) -> syn::Ident {
     format_ident!("__quasar_pda_{}", field)
+}
+
+/// A client-derivable associated token account field.
+///
+/// The derive stays protocol-neutral on-chain; this is a client-codegen
+/// convention: a behavior group whose path ends in `associated_token` and
+/// maps `authority` + `mint` to plain account fields derives the address
+/// through the behavior module's `client_address` fn. `token_program` joins
+/// when it maps to a `Program<T>` field (its canonical const), and defaults
+/// inside the behavior otherwise.
+pub(crate) struct DerivableAta<'p> {
+    pub behavior_path: &'p syn::Path,
+    pub authority: &'p syn::Ident,
+    pub mint: &'p syn::Ident,
+    pub token_program: Option<&'p syn::Ident>,
+}
+
+pub(crate) fn client_derivable_ata<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    fp: &'p crate::accounts::resolve::specs::FieldPlan,
+) -> Option<DerivableAta<'p>> {
+    use crate::accounts::resolve::specs::IdlResolverPlan;
+    if fp.idl_resolver.is_some() {
+        return None;
+    }
+    let group = fp
+        .behaviors
+        .iter()
+        .find(|group| group.name.ends_with("associated_token"))?;
+    let arg = |key: &str| {
+        group
+            .idl_account_args
+            .iter()
+            .find(|arg| arg.key == key)
+            .map(|arg| &arg.field_ident)
+    };
+    let plain_field = |ident: &syn::Ident| {
+        plan.fields.iter().any(|other| {
+            other.ident == *ident
+                && fixed_address_expr(other).is_none()
+                && !matches!(other.idl_resolver, Some(IdlResolverPlan::Pda { .. }))
+        })
+    };
+    let fixed_field = |ident: &syn::Ident| {
+        plan.fields
+            .iter()
+            .any(|other| other.ident == *ident && fixed_address_expr(other).is_some())
+    };
+    let authority = arg("authority").filter(|f| plain_field(f))?;
+    let mint = arg("mint").filter(|f| plain_field(f))?;
+    let token_program = match arg("token_program") {
+        Some(field) if fixed_field(field) => Some(field),
+        // An explicit token program the client cannot resolve statically
+        // (e.g. an interface field) keeps the ATA field.
+        Some(_) => return None,
+        None => None,
+    };
+    Some(DerivableAta {
+        behavior_path: &group.path,
+        authority,
+        mint,
+        token_program,
+    })
 }
 
 /// The canonical-address expression for a `Program<T>`/`Sysvar<T>` field,

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -29,6 +29,19 @@ pub fn generate_accounts_macro(
     let descriptors = describe_accounts(name, generics, plan);
     let macro_name = format_ident!("__{}_instruction", pascal_to_snake(&name.to_string()));
     let module_name = format_ident!("__{}_client_macro", pascal_to_snake(&name.to_string()));
+    // Two derived fields may share a stored-data seed root (a chained field
+    // inherits its base's inputs); the input appears once, at first use.
+    let mut seen_inputs: Vec<syn::Ident> = Vec::new();
+    let mut descriptors = descriptors;
+    for descriptor in &mut descriptors {
+        descriptor
+            .seed_inputs
+            .retain(|(input, _)| !seen_inputs.contains(input));
+        for (input, _) in &descriptor.seed_inputs {
+            seen_inputs.push(input.clone());
+        }
+    }
+    let descriptors = descriptors;
     let account_fields: Vec<_> = descriptors
         .iter()
         .map(|descriptor| emit_account_field(name, descriptor))
@@ -38,7 +51,7 @@ pub fn generate_accounts_macro(
         .iter()
         .flat_map(|descriptor| {
             descriptor.seed_inputs.iter().map(|(input, alias)| {
-                let realias = seed_input_realias(name, &descriptor.name, input);
+                let realias = seed_input_realias(name, input);
                 quote! {
                     #[doc(hidden)]
                     #[allow(unexpected_cfgs)]
@@ -199,7 +212,7 @@ fn emit_account_field(name: &syn::Ident, descriptor: &AccountDescriptor) -> Toke
         // typed inputs carrying those values (via definition-site re-aliases,
         // so the type resolves inside the cpi module).
         let inputs = descriptor.seed_inputs.iter().map(|(input, _)| {
-            let realias = seed_input_realias(name, &descriptor.name, input);
+            let realias = seed_input_realias(name, input);
             quote! { pub #input: #realias, }
         });
         return quote! { #(#inputs)* };
@@ -212,15 +225,10 @@ fn emit_account_field(name: &syn::Ident, descriptor: &AccountDescriptor) -> Toke
 /// The definition-site re-alias for one synthetic seed input, scoped by the
 /// accounts struct so sibling structs with identical fields don't collide in
 /// the program module's glob imports.
-fn seed_input_realias(
-    accounts_struct: &syn::Ident,
-    field: &syn::Ident,
-    input: &syn::Ident,
-) -> syn::Ident {
+fn seed_input_realias(accounts_struct: &syn::Ident, input: &syn::Ident) -> syn::Ident {
     format_ident!(
-        "__QuasarSeedInput{}{}{}",
+        "__QuasarSeedInput{}{}",
         accounts_struct,
-        crate::helpers::snake_to_camel(&field.to_string()),
         crate::helpers::snake_to_camel(&input.to_string())
     )
 }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -428,12 +428,20 @@ pub(crate) fn field_derivation<'p>(
             .behaviors
             .iter()
             .find(|group| group.name.ends_with("associated_token"))?;
+        // An unmapped behavior arg resolves to the same-named account field
+        // (mirroring the runtime init inference).
         let arg = |key: &str| {
             group
                 .idl_account_args
                 .iter()
                 .find(|arg| arg.key == key)
                 .map(|arg| &arg.field_ident)
+                .or_else(|| {
+                    plan.fields
+                        .iter()
+                        .find(|field| field.ident == key)
+                        .map(|field| &field.ident)
+                })
         };
         let authority = account_source(plan, arg("authority")?, stack)?;
         let mint = account_source(plan, arg("mint")?, stack)?;

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -221,20 +221,15 @@ fn describe_accounts(
             let fixed_address = if fixed_address_expr(fp).is_some() {
                 let const_ident = fixed_address_const(&fp.ident);
                 Some(quote! { #account_type::#const_ident })
-            } else if let Some((_, seeds)) = client_derivable_pda(plan, fp) {
+            } else if let Some(derivation) = field_derivation(plan, fp, &mut Vec::new()) {
                 let fn_ident = pda_address_fn(&fp.ident);
-                let args = seeds.iter().filter_map(|seed| match seed {
-                    DerivedSeed::AccountRef(base) => Some(quote! { &ix.#base }),
-                    DerivedSeed::ArgRef(name) => Some(quote! { &ix.#name }),
-                    DerivedSeed::ArgValue(name, _) => Some(quote! { ix.#name }),
-                    DerivedSeed::Const(_) => None,
-                });
+                let args = derivation_roots(plan, &derivation)
+                    .into_iter()
+                    .map(|root| match root {
+                        DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) => quote! { &ix.#i },
+                        DeriveRoot::ArgValue(i, _) => quote! { ix.#i },
+                    });
                 Some(quote! { #account_type::#fn_ident(#(#args,)* &$crate::ID) })
-            } else if let Some(ata) = client_derivable_ata(plan, fp) {
-                let fn_ident = pda_address_fn(&fp.ident);
-                let authority = ata.authority;
-                let mint = ata.mint;
-                Some(quote! { #account_type::#fn_ident(&ix.#authority, &ix.#mint, &$crate::ID) })
             } else {
                 None
             };
@@ -253,53 +248,230 @@ fn describe_accounts(
         .collect()
 }
 
-/// A PDA field the client can derive: every seed is either the address of a
-/// plain (non-derived) account field or a constant expression.
-pub(crate) fn client_derivable_pda<'p>(
-    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
-    fp: &'p crate::accounts::resolve::specs::FieldPlan,
-) -> Option<(&'p syn::Path, Vec<DerivedSeed<'p>>)> {
-    use crate::accounts::resolve::specs::{IdlResolverPlan, IdlSeedPlan};
-    let IdlResolverPlan::Pda { account_ty, seeds } = fp.idl_resolver.as_ref()? else {
-        return None;
-    };
-    let plain_field = |base: &syn::Ident| {
-        plan.fields.iter().any(|other| {
-            other.ident == *base
-                && fixed_address_expr(other).is_none()
-                && !matches!(other.idl_resolver, Some(IdlResolverPlan::Pda { .. }))
-        })
-    };
-    let mut classified = Vec::with_capacity(seeds.len());
-    for seed in seeds {
-        classified.push(match seed {
-            IdlSeedPlan::AccountAddr { base } if plain_field(base) => DerivedSeed::AccountRef(base),
-            IdlSeedPlan::Const { expr } => DerivedSeed::Const(expr),
-            IdlSeedPlan::IxArg { name, ty } => {
-                if is_address_type(ty) {
-                    DerivedSeed::ArgRef(name)
-                } else if is_value_seed_type(ty) {
-                    DerivedSeed::ArgValue(name, ty)
-                } else {
-                    return None;
-                }
-            }
-            _ => return None,
-        });
-    }
-    Some((account_ty, classified))
+/// How one input to a client-side address derivation resolves.
+pub(crate) enum SeedSource<'p> {
+    /// A plain account field that stays in the instruction struct: a
+    /// `&Address` fn parameter, `&ix.field` at the call site.
+    PlainAccount(&'p syn::Ident),
+    /// Another derived field: a `let` local inside the derivation fn.
+    DerivedAccount(&'p syn::Ident),
+    /// An `Address`-typed instruction arg: `&Address` parameter, `&ix.name`.
+    ArgRef(&'p syn::Ident),
+    /// A by-value primitive instruction arg: `ty` parameter, `ix.name`.
+    ArgValue(&'p syn::Ident, &'p syn::Type),
+    /// A constant expression, resolvable at the definition site.
+    Const(&'p syn::Expr),
 }
 
-/// One client-resolvable seed of a derived PDA field.
-pub(crate) enum DerivedSeed<'p> {
-    /// The address of another (plain) account field: passed as `&ix.base`.
-    AccountRef(&'p syn::Ident),
-    /// An `Address`-typed instruction arg: passed as `&ix.name`.
+/// A field's client-side address derivation, when one exists.
+///
+/// The derive stays protocol-neutral on-chain; both forms are client-codegen
+/// conventions. Typed-seeds PDAs derive from `address = T::seeds(..)`.
+/// Associated token accounts derive when a behavior group whose path ends in
+/// `associated_token` maps `authority` + `mint` to resolvable fields, through
+/// the behavior module's `client_address` fn; `token_program` joins when it
+/// maps to a `Program<T>` field (its canonical const) and defaults inside the
+/// behavior otherwise. Derivations chain: a seed may itself be a derived
+/// field, so `vault` seeded by the derived `config` still resolves down to
+/// `config`'s own plain roots.
+pub(crate) enum FieldDerivation<'p> {
+    Pda {
+        account_ty: &'p syn::Path,
+        seeds: Vec<SeedSource<'p>>,
+    },
+    Ata {
+        behavior_path: &'p syn::Path,
+        authority: SeedSource<'p>,
+        mint: SeedSource<'p>,
+        token_program: Option<&'p syn::Ident>,
+    },
+}
+
+pub(crate) fn field_derivation<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    fp: &'p crate::accounts::resolve::specs::FieldPlan,
+    stack: &mut Vec<syn::Ident>,
+) -> Option<FieldDerivation<'p>> {
+    use crate::accounts::resolve::specs::{IdlResolverPlan, IdlSeedPlan};
+    if stack.contains(&fp.ident) {
+        return None;
+    }
+    stack.push(fp.ident.clone());
+    let derivation = (|| {
+        if let Some(IdlResolverPlan::Pda { account_ty, seeds }) = fp.idl_resolver.as_ref() {
+            let mut classified = Vec::with_capacity(seeds.len());
+            for seed in seeds {
+                classified.push(match seed {
+                    IdlSeedPlan::AccountAddr { base } => account_source(plan, base, stack)?,
+                    IdlSeedPlan::Const { expr } => SeedSource::Const(expr),
+                    IdlSeedPlan::IxArg { name, ty } => {
+                        if is_address_type(ty) {
+                            SeedSource::ArgRef(name)
+                        } else if is_value_seed_type(ty) {
+                            SeedSource::ArgValue(name, ty)
+                        } else {
+                            return None;
+                        }
+                    }
+                    IdlSeedPlan::AccountField { .. } => return None,
+                });
+            }
+            return Some(FieldDerivation::Pda {
+                account_ty,
+                seeds: classified,
+            });
+        }
+        if fp.idl_resolver.is_some() {
+            return None;
+        }
+        let group = fp
+            .behaviors
+            .iter()
+            .find(|group| group.name.ends_with("associated_token"))?;
+        let arg = |key: &str| {
+            group
+                .idl_account_args
+                .iter()
+                .find(|arg| arg.key == key)
+                .map(|arg| &arg.field_ident)
+        };
+        let authority = account_source(plan, arg("authority")?, stack)?;
+        let mint = account_source(plan, arg("mint")?, stack)?;
+        let token_program = match arg("token_program") {
+            Some(field)
+                if find_field(plan, field).is_some_and(|f| fixed_address_expr(f).is_some()) =>
+            {
+                Some(field)
+            }
+            // An explicit token program the client cannot resolve statically
+            // (e.g. an interface field) keeps the ATA field.
+            Some(_) => return None,
+            None => None,
+        };
+        Some(FieldDerivation::Ata {
+            behavior_path: &group.path,
+            authority,
+            mint,
+            token_program,
+        })
+    })();
+    stack.pop();
+    derivation
+}
+
+fn find_field<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    ident: &syn::Ident,
+) -> Option<&'p crate::accounts::resolve::specs::FieldPlan> {
+    plan.fields.iter().find(|field| field.ident == *ident)
+}
+
+/// Resolve an account-field reference used as a derivation input.
+fn account_source<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    ident: &'p syn::Ident,
+    stack: &mut Vec<syn::Ident>,
+) -> Option<SeedSource<'p>> {
+    let field = find_field(plan, ident)?;
+    if fixed_address_expr(field).is_some() {
+        return None;
+    }
+    if field_derivation(plan, field, stack).is_some() {
+        return Some(SeedSource::DerivedAccount(ident));
+    }
+    Some(SeedSource::PlainAccount(ident))
+}
+
+/// A derivation's transitive inputs: the fn parameters at the definition
+/// site and the `ix.*` arguments at the call site, deduplicated in
+/// first-use order.
+pub(crate) enum DeriveRoot<'p> {
+    Account(&'p syn::Ident),
     ArgRef(&'p syn::Ident),
-    /// A by-value primitive instruction arg: passed as `ix.name`.
     ArgValue(&'p syn::Ident, &'p syn::Type),
-    /// A constant expression, baked in at the definition site.
-    Const(&'p syn::Expr),
+}
+
+impl<'p> DeriveRoot<'p> {
+    pub(crate) fn ident(&self) -> &'p syn::Ident {
+        match self {
+            DeriveRoot::Account(i) | DeriveRoot::ArgRef(i) | DeriveRoot::ArgValue(i, _) => i,
+        }
+    }
+}
+
+pub(crate) fn derivation_roots<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    derivation: &FieldDerivation<'p>,
+) -> Vec<DeriveRoot<'p>> {
+    let mut roots: Vec<DeriveRoot<'p>> = Vec::new();
+    collect_roots(plan, derivation, &mut roots);
+    roots
+}
+
+fn collect_roots<'p>(
+    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
+    derivation: &FieldDerivation<'p>,
+    roots: &mut Vec<DeriveRoot<'p>>,
+) {
+    let source = |source: &SeedSource<'p>, roots: &mut Vec<DeriveRoot<'p>>| match source {
+        SeedSource::PlainAccount(ident) => {
+            if !roots.iter().any(|seen| seen.ident() == *ident) {
+                roots.push(DeriveRoot::Account(ident));
+            }
+        }
+        SeedSource::ArgRef(name) => {
+            if !roots.iter().any(|seen| seen.ident() == *name) {
+                roots.push(DeriveRoot::ArgRef(name));
+            }
+        }
+        SeedSource::ArgValue(name, ty) => {
+            if !roots.iter().any(|seen| seen.ident() == *name) {
+                roots.push(DeriveRoot::ArgValue(name, ty));
+            }
+        }
+        SeedSource::DerivedAccount(ident) => {
+            let field = find_field(plan, ident).expect("derived field exists");
+            let nested =
+                field_derivation(plan, field, &mut Vec::new()).expect("derived field re-resolves");
+            collect_roots(plan, &nested, roots);
+        }
+        SeedSource::Const(_) => {}
+    };
+    match derivation {
+        FieldDerivation::Pda { seeds, .. } => {
+            for seed in seeds {
+                source(seed, roots);
+            }
+        }
+        FieldDerivation::Ata {
+            authority, mint, ..
+        } => {
+            source(authority, roots);
+            source(mint, roots);
+        }
+    }
+}
+
+/// The derived fields a derivation reads directly, in first-use order.
+pub(crate) fn direct_derived_deps<'p>(derivation: &FieldDerivation<'p>) -> Vec<&'p syn::Ident> {
+    let mut deps: Vec<&'p syn::Ident> = Vec::new();
+    let mut visit = |source: &SeedSource<'p>| {
+        if let SeedSource::DerivedAccount(ident) = source {
+            if !deps.contains(ident) {
+                deps.push(ident);
+            }
+        }
+    };
+    match derivation {
+        FieldDerivation::Pda { seeds, .. } => seeds.iter().for_each(&mut visit),
+        FieldDerivation::Ata {
+            authority, mint, ..
+        } => {
+            visit(authority);
+            visit(mint);
+        }
+    }
+    deps
 }
 
 fn is_address_type(ty: &syn::Type) -> bool {
@@ -319,72 +491,9 @@ fn is_value_seed_type(ty: &syn::Type) -> bool {
     }
 }
 
-/// The hidden associated fn deriving one PDA field's address.
+/// The hidden associated fn deriving one field's address.
 pub(crate) fn pda_address_fn(field: &syn::Ident) -> syn::Ident {
     format_ident!("__quasar_pda_{}", field)
-}
-
-/// A client-derivable associated token account field.
-///
-/// The derive stays protocol-neutral on-chain; this is a client-codegen
-/// convention: a behavior group whose path ends in `associated_token` and
-/// maps `authority` + `mint` to plain account fields derives the address
-/// through the behavior module's `client_address` fn. `token_program` joins
-/// when it maps to a `Program<T>` field (its canonical const), and defaults
-/// inside the behavior otherwise.
-pub(crate) struct DerivableAta<'p> {
-    pub behavior_path: &'p syn::Path,
-    pub authority: &'p syn::Ident,
-    pub mint: &'p syn::Ident,
-    pub token_program: Option<&'p syn::Ident>,
-}
-
-pub(crate) fn client_derivable_ata<'p>(
-    plan: &'p crate::accounts::resolve::specs::AccountsPlanTyped,
-    fp: &'p crate::accounts::resolve::specs::FieldPlan,
-) -> Option<DerivableAta<'p>> {
-    use crate::accounts::resolve::specs::IdlResolverPlan;
-    if fp.idl_resolver.is_some() {
-        return None;
-    }
-    let group = fp
-        .behaviors
-        .iter()
-        .find(|group| group.name.ends_with("associated_token"))?;
-    let arg = |key: &str| {
-        group
-            .idl_account_args
-            .iter()
-            .find(|arg| arg.key == key)
-            .map(|arg| &arg.field_ident)
-    };
-    let plain_field = |ident: &syn::Ident| {
-        plan.fields.iter().any(|other| {
-            other.ident == *ident
-                && fixed_address_expr(other).is_none()
-                && !matches!(other.idl_resolver, Some(IdlResolverPlan::Pda { .. }))
-        })
-    };
-    let fixed_field = |ident: &syn::Ident| {
-        plan.fields
-            .iter()
-            .any(|other| other.ident == *ident && fixed_address_expr(other).is_some())
-    };
-    let authority = arg("authority").filter(|f| plain_field(f))?;
-    let mint = arg("mint").filter(|f| plain_field(f))?;
-    let token_program = match arg("token_program") {
-        Some(field) if fixed_field(field) => Some(field),
-        // An explicit token program the client cannot resolve statically
-        // (e.g. an interface field) keeps the ATA field.
-        Some(_) => return None,
-        None => None,
-    };
-    Some(DerivableAta {
-        behavior_path: &group.path,
-        authority,
-        mint,
-        token_program,
-    })
 }
 
 /// The canonical-address expression for a `Program<T>`/`Sysvar<T>` field,

--- a/derive/src/error_code.rs
+++ b/derive/src/error_code.rs
@@ -152,6 +152,13 @@ pub(crate) fn error_code_inner(_attr: TokenStream2, item: TokenStream2) -> Token
             }
         }
 
+        impl From<#name> for u32 {
+            #[inline(always)]
+            fn from(e: #name) -> Self {
+                e as u32
+            }
+        }
+
         impl TryFrom<u32> for #name {
             type Error = #krate::__solana_program_error::ProgramError;
 

--- a/derive/src/seed_param.rs
+++ b/derive/src/seed_param.rs
@@ -42,6 +42,28 @@ impl SeedType {
         }
     }
 
+    /// The owned form of the constructor parameter type, for derivation
+    /// helpers that take every seed by value.
+    pub(crate) fn owned_param_type(&self) -> proc_macro2::TokenStream {
+        let krate = crate::krate::lang_path();
+        match self {
+            SeedType::Address => quote! { #krate::prelude::Address },
+            SeedType::U8 => quote! { u8 },
+            SeedType::U16 => quote! { u16 },
+            SeedType::U32 => quote! { u32 },
+            SeedType::U64 => quote! { u64 },
+            SeedType::Bytes(len) => quote! { [u8; #len] },
+        }
+    }
+
+    /// Expression converting an owned parameter into `seeds()`'s form.
+    pub(crate) fn owned_to_seed_arg(&self, param: &Ident) -> proc_macro2::TokenStream {
+        match self {
+            SeedType::Address => quote! { &#param },
+            _ => quote! { #param },
+        }
+    }
+
     /// Expression to store the constructor parameter in the SeedSet field.
     pub(crate) fn to_stored_expr(&self, param: &Ident) -> proc_macro2::TokenStream {
         match self {

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -180,6 +180,19 @@ pub(crate) fn generate_seeds_impl(
         .iter()
         .map(|param| param.ty.to_stored_expr(&param.name))
         .collect();
+    let owned_param_types: Vec<_> = seeds_attr
+        .params
+        .iter()
+        .map(|param| param.ty.owned_param_type())
+        .collect();
+    let owned_seed_args: Vec<_> = seeds_attr
+        .params
+        .iter()
+        .map(|param| param.ty.owned_to_seed_arg(&param.name))
+        .collect();
+    let seed_indices: Vec<_> = (0..seeds_attr.params.len())
+        .map(|index| quote! { #index })
+        .collect();
 
     let slice_exprs: Vec<_> = {
         let mut slices = Vec::new();
@@ -255,7 +268,23 @@ pub(crate) fn generate_seeds_impl(
                     #phantom_init
                 }
             }
+
+            /// Derive this PDA's canonical address from owned seed values.
+            #[inline]
+            #vis fn find_address(
+                #( #param_names: #owned_param_types, )*
+                program_id: &#krate::prelude::Address,
+            ) -> #krate::prelude::Address {
+                let seeds = Self::seeds(#(#owned_seed_args),*);
+                #krate::pda::find_program_address_const(&seeds.as_slices(), program_id).0
+            }
         }
+
+        #(
+            impl #impl_generics #krate::traits::SeedParam<#seed_indices> for #name #ty_generics #where_clause {
+                type Ty = #owned_param_types;
+            }
+        )*
 
         impl<'__quasar_seed> #seed_set<'__quasar_seed> {
             #[inline(always)]

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -313,6 +313,17 @@ pub(crate) fn generate_seeds_impl(
             pub fn as_slices(&self) -> [&[u8]; #n_slices_with_bump] {
                 [ #( #slice_exprs_bump ),* ]
             }
+
+            /// Materialize the signer-seed array once.
+            ///
+            /// `invoke_signed(&set)` rebuilds the array on every call (the
+            /// pointer escapes into the syscall, so the rebuild cannot be
+            /// elided). Bind this before signing several CPIs to pay the
+            /// construction cost once.
+            #[inline(always)]
+            pub fn signer_seeds(&self) -> [#krate::cpi::Seed<'_>; #n_slices_with_bump] {
+                [ #( #krate::cpi::Seed::from(#slice_exprs_bump) ),* ]
+            }
         }
 
         impl<'__quasar_seed> #krate::cpi::CpiSignerSeeds for #seed_set_bump<'__quasar_seed> {

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -272,6 +272,13 @@ pub(crate) fn generate_seeds_impl(
             }
         }
 
+        impl<'__quasar_seed> #krate::traits::SeedSlices for #seed_set<'__quasar_seed> {
+            #[inline(always)]
+            fn with_slices<R>(&self, f: impl FnOnce(&[&[u8]]) -> R) -> R {
+                f(&self.as_slices())
+            }
+        }
+
         impl<'__quasar_seed> #seed_set_bump<'__quasar_seed> {
             #[inline(always)]
             pub fn as_slices(&self) -> [&[u8]; #n_slices_with_bump] {

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -244,6 +244,7 @@ pub(crate) fn generate_seeds_impl(
             const HAS_SEED_PREFIX: bool = #has_prefix;
             const SEED_PREFIX: &'static [u8] = &[#(#prefix_bytes),*];
             const SEED_DYNAMIC_COUNT: usize = #dynamic_count;
+            type WithBump<'__quasar_seed> = #seed_set_bump<'__quasar_seed>;
         }
 
         /// Zero-copy seed storage (without bump).

--- a/derive/tests/account_meta_signers.rs
+++ b/derive/tests/account_meta_signers.rs
@@ -35,8 +35,6 @@ struct InitAssociatedToken {
     ata_program: Program<AssociatedTokenProgram>,
 }
 
-__init_associated_token_instruction!(InitAssociatedTokenInstruction, [0], {});
-
 #[derive(Accounts)]
 struct InitTokenAccount {
     #[account(mut)]
@@ -53,7 +51,16 @@ struct InitTokenAccount {
     system_program: Program<SystemProgram>,
 }
 
-__init_token_account_instruction!(InitTokenAccountInstruction, [1], {});
+// The client macro expands inside the generated `cpi` module (a child of
+// the `#[program]` module); this mirror gives its `super::` paths the same
+// shape.
+mod cpi {
+    use super::*;
+
+    __init_associated_token_instruction!(InitAssociatedTokenInstruction, [0], {});
+    __init_token_account_instruction!(InitTokenAccountInstruction, [1], {});
+}
+use cpi::*;
 
 fn address(byte: u8) -> Address {
     Address::from([byte; 32])
@@ -65,9 +72,6 @@ fn associated_token_init_does_not_require_the_derived_account_to_sign() {
         payer: address(1),
         mint: address(2),
         ata: address(3),
-        token_program: address(4),
-        system_program: address(5),
-        ata_program: address(6),
     }
     .into();
 
@@ -82,8 +86,6 @@ fn direct_token_init_still_requires_the_new_account_to_sign() {
         mint: address(2),
         authority: address(3),
         token: address(4),
-        token_program: address(5),
-        system_program: address(6),
     }
     .into();
 

--- a/derive/tests/account_meta_signers.rs
+++ b/derive/tests/account_meta_signers.rs
@@ -71,7 +71,6 @@ fn associated_token_init_does_not_require_the_derived_account_to_sign() {
     let instruction: quasar_lang::client::Instruction = InitAssociatedTokenInstruction {
         payer: address(1),
         mint: address(2),
-        ata: address(3),
     }
     .into();
 

--- a/examples/escrow/Cargo.toml
+++ b/examples/escrow/Cargo.toml
@@ -22,7 +22,4 @@ quasar-lang = { path = "../../lang" }
 quasar-spl = { path = "../../spl" }
 
 [dev-dependencies]
-quasar-escrow-client = { path = "client" }
-wincode = { version = "0.4", features = ["derive"] }
-quasar-svm = { git = "https://github.com/blueshift-gg/quasar-svm" }
-spl-token-interface = { version = "2.0.0" }
+quasar-test = { path = "../../testing" }

--- a/examples/escrow/src/tests.rs
+++ b/examples/escrow/src/tests.rs
@@ -1,9 +1,10 @@
 extern crate std;
 use {
-    alloc::vec,
-    quasar_escrow_client::*,
-    quasar_svm::{Account, Instruction, Pubkey, QuasarSvm},
-    spl_token_interface::state::{Account as TokenAccount, AccountState, Mint},
+    crate::{
+        cpi::*,
+        state::{Escrow, EscrowData},
+    },
+    quasar_test::prelude::*,
 };
 
 #[path = "../../cu_bench.rs"]
@@ -22,374 +23,66 @@ const TAKER_TA_A: Pubkey = Pubkey::new_from_array([8; 32]);
 const TAKER_TA_B: Pubkey = Pubkey::new_from_array([9; 32]);
 const WRONG_OWNER: Pubkey = Pubkey::new_from_array([10; 32]);
 
-fn setup() -> QuasarSvm {
-    let elf = std::fs::read("../../target/deploy/quasar_escrow.so").unwrap();
-    QuasarSvm::new()
-        .with_program(&crate::ID, &elf)
-        .with_token_program()
+/// Register the maker and both mints.
+fn base_world(q: &mut QuasarTest) {
+    q.actor_at(MAKER);
+    q.mint_at(MINT_A, MAKER, 1_000_000_000, 9);
+    q.mint_at(MINT_B, MAKER, 1_000_000_000, 9);
 }
 
-fn signer(address: Pubkey) -> Account {
-    quasar_svm::token::create_keyed_system_account(&address, 1_000_000_000)
-}
-
-fn empty(address: Pubkey) -> Account {
-    Account {
-        address,
-        lamports: 0,
-        data: vec![],
-        owner: quasar_svm::system_program::ID,
-        executable: false,
-    }
-}
-
-fn mint(address: Pubkey, authority: Pubkey) -> Account {
-    quasar_svm::token::create_keyed_mint_account(
-        &address,
-        &Mint {
-            mint_authority: Some(authority).into(),
-            supply: 1_000_000_000,
-            decimals: 9,
-            is_initialized: true,
-            freeze_authority: None.into(),
-        },
-    )
-}
-
-fn token(address: Pubkey, mint: Pubkey, owner: Pubkey, amount: u64) -> Account {
-    quasar_svm::token::create_keyed_token_account(
-        &address,
-        &TokenAccount {
-            mint,
-            owner,
-            amount,
-            state: AccountState::Initialized,
-            ..TokenAccount::default()
-        },
-    )
-}
-
-fn escrow_account(
-    address: Pubkey,
-    maker: Pubkey,
-    mint_a: Pubkey,
-    mint_b: Pubkey,
-    maker_ta_b: Pubkey,
-    receive: u64,
-    bump: u8,
-) -> Account {
-    let escrow = Escrow {
-        maker,
-        mint_a,
-        mint_b,
-        maker_ta_b,
-        receive,
-        bump,
-    };
-    Account {
-        address,
-        lamports: 2_000_000,
-        data: wincode::serialize(&escrow).unwrap(),
-        owner: crate::ID,
-        executable: false,
-    }
-}
-
-/// Mark specific account indices as signers on an instruction.
-fn with_signers(mut ix: Instruction, indices: &[usize]) -> Instruction {
-    for &i in indices {
-        ix.accounts[i].is_signer = true;
-    }
-    ix
-}
-
-#[test]
-fn test_make_cu() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, escrow_bump) =
-        Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction = with_signers(
-        MakeInstruction {
+/// Register a live escrow holding 1337 vault tokens, as `make` leaves it.
+fn live_escrow(q: &mut QuasarTest) -> Pubkey {
+    let (escrow, bump) = q.pda_with_bump(Escrow::seeds(&MAKER));
+    q.write::<Escrow>(
+        escrow,
+        EscrowData {
             maker: MAKER,
-            escrow,
             mint_a: MINT_A,
             mint_b: MINT_B,
-            maker_ta_a: MAKER_TA_A,
             maker_ta_b: MAKER_TA_B,
-            vault_ta_a: VAULT_TA_A,
-            rent,
-            token_program,
-            system_program,
-            deposit: 1337,
-            receive: 1337,
-        }
-        .into(),
-        &[5, 6],
+            receive: 1337.into(),
+            bump,
+        },
     );
+    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 1337);
+    escrow
+}
 
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            empty(escrow),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            token(MAKER_TA_A, MINT_A, MAKER, 1_000_000),
-            empty(MAKER_TA_B),
-            empty(VAULT_TA_A),
-        ],
-    );
+#[quasar_test]
+fn test_make_cu(q: &mut QuasarTest) {
+    base_world(q);
+    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let (escrow, bump) = q.pda_with_bump(Escrow::seeds(&MAKER));
 
-    assert!(result.is_ok(), "make failed: {:?}", result.raw_result);
+    let result = q.send(MakeInstruction {
+        maker: MAKER,
+        mint_a: MINT_A,
+        mint_b: MINT_B,
+        maker_ta_a: MAKER_TA_A,
+        maker_ta_b: MAKER_TA_B,
+        vault_ta_a: VAULT_TA_A,
+        deposit: 1337,
+        receive: 1337,
+    });
+    result.succeeds();
 
-    let escrow_data = &result.account(&escrow).unwrap().data;
-    assert_eq!(escrow_data[0], 1, "discriminator");
-    assert_eq!(&escrow_data[1..33], MAKER.as_ref(), "maker");
-    assert_eq!(&escrow_data[129..137], &1337u64.to_le_bytes(), "receive");
-    assert_eq!(escrow_data[137], escrow_bump, "bump");
+    let state = q.read::<Escrow>(escrow);
+    assert_eq!(state.maker, MAKER);
+    assert_eq!(state.receive, 1337);
+    assert_eq!(state.bump, bump);
 
     cu_bench::record_cu("make", result.compute_units_consumed);
 }
 
-#[test]
-fn test_take_cu() {
-    let mut svm = setup();
+#[quasar_test]
+fn test_take_cu(q: &mut QuasarTest) {
+    base_world(q);
+    q.actor_at(TAKER);
+    live_escrow(q);
+    q.token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
 
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, escrow_bump) =
-        Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction = with_signers(
-        TakeInstruction {
-            taker: TAKER,
-            escrow,
-            maker: MAKER,
-            mint_a: MINT_A,
-            mint_b: MINT_B,
-            taker_ta_a: TAKER_TA_A,
-            taker_ta_b: TAKER_TA_B,
-            maker_ta_b: MAKER_TA_B,
-            vault_ta_a: VAULT_TA_A,
-            rent,
-            token_program,
-            system_program,
-        }
-        .into(),
-        &[5, 7],
-    );
-
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(TAKER),
-            escrow_account(escrow, MAKER, MINT_A, MINT_B, MAKER_TA_B, 1337, escrow_bump),
-            signer(MAKER),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            empty(TAKER_TA_A),
-            token(TAKER_TA_B, MINT_B, TAKER, 10_000),
-            empty(MAKER_TA_B),
-            token(VAULT_TA_A, MINT_A, escrow, 1337),
-        ],
-    );
-
-    assert!(result.is_ok(), "take failed: {:?}", result.raw_result);
-    cu_bench::record_cu("take", result.compute_units_consumed);
-}
-
-#[test]
-fn test_refund_cu() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, escrow_bump) =
-        Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction = with_signers(
-        RefundInstruction {
-            maker: MAKER,
-            escrow,
-            mint_a: MINT_A,
-            maker_ta_a: MAKER_TA_A,
-            vault_ta_a: VAULT_TA_A,
-            rent,
-            token_program,
-            system_program,
-        }
-        .into(),
-        &[3],
-    );
-
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            escrow_account(escrow, MAKER, MINT_A, MINT_B, MAKER_TA_B, 1337, escrow_bump),
-            mint(MINT_A, MAKER),
-            empty(MAKER_TA_A),
-            token(VAULT_TA_A, MINT_A, escrow, 1337),
-        ],
-    );
-
-    assert!(result.is_ok(), "refund failed: {:?}", result.raw_result);
-    cu_bench::record_cu("refund", result.compute_units_consumed);
-}
-
-#[test]
-fn test_make_existing_token_accounts() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, _) = Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction: Instruction = MakeInstruction {
-        maker: MAKER,
-        escrow,
-        mint_a: MINT_A,
-        mint_b: MINT_B,
-        maker_ta_a: MAKER_TA_A,
-        maker_ta_b: MAKER_TA_B,
-        vault_ta_a: VAULT_TA_A,
-        rent,
-        token_program,
-        system_program,
-        deposit: 1337,
-        receive: 1337,
-    }
-    .into();
-
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            empty(escrow),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            token(MAKER_TA_A, MINT_A, MAKER, 1_000_000),
-            token(MAKER_TA_B, MINT_B, MAKER, 0),
-            token(VAULT_TA_A, MINT_A, escrow, 0),
-        ],
-    );
-
-    assert!(
-        result.is_ok(),
-        "make with existing token accounts failed: {:?}",
-        result.raw_result
-    );
-}
-
-#[test]
-fn test_make_existing_maker_ta_b_wrong_mint() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, _) = Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction: Instruction = MakeInstruction {
-        maker: MAKER,
-        escrow,
-        mint_a: MINT_A,
-        mint_b: MINT_B,
-        maker_ta_a: MAKER_TA_A,
-        maker_ta_b: MAKER_TA_B,
-        vault_ta_a: VAULT_TA_A,
-        rent,
-        token_program,
-        system_program,
-        deposit: 1337,
-        receive: 1337,
-    }
-    .into();
-
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            empty(escrow),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            token(MAKER_TA_A, MINT_A, MAKER, 1_000_000),
-            token(MAKER_TA_B, MINT_A, MAKER, 0), // wrong mint
-            token(VAULT_TA_A, MINT_A, escrow, 0),
-        ],
-    );
-
-    assert!(
-        result.is_err(),
-        "make should fail with wrong mint on maker_ta_b"
-    );
-}
-
-#[test]
-fn test_make_existing_maker_ta_b_wrong_owner() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, _) = Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction: Instruction = MakeInstruction {
-        maker: MAKER,
-        escrow,
-        mint_a: MINT_A,
-        mint_b: MINT_B,
-        maker_ta_a: MAKER_TA_A,
-        maker_ta_b: MAKER_TA_B,
-        vault_ta_a: VAULT_TA_A,
-        rent,
-        token_program,
-        system_program,
-        deposit: 1337,
-        receive: 1337,
-    }
-    .into();
-
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            empty(escrow),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            token(MAKER_TA_A, MINT_A, MAKER, 1_000_000),
-            token(MAKER_TA_B, MINT_B, WRONG_OWNER, 0), // wrong owner
-            token(VAULT_TA_A, MINT_A, escrow, 0),
-        ],
-    );
-
-    assert!(
-        result.is_err(),
-        "make should fail with wrong owner on maker_ta_b"
-    );
-}
-
-#[test]
-fn test_take_existing_token_accounts() {
-    let mut svm = setup();
-
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, escrow_bump) =
-        Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction: Instruction = TakeInstruction {
+    let result = q.send(TakeInstruction {
         taker: TAKER,
-        escrow,
         maker: MAKER,
         mint_a: MINT_A,
         mint_b: MINT_B,
@@ -397,70 +90,130 @@ fn test_take_existing_token_accounts() {
         taker_ta_b: TAKER_TA_B,
         maker_ta_b: MAKER_TA_B,
         vault_ta_a: VAULT_TA_A,
-        rent,
-        token_program,
-        system_program,
-    }
-    .into();
+    });
+    result.succeeds();
 
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(TAKER),
-            escrow_account(escrow, MAKER, MINT_A, MINT_B, MAKER_TA_B, 1337, escrow_bump),
-            signer(MAKER),
-            mint(MINT_A, MAKER),
-            mint(MINT_B, MAKER),
-            token(TAKER_TA_A, MINT_A, TAKER, 0),
-            token(TAKER_TA_B, MINT_B, TAKER, 10_000),
-            token(MAKER_TA_B, MINT_B, MAKER, 500),
-            token(VAULT_TA_A, MINT_A, escrow, 1337),
-        ],
-    );
-
-    assert!(
-        result.is_ok(),
-        "take with existing token accounts failed: {:?}",
-        result.raw_result
-    );
+    cu_bench::record_cu("take", result.compute_units_consumed);
 }
 
-#[test]
-fn test_refund_existing_maker_ta_a() {
-    let mut svm = setup();
+#[quasar_test]
+fn test_refund_cu(q: &mut QuasarTest) {
+    base_world(q);
+    live_escrow(q);
 
-    let token_program = quasar_svm::SPL_TOKEN_PROGRAM_ID;
-    let system_program = quasar_svm::system_program::ID;
-    let (escrow, escrow_bump) =
-        Pubkey::find_program_address(&[b"escrow", MAKER.as_ref()], &crate::ID);
-    let rent = quasar_svm::solana_sdk_ids::sysvar::rent::ID;
-
-    let instruction: Instruction = RefundInstruction {
+    let result = q.send(RefundInstruction {
         maker: MAKER,
-        escrow,
         mint_a: MINT_A,
         maker_ta_a: MAKER_TA_A,
         vault_ta_a: VAULT_TA_A,
-        rent,
-        token_program,
-        system_program,
-    }
-    .into();
+    });
+    result.succeeds();
 
-    let result = svm.process_instruction(
-        &instruction,
-        &[
-            signer(MAKER),
-            escrow_account(escrow, MAKER, MINT_A, MINT_B, MAKER_TA_B, 1337, escrow_bump),
-            mint(MINT_A, MAKER),
-            token(MAKER_TA_A, MINT_A, MAKER, 5_000),
-            token(VAULT_TA_A, MINT_A, escrow, 1337),
-        ],
-    );
+    cu_bench::record_cu("refund", result.compute_units_consumed);
+}
 
+#[quasar_test]
+fn test_make_existing_token_accounts(q: &mut QuasarTest) {
+    base_world(q);
+    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.pda(Escrow::seeds(&MAKER));
+    q.token_account_at(MAKER_TA_B, MAKER, MINT_B, 0);
+    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+
+    q.send(MakeInstruction {
+        maker: MAKER,
+        mint_a: MINT_A,
+        mint_b: MINT_B,
+        maker_ta_a: MAKER_TA_A,
+        maker_ta_b: MAKER_TA_B,
+        vault_ta_a: VAULT_TA_A,
+        deposit: 1337,
+        receive: 1337,
+    })
+    .succeeds();
+}
+
+#[quasar_test]
+fn test_make_existing_maker_ta_b_wrong_mint(q: &mut QuasarTest) {
+    base_world(q);
+    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.pda(Escrow::seeds(&MAKER));
+    q.token_account_at(MAKER_TA_B, MAKER, MINT_A, 0); // wrong mint
+    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+
+    let result = q.send(MakeInstruction {
+        maker: MAKER,
+        mint_a: MINT_A,
+        mint_b: MINT_B,
+        maker_ta_a: MAKER_TA_A,
+        maker_ta_b: MAKER_TA_B,
+        vault_ta_a: VAULT_TA_A,
+        deposit: 1337,
+        receive: 1337,
+    });
     assert!(
-        result.is_ok(),
-        "refund with existing maker_ta_a failed: {:?}",
-        result.raw_result
+        result.is_err(),
+        "make should fail with wrong mint on maker_ta_b"
     );
+}
+
+#[quasar_test]
+fn test_make_existing_maker_ta_b_wrong_owner(q: &mut QuasarTest) {
+    base_world(q);
+    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.pda(Escrow::seeds(&MAKER));
+    q.token_account_at(MAKER_TA_B, WRONG_OWNER, MINT_B, 0); // wrong owner
+    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+
+    let result = q.send(MakeInstruction {
+        maker: MAKER,
+        mint_a: MINT_A,
+        mint_b: MINT_B,
+        maker_ta_a: MAKER_TA_A,
+        maker_ta_b: MAKER_TA_B,
+        vault_ta_a: VAULT_TA_A,
+        deposit: 1337,
+        receive: 1337,
+    });
+    assert!(
+        result.is_err(),
+        "make should fail with wrong owner on maker_ta_b"
+    );
+}
+
+#[quasar_test]
+fn test_take_existing_token_accounts(q: &mut QuasarTest) {
+    base_world(q);
+    q.actor_at(TAKER);
+    live_escrow(q);
+    q.token_account_at(TAKER_TA_A, TAKER, MINT_A, 0);
+    q.token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
+    q.token_account_at(MAKER_TA_B, MAKER, MINT_B, 500);
+
+    q.send(TakeInstruction {
+        taker: TAKER,
+        maker: MAKER,
+        mint_a: MINT_A,
+        mint_b: MINT_B,
+        taker_ta_a: TAKER_TA_A,
+        taker_ta_b: TAKER_TA_B,
+        maker_ta_b: MAKER_TA_B,
+        vault_ta_a: VAULT_TA_A,
+    })
+    .succeeds();
+}
+
+#[quasar_test]
+fn test_refund_existing_maker_ta_a(q: &mut QuasarTest) {
+    base_world(q);
+    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 5_000);
+    live_escrow(q);
+
+    q.send(RefundInstruction {
+        maker: MAKER,
+        mint_a: MINT_A,
+        maker_ta_a: MAKER_TA_A,
+        vault_ta_a: VAULT_TA_A,
+    })
+    .succeeds();
 }

--- a/lang/src/idl_build.rs
+++ b/lang/src/idl_build.rs
@@ -29,16 +29,44 @@ pub mod __reexport {
 
 use quasar_idl_schema::*;
 
+/// camelCase form of a snake_case behavior-arg name.
+fn snake_to_camel(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut upper_next = false;
+    for c in name.chars() {
+        if c == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(c.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Resolve one protocol behavior's address metadata against the account-field
 /// arguments used by a concrete `#[account(...)]` declaration.
 pub fn behavior_resolver(
     resolver: Option<crate::account_behavior::BehaviorIdlResolver>,
     account_args: &[(&str, &str)],
+    fields: &[&str],
 ) -> Option<IdlResolver> {
+    // An unmapped behavior arg resolves to the same-named account field
+    // (mirroring the runtime init inference); `fields` carries camelCase
+    // names, so compare the argument camelized.
     let account = |argument: &str| {
         account_args
             .iter()
             .find_map(|(key, field)| (*key == argument).then(|| String::from(*field)))
+            .or_else(|| {
+                let camel = snake_to_camel(argument);
+                fields
+                    .iter()
+                    .find(|field| **field == camel)
+                    .map(|field| String::from(*field))
+            })
     };
 
     match resolver? {
@@ -470,7 +498,13 @@ mod codec_tests {
             },
         );
         let incomplete = [("mint", "mint"), ("owner", "wallet")];
-        assert!(behavior_resolver(recipe, &incomplete).is_none());
+        assert!(behavior_resolver(recipe, &incomplete, &[]).is_none());
+
+        // An unmapped declared argument resolves to a same-named field.
+        assert!(matches!(
+            behavior_resolver(recipe, &incomplete, &["tokenProgram"]),
+            Some(IdlResolver::AssociatedToken { .. })
+        ));
 
         let complete = [
             ("mint", "mint"),
@@ -478,7 +512,7 @@ mod codec_tests {
             ("token_program", "tokenProgram"),
         ];
         assert!(matches!(
-            behavior_resolver(recipe, &complete),
+            behavior_resolver(recipe, &complete, &[]),
             Some(IdlResolver::AssociatedToken {
                 mint,
                 owner,

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -319,6 +319,17 @@ pub trait HasSeeds {
     const SEED_DYNAMIC_COUNT: usize;
 }
 
+/// Generic access to a seed set's raw slices (prefix + dynamic seeds, no
+/// bump).
+///
+/// Implemented by: the `{Name}SeedSet` type generated from `#[seeds(...)]`.
+/// Used by: off-chain helpers (`quasar-test`) to derive PDA addresses from
+/// the same seed definition the program validates against.
+pub trait SeedSlices {
+    /// Call `f` with this seed set's slices.
+    fn with_slices<R>(&self, f: impl FnOnce(&[&[u8]]) -> R) -> R;
+}
+
 /// Marker trait for account view types that are `#[repr(transparent)]` over
 /// `AccountView` and therefore safe to construct via pointer cast.
 ///

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -319,6 +319,15 @@ pub trait HasSeeds {
     const SEED_DYNAMIC_COUNT: usize;
 }
 
+/// Owned type of one `#[seeds(...)]` dynamic parameter, by position.
+///
+/// Implemented by: seeds codegen for each dynamic seed.
+/// Used by: generated clients to type stored-data seed inputs.
+pub trait SeedParam<const INDEX: usize> {
+    /// The parameter's owned form (`Address`, integer, or byte array).
+    type Ty;
+}
+
 /// Generic access to a seed set's raw slices (prefix + dynamic seeds, no
 /// bump).
 ///

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -317,6 +317,9 @@ pub trait HasSeeds {
     const SEED_PREFIX: &'static [u8];
     /// Number of dynamic seed arguments (excluding prefix and bump).
     const SEED_DYNAMIC_COUNT: usize;
+    /// The generated `{Name}SeedSetWithBump` type, nameable through the
+    /// account type from any scope (generated signer helpers return it).
+    type WithBump<'seed>;
 }
 
 /// Owned type of one `#[seeds(...)]` dynamic parameter, by position.

--- a/spl/src/accounts/associated_token.rs
+++ b/spl/src/accounts/associated_token.rs
@@ -17,6 +17,25 @@
 
 use quasar_lang::prelude::*;
 
+/// Derive the canonical associated token address for a generated client.
+///
+/// Called by client codegen for `associated_token` fields, so the
+/// instruction struct can drop them. `token_program` defaults to SPL Token
+/// when the accounts struct does not pin one.
+pub fn client_address(
+    authority: &Address,
+    mint: &Address,
+    token_program: Option<&Address>,
+) -> Address {
+    let token_program = token_program.unwrap_or(&crate::SPL_TOKEN_ID);
+    crate::associated_token::get_associated_token_address_with_program_const(
+        authority,
+        mint,
+        token_program,
+    )
+    .0
+}
+
 /// Resolved arguments for associated-token validation or initialization.
 pub struct Args<'a> {
     /// Token mint account.

--- a/spl/src/accounts/associated_token.rs
+++ b/spl/src/accounts/associated_token.rs
@@ -11,9 +11,10 @@
 //! pub ata: Account<Token>,
 //! ```
 //!
-//! During initialization, fields named `system_program`, `ata_program`, or
-//! `associated_token_program` are inferred from the accounts struct. Explicit
-//! arguments remain available for non-standard field names.
+//! During initialization, fields named `token_program`, `system_program`,
+//! `ata_program`, or `associated_token_program` are inferred from the
+//! accounts struct. Explicit arguments remain available for non-standard
+//! field names.
 
 use quasar_lang::prelude::*;
 
@@ -130,7 +131,9 @@ impl<'a> quasar_lang::account_behavior::BehaviorArgsBuilder for ArgsBuilder<'a> 
         Ok(Args {
             mint: self.mint.ok_or(ProgramError::InvalidArgument)?,
             authority: self.authority.ok_or(ProgramError::InvalidArgument)?,
-            token_program: Some(self.token_program.ok_or(ProgramError::InvalidArgument)?),
+            // Left open for field-name inference; `set_init_param` rejects a
+            // still-unresolved token program.
+            token_program: self.token_program,
             system_program: self.system_program,
             ata_program: self.ata_program,
         })
@@ -186,9 +189,24 @@ macro_rules! impl_ata_behavior {
                 params: &mut <$wrapper as AccountInit>::InitParams<'a>,
                 args: &Args<'a>,
             ) -> Result<(), ProgramError> {
-                let tp = args.token_program.ok_or(ProgramError::InvalidArgument)?;
-                let sp = args.system_program.ok_or(ProgramError::InvalidArgument)?;
-                let ap = args.ata_program.ok_or(ProgramError::InvalidArgument)?;
+                let tp = args.token_program.ok_or_else(|| {
+                    #[cfg(feature = "debug")]
+                    quasar_lang::prelude::log(
+                        "associated_token init: no token_program (name a token_program field or \
+                         pass token_program = ...)",
+                    );
+                    ProgramError::InvalidArgument
+                })?;
+                let sp = args.system_program.ok_or_else(|| {
+                    #[cfg(feature = "debug")]
+                    quasar_lang::prelude::log("associated_token init: no system_program field");
+                    ProgramError::InvalidArgument
+                })?;
+                let ap = args.ata_program.ok_or_else(|| {
+                    #[cfg(feature = "debug")]
+                    quasar_lang::prelude::log("associated_token init: no ata_program field");
+                    ProgramError::InvalidArgument
+                })?;
                 *params = crate::token::TokenInitKind::AssociatedToken {
                     mint: args.mint,
                     authority: args.authority,
@@ -207,6 +225,9 @@ macro_rules! impl_ata_behavior {
             ) {
                 if KEY == SYSTEM_PROGRAM_ARG && args.system_program.is_none() {
                     args.system_program = Some(account);
+                }
+                if KEY == TOKEN_PROGRAM_ARG && args.token_program.is_none() {
+                    args.token_program = Some(account);
                 }
                 if (KEY == ATA_PROGRAM_ARG || KEY == ASSOCIATED_TOKEN_PROGRAM_ARG)
                     && args.ata_program.is_none()

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 
 [dependencies]
 quasar-svm = "=0.1.0"
+quasar-lang = { path = "../lang", version = "=0.1.0" }
+quasar-test-derive = { path = "derive", version = "=0.1.0" }
 spl-token = { version = "=9.0.0", default-features = false, features = ["no-entrypoint"] }
 
 [lib]

--- a/testing/README.md
+++ b/testing/README.md
@@ -20,31 +20,34 @@ use {
 #[quasar_test]
 fn deposits_into_the_vault(q: &mut QuasarTest) {
     let authority = q.actor();
-    let vault = q.pda(Vault::seeds(&authority));
 
-    q.send(InitializeInstruction { authority, vault }).succeeds();
+    q.send(InitializeInstruction { authority }).succeeds();
     q.send(DepositInstruction {
         authority,
-        vault,
         amount: 1_000_000_000,
     })
     .succeeds()
     .cu_below(10_000);
 
-    let state = q.read::<Vault>(vault);
+    let state = q.read::<Vault>(q.pda(Vault::seeds(&authority)));
     assert_eq!(state.balance, 1_000_000_000);
 }
 ```
 
 A `#[quasar_test]` function is a plain `#[test]` whose world is loaded from
 the crate's compiled program. Everything typed comes from the program itself:
-instructions from the generated client, addresses via `pda` from `#[seeds]`,
-state via `read`/`write` from `#[account]`. `actor`, `actors`, `actor_at`,
-`mint`, `ata`, and `empty` put common fixtures directly into the test world,
-and `send` backs missing writable accounts with empty system accounts so init
-targets need no setup. The returned result supports fluent success, typed
-error, compute-unit, balance, supply, and account-closure checks. Raw
-fixtures and the full `QuasarSvm` API remain available for unusual cases.
+instructions from the generated client (which fills in `Program<T>`/
+`Sysvar<T>` addresses and derives `#[seeds]` PDA accounts, so neither appears
+in the struct), addresses via `pda` from `#[seeds]`, state via `read`/`write`
+from `#[account]`. `actor`, `actors`, `actor_at`, `mint`, `ata`, and `empty`
+put common fixtures directly into the test world, and `send` backs missing
+writable accounts with empty system accounts so init targets need no setup.
+The returned result supports fluent success, typed error, compute-unit,
+balance, supply, and account-closure checks. For a deliberate deviation from
+the canonical call — a spoofed PDA, a missing signature — adjust the built
+instruction with `swap_account`/`signed_by` so the deviation is visible where
+the test constructs it. Raw fixtures and the full `QuasarSvm` API remain
+available for unusual cases.
 
 `quasar test` passes the exact program artifact through
 `QUASAR_PROGRAM_PATH`. Direct `cargo test` runs prefer

--- a/testing/README.md
+++ b/testing/README.md
@@ -12,40 +12,47 @@ quasar-test = "=0.1.0"
 ```
 
 ```rust,ignore
-use quasar_test::prelude::*;
+use {
+    crate::{cpi::*, state::Vault},
+    quasar_test::prelude::*,
+};
 
-quasar_test! {
-    fn deposits_into_the_vault(q) {
-        let authority = q.actor();
-        let vault = find_vault_address(&authority, &crate::ID).0;
-        q.empty(vault);
+#[quasar_test]
+fn deposits_into_the_vault(q: &mut QuasarTest) {
+    let authority = q.actor();
+    let vault = q.pda(Vault::seeds(&authority));
 
-        q.send(InitializeInstructionInput { authority }).succeeds();
-        let deposited = q.send(DepositInstructionInput {
-            authority,
-            amount: 1_000_000_000,
-        });
-        deposited.succeeds().cu_below(10_000);
+    q.send(InitializeInstruction { authority, vault }).succeeds();
+    q.send(DepositInstruction {
+        authority,
+        vault,
+        amount: 1_000_000_000,
+    })
+    .succeeds()
+    .cu_below(10_000);
 
-        let account = deposited.account(&vault).expect("vault exists");
-        let ProgramAccount::Vault(state) = decode_account(&account.data).unwrap();
-        assert_eq!(state.balance, 1_000_000_000);
-    }
+    let state = q.read::<Vault>(vault);
+    assert_eq!(state.balance, 1_000_000_000);
 }
 ```
 
-`actor`, `actors`, `actor_at`, `mint`, `ata`, and `empty` put common fixtures
-directly into the test world. `send` executes generated client inputs without
-an intermediate `Instruction` or account slice. The returned result supports
-fluent success, typed error, compute-unit, balance, supply, and account-closure
-checks. Raw fixtures and the full `QuasarSvm` API remain available for unusual
-cases.
+A `#[quasar_test]` function is a plain `#[test]` whose world is loaded from
+the crate's compiled program. Everything typed comes from the program itself:
+instructions from the generated client, addresses via `pda` from `#[seeds]`,
+state via `read`/`write` from `#[account]`. `actor`, `actors`, `actor_at`,
+`mint`, `ata`, and `empty` put common fixtures directly into the test world,
+and `send` backs missing writable accounts with empty system accounts so init
+targets need no setup. The returned result supports fluent success, typed
+error, compute-unit, balance, supply, and account-closure checks. Raw
+fixtures and the full `QuasarSvm` API remain available for unusual cases.
 
 `quasar test` passes the exact program artifact through
-`QUASAR_PROGRAM_PATH`. Direct `cargo test` runs discover one `.so` in the
-nearest ancestor `target/deploy` directory. Discovery fails when the directory
-contains multiple programs, so a test cannot silently execute the wrong
-binary. Use `QuasarTest::from_program_path` when you need an explicit path.
+`QUASAR_PROGRAM_PATH`. Direct `cargo test` runs prefer
+`target/deploy/{crate_name}.so` in the nearest ancestor target directory and
+otherwise require a single unambiguous `.so`, so a test cannot silently
+execute the wrong binary. Use `#[quasar_test(program_id = EXPR)]` for an
+external program and `QuasarTest::from_program_path` for an explicit
+artifact.
 
 `QuasarTest` dereferences to `QuasarSvm`, so the complete VM API remains
 available. Use `quasar-svm` directly only when you are testing the VM itself or

--- a/testing/derive/Cargo.toml
+++ b/testing/derive/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "quasar-test-derive"
+description = "Attribute macros for quasar-test"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+documentation = "https://docs.rs/quasar-test-derive/0.1.0"
+readme = "README.md"
+keywords = ["solana", "quasar", "testing", "proc-macro"]
+categories = ["development-tools::procedural-macro-helpers", "development-tools::testing"]
+
+include = ["/src/**", "/README.md", "/LICENSE-APACHE", "/LICENSE-MIT"]
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+doctest = false
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/testing/derive/LICENSE-APACHE
+++ b/testing/derive/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2025 Blueshift
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/testing/derive/LICENSE-MIT
+++ b/testing/derive/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Blueshift
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testing/derive/README.md
+++ b/testing/derive/README.md
@@ -1,0 +1,19 @@
+# quasar-test-derive
+
+Attribute macros for [`quasar-test`](https://crates.io/crates/quasar-test).
+Depend on `quasar-test` instead of this crate; it re-exports `#[quasar_test]`.
+
+```rust,ignore
+use quasar_test::prelude::*;
+
+#[quasar_test]
+fn initialize(q: &mut QuasarTest) {
+    let payer = q.actor();
+    q.send(InitializeInstruction { payer }).succeeds();
+}
+```
+
+A `#[quasar_test]` function is a plain `#[test]` whose world is loaded from
+the crate's compiled program (`target/deploy/{crate_name}.so`, or the
+artifact `quasar test` supplies). Use
+`#[quasar_test(program_id = EXPR)]` for an external program.

--- a/testing/derive/src/lib.rs
+++ b/testing/derive/src/lib.rs
@@ -1,0 +1,80 @@
+//! Attribute macros for `quasar-test`.
+
+use {
+    proc_macro::TokenStream,
+    quote::quote,
+    syn::{parse_macro_input, FnArg, ItemFn, Pat},
+};
+
+/// Turn a function into a `#[test]` with a loaded on-chain world.
+///
+/// The function takes the world as its only parameter; the program id
+/// defaults to `crate::ID`:
+///
+/// ```rust,ignore
+/// #[quasar_test]
+/// fn initialize(q: &mut QuasarTest) {
+///     let payer = q.actor();
+///     q.send(InitializeInstruction { payer, value: 42 }).succeeds();
+/// }
+/// ```
+///
+/// Use `#[quasar_test(program_id = EXPR)]` for an external program, e.g. from
+/// an integration test where `crate::ID` is not the program crate.
+#[proc_macro_attribute]
+pub fn quasar_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+
+    let program_id = if attr.is_empty() {
+        quote! { crate::ID }
+    } else {
+        let args = parse_macro_input!(attr as syn::MetaNameValue);
+        if !args.path.is_ident("program_id") {
+            return syn::Error::new_spanned(
+                &args.path,
+                "expected `#[quasar_test]` or `#[quasar_test(program_id = EXPR)]`",
+            )
+            .to_compile_error()
+            .into();
+        }
+        let expr = &args.value;
+        quote! { #expr }
+    };
+
+    let signature_error = || {
+        syn::Error::new_spanned(
+            &func.sig,
+            "a #[quasar_test] function takes the world as its only parameter: \
+             `fn name(q: &mut QuasarTest)`",
+        )
+        .to_compile_error()
+        .into()
+    };
+    if func.sig.inputs.len() != 1 {
+        return signature_error();
+    }
+    let Some(FnArg::Typed(param)) = func.sig.inputs.first() else {
+        return signature_error();
+    };
+    let Pat::Ident(world) = &*param.pat else {
+        return signature_error();
+    };
+
+    let attrs = &func.attrs;
+    let name = &func.sig.ident;
+    let world_ty = &param.ty;
+    let world_name = &world.ident;
+    let body = &func.block;
+
+    quote! {
+        #(#attrs)*
+        #[test]
+        fn #name() {
+            let mut __quasar_world =
+                ::quasar_test::QuasarTest::new_for_crate(#program_id, env!("CARGO_PKG_NAME"));
+            let #world_name: #world_ty = &mut __quasar_world;
+            #body
+        }
+    }
+    .into()
+}

--- a/testing/derive/src/lib.rs
+++ b/testing/derive/src/lib.rs
@@ -44,8 +44,8 @@ pub fn quasar_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let signature_error = || {
         syn::Error::new_spanned(
             &func.sig,
-            "a #[quasar_test] function takes the world as its only parameter: \
-             `fn name(q: &mut QuasarTest)`",
+            "a #[quasar_test] function takes the world as its only parameter: `fn name(q: &mut \
+             QuasarTest)`",
         )
         .to_compile_error()
         .into()

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -728,6 +728,42 @@ pub mod fixtures {
     }
 }
 
+/// Test-side adjustments to a built [`quasar_svm::Instruction`].
+///
+/// Generated client instructions encode the canonical call. These helpers
+/// express a test's deliberate deviations from it by address, so the
+/// deviation is visible where the test constructs the instruction.
+pub trait InstructionExt: Sized {
+    /// Mark the given accounts as signers.
+    fn signed_by(self, signers: &[Pubkey]) -> quasar_svm::Instruction;
+
+    /// Replace every meta for `from` with `to`, e.g. to hand an instruction
+    /// the wrong program or a foreign account on purpose.
+    fn swap_account(self, from: Pubkey, to: Pubkey) -> quasar_svm::Instruction;
+}
+
+impl<T: Into<quasar_svm::Instruction>> InstructionExt for T {
+    fn signed_by(self, signers: &[Pubkey]) -> quasar_svm::Instruction {
+        let mut instruction = self.into();
+        for meta in &mut instruction.accounts {
+            if signers.contains(&meta.pubkey) {
+                meta.is_signer = true;
+            }
+        }
+        instruction
+    }
+
+    fn swap_account(self, from: Pubkey, to: Pubkey) -> quasar_svm::Instruction {
+        let mut instruction = self.into();
+        for meta in &mut instruction.accounts {
+            if meta.pubkey == from {
+                meta.pubkey = to;
+            }
+        }
+        instruction
+    }
+}
+
 /// Assertions layered on [`quasar_svm::ExecutionResult`].
 pub trait ExecutionResultExt {
     /// Assert success and keep the result available for chained expectations.
@@ -906,7 +942,9 @@ fn result_account<'a>(result: &'a quasar_svm::ExecutionResult, address: &Pubkey)
 /// Convenient imports for Quasar program tests.
 pub mod prelude {
     pub use {
-        crate::{quasar_test, ExecutionResultExt, QuasarSvmConfig, QuasarTest, Snapshot},
+        crate::{
+            quasar_test, ExecutionResultExt, InstructionExt, QuasarSvmConfig, QuasarTest, Snapshot,
+        },
         quasar_svm::{
             system_program, Account, AccountMeta, ExecutionResult, Instruction, ProgramError,
             Pubkey,

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -283,6 +283,22 @@ impl QuasarTest {
         address
     }
 
+    /// Derive an associated token address without registering an account.
+    ///
+    /// Use this for init targets: [`Self::ata`] would register an existing
+    /// account, which is exactly what an init instruction must not find.
+    pub fn ata_address(&self, owner: Pubkey, mint: Pubkey) -> Pubkey {
+        Pubkey::find_program_address(
+            &[
+                owner.as_ref(),
+                quasar_svm::SPL_TOKEN_PROGRAM_ID.as_ref(),
+                mint.as_ref(),
+            ],
+            &quasar_svm::SPL_ASSOCIATED_TOKEN_PROGRAM_ID,
+        )
+        .0
+    }
+
     /// Create an associated token account and return its derived address.
     pub fn ata(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
         let account = fixtures::associated_token_account(owner, mint, amount);
@@ -962,7 +978,8 @@ pub mod prelude {
         },
         quasar_svm::{
             system_program, Account, AccountMeta, ExecutionResult, Instruction, ProgramError,
-            Pubkey,
+            Pubkey, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_2022_PROGRAM_ID,
+            SPL_TOKEN_PROGRAM_ID,
         },
     };
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -5,13 +5,22 @@
 //! cover the account setup repeated by most program tests, while
 //! [`ExecutionResultExt`] makes outcomes readable as protocol expectations.
 
-pub use quasar_svm::{Account, Pubkey, QuasarSvm, QuasarSvmConfig};
-use std::{
-    env,
-    error::Error,
-    fmt, fs,
-    ops::{Deref, DerefMut},
-    path::{Path, PathBuf},
+use {
+    quasar_lang::{
+        __zeropod::{ZcElem, ZcValidate},
+        traits::{Discriminator, Owner, SeedSlices},
+    },
+    std::{
+        env,
+        error::Error,
+        fmt, fs,
+        ops::{Deref, DerefMut},
+        path::{Path, PathBuf},
+    },
+};
+pub use {
+    quasar_svm::{Account, Pubkey, QuasarSvm, QuasarSvmConfig},
+    quasar_test_derive::quasar_test,
 };
 
 /// Environment variable set by `quasar test` to the freshly built program.
@@ -26,6 +35,7 @@ pub const DEFAULT_ACTOR_LAMPORTS: u64 = 10_000_000_000;
 /// [`QuasarSvm`] methods remain available through `Deref`/`DerefMut`.
 pub struct QuasarTest {
     svm: QuasarSvm,
+    program_id: Pubkey,
     program_path: PathBuf,
 }
 
@@ -56,6 +66,25 @@ impl QuasarTest {
     /// Fallible variant of [`Self::new`].
     pub fn try_new(program_id: impl Into<Pubkey>) -> Result<Self, ProjectError> {
         Self::try_new_with_config(program_id, QuasarSvmConfig::default())
+    }
+
+    /// Load a crate's compiled program by name.
+    ///
+    /// Prefers `target/deploy/{crate_name}.so` (with `-` mapped to `_`) over
+    /// the only-artifact rule, so tests resolve their own program in a
+    /// workspace that builds several. `#[quasar_test]` calls this with
+    /// `env!("CARGO_PKG_NAME")`.
+    pub fn new_for_crate(program_id: impl Into<Pubkey>, crate_name: &str) -> Self {
+        Self::try_new_for_crate(program_id, crate_name).unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    /// Fallible variant of [`Self::new_for_crate`].
+    pub fn try_new_for_crate(
+        program_id: impl Into<Pubkey>,
+        crate_name: &str,
+    ) -> Result<Self, ProjectError> {
+        let path = resolve_program_path_named(crate_name)?;
+        Self::from_program_path_with_config(program_id, path, QuasarSvmConfig::default())
     }
 
     /// Fallible variant of [`Self::new_with_config`].
@@ -90,8 +119,14 @@ impl QuasarTest {
         let svm = QuasarSvm::new_with_config(config).with_program(&program_id, &elf);
         Ok(Self {
             svm,
+            program_id,
             program_path: path,
         })
+    }
+
+    /// The program under test.
+    pub fn program_id(&self) -> Pubkey {
+        self.program_id
     }
 
     /// The ELF artifact loaded for this test runtime.
@@ -241,12 +276,130 @@ impl QuasarTest {
         address
     }
 
+    /// Derive the canonical PDA for a seed set under the program under test.
+    ///
+    /// The seed set comes from the account's own `#[seeds(...)]` definition,
+    /// so the test derives addresses from the same source the program
+    /// validates against:
+    ///
+    /// ```rust,ignore
+    /// let vault = q.pda(Vault::seeds(&maker));
+    /// ```
+    pub fn pda(&self, seeds: impl SeedSlices) -> Pubkey {
+        self.pda_with_bump(seeds).0
+    }
+
+    /// Derive the canonical PDA and bump for a seed set.
+    pub fn pda_with_bump(&self, seeds: impl SeedSlices) -> (Pubkey, u8) {
+        seeds.with_slices(|slices| Pubkey::find_program_address(slices, &self.program_id))
+    }
+
+    /// Read an account as its typed state.
+    ///
+    /// Runs the same checks the program applies when loading `T`: the account
+    /// must exist, be owned by `T`'s program, carry `T`'s discriminator, and
+    /// hold enough valid data. The snapshot derefs to the account's data
+    /// layout, so assertions read in field terms:
+    ///
+    /// ```rust,ignore
+    /// let state = q.read::<Vault>(vault);
+    /// assert_eq!(state.authority, maker);
+    /// assert_eq!(state.balance, 500);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics with the failed check when the account does not hold a valid
+    /// `T`. Tests asserting on invalid accounts should use
+    /// [`QuasarSvm::get_account`] directly.
+    pub fn read<T>(&self, address: Pubkey) -> Snapshot<T>
+    where
+        T: Discriminator + Owner + Deref,
+        T::Target: ZcElem + ZcValidate + Copy,
+    {
+        let name = core::any::type_name::<T>();
+        let account = self
+            .svm
+            .get_account(&address)
+            .unwrap_or_else(|| panic!("read {name}: no account at {address}"));
+        if account.owner != T::OWNER {
+            panic!(
+                "read {name}: account {address} is owned by {}, expected {}",
+                account.owner,
+                T::OWNER
+            );
+        }
+        let disc = T::DISCRIMINATOR;
+        let expected_len = disc.len() + core::mem::size_of::<T::Target>();
+        if account.data.len() < expected_len {
+            panic!(
+                "read {name}: account {address} holds {} bytes, expected at least {expected_len}",
+                account.data.len()
+            );
+        }
+        if &account.data[..disc.len()] != disc {
+            panic!(
+                "read {name}: account {address} discriminator is {:?}, expected {disc:?}",
+                &account.data[..disc.len()]
+            );
+        }
+        // SAFETY: `T::Target` is `ZcElem` (`#[repr(C)]`, alignment 1), and the
+        // length check above proves the value's bytes are in bounds.
+        let state = unsafe { &*(account.data[disc.len()..].as_ptr() as *const T::Target) };
+        if let Err(error) = <T::Target as ZcValidate>::validate_ref(state) {
+            panic!("read {name}: account {address} holds invalid data: {error:?}");
+        }
+        Snapshot {
+            address,
+            lamports: account.lamports,
+            state: *state,
+        }
+    }
+
+    /// Register a rent-exempt program account holding `state`.
+    ///
+    /// The account gets `T`'s owner and discriminator, so a follow-up
+    /// [`Self::read`] (or the program itself) accepts it:
+    ///
+    /// ```rust,ignore
+    /// q.write::<Vault>(vault, VaultData { authority: maker, balance: 500.into(), bump });
+    /// ```
+    pub fn write<T>(&mut self, address: Pubkey, state: T::Target) -> Pubkey
+    where
+        T: Discriminator + Owner + Deref,
+        T::Target: ZcElem + Copy,
+    {
+        let disc = T::DISCRIMINATOR;
+        let size = core::mem::size_of::<T::Target>();
+        let mut data = vec![0u8; disc.len() + size];
+        data[..disc.len()].copy_from_slice(disc);
+        // SAFETY: `T::Target` is `ZcElem` (`#[repr(C)]`, alignment 1, no
+        // padding), so its `size` bytes are initialized and the destination
+        // range was sized for them.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                (&state as *const T::Target).cast::<u8>(),
+                data[disc.len()..].as_mut_ptr(),
+                size,
+            );
+        }
+        self.svm
+            .set_account(fixtures::program_account(address, T::OWNER, data));
+        address
+    }
+
     /// Execute and commit one instruction using the accounts in this world.
+    ///
+    /// Writable instruction accounts missing from the world are registered as
+    /// empty system accounts first, so freshly initialized accounts survive
+    /// into follow-up sends and [`Self::read`] without an explicit
+    /// [`Self::empty`] call.
     pub fn send(
         &mut self,
         instruction: impl Into<quasar_svm::Instruction>,
     ) -> quasar_svm::ExecutionResult {
         let instruction = instruction.into();
+        self.register_writable_accounts(&instruction);
         self.svm.process_instruction(&instruction, &[])
     }
 
@@ -262,8 +415,22 @@ impl QuasarTest {
         accounts: impl IntoIterator<Item = Account>,
     ) -> quasar_svm::ExecutionResult {
         let instruction = instruction.into();
+        self.register_writable_accounts(&instruction);
         let accounts = accounts.into_iter().collect::<Vec<_>>();
         self.svm.process_instruction(&instruction, &accounts)
+    }
+
+    /// Back missing writable instruction accounts with empty system accounts.
+    ///
+    /// The SVM only commits accounts that existed before the transaction, so
+    /// an unregistered init target would execute correctly and then vanish
+    /// from the world.
+    fn register_writable_accounts(&mut self, instruction: &quasar_svm::Instruction) {
+        for meta in &instruction.accounts {
+            if meta.is_writable && self.svm.get_account(&meta.pubkey).is_none() {
+                self.svm.set_account(fixtures::empty_account(meta.pubkey));
+            }
+        }
     }
 
     /// Simulate one instruction without committing its account changes.
@@ -290,25 +457,93 @@ impl DerefMut for QuasarTest {
     }
 }
 
-/// Resolve the compiled program path used by [`QuasarTest`].
-pub fn resolve_program_path() -> Result<PathBuf, ProjectError> {
-    if let Some(path) = env::var_os(PROGRAM_PATH_ENV) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Ok(path);
-        }
-        return Err(ProjectError::ConfiguredProgramMissing { path });
+/// Typed account state captured by [`QuasarTest::read`].
+///
+/// Derefs to the account's data layout (`{Name}Data`), so fields read
+/// directly: `snapshot.authority`, `snapshot.value`.
+pub struct Snapshot<T: Deref>
+where
+    T::Target: Sized + Copy,
+{
+    address: Pubkey,
+    lamports: u64,
+    state: T::Target,
+}
+
+impl<T: Deref> Snapshot<T>
+where
+    T::Target: Sized + Copy,
+{
+    /// The account's address.
+    pub fn address(&self) -> Pubkey {
+        self.address
     }
 
+    /// The account's lamport balance at read time.
+    pub fn lamports(&self) -> u64 {
+        self.lamports
+    }
+}
+
+impl<T: Deref> Deref for Snapshot<T>
+where
+    T::Target: Sized + Copy,
+{
+    type Target = T::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+/// Resolve the compiled program path used by [`QuasarTest`].
+pub fn resolve_program_path() -> Result<PathBuf, ProjectError> {
+    if let Some(path) = configured_program_path()? {
+        return Ok(path);
+    }
     let current_dir = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
     resolve_program_path_from(&current_dir)
 }
 
+/// Resolve a crate's compiled program path by name.
+pub fn resolve_program_path_named(crate_name: &str) -> Result<PathBuf, ProjectError> {
+    if let Some(path) = configured_program_path()? {
+        return Ok(path);
+    }
+    let current_dir = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
+    resolve_program_path_from_named(&current_dir, Some(crate_name))
+}
+
+fn configured_program_path() -> Result<Option<PathBuf>, ProjectError> {
+    let Some(path) = env::var_os(PROGRAM_PATH_ENV) else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(path);
+    if path.is_file() {
+        return Ok(Some(path));
+    }
+    Err(ProjectError::ConfiguredProgramMissing { path })
+}
+
 fn resolve_program_path_from(start: &Path) -> Result<PathBuf, ProjectError> {
+    resolve_program_path_from_named(start, None)
+}
+
+fn resolve_program_path_from_named(
+    start: &Path,
+    crate_name: Option<&str>,
+) -> Result<PathBuf, ProjectError> {
+    let artifact = crate_name.map(|name| format!("{}.so", name.replace('-', "_")));
     let mut checked = Vec::new();
     for ancestor in start.ancestors() {
         let deploy = ancestor.join("target/deploy");
         checked.push(deploy.clone());
+        if let Some(ref artifact) = artifact {
+            let path = deploy.join(artifact);
+            if path.is_file() {
+                return Ok(path);
+            }
+        }
         let mut programs = match fs::read_dir(&deploy) {
             Ok(entries) => entries
                 .filter_map(Result::ok)
@@ -671,46 +906,15 @@ fn result_account<'a>(result: &'a quasar_svm::ExecutionResult, address: &Pubkey)
 /// Convenient imports for Quasar program tests.
 pub mod prelude {
     pub use {
-        crate::{quasar_test, ExecutionResultExt, QuasarSvmConfig, QuasarTest},
-        quasar_svm::{Account, AccountMeta, ExecutionResult, Instruction, ProgramError, Pubkey},
+        crate::{quasar_test, ExecutionResultExt, QuasarSvmConfig, QuasarTest, Snapshot},
+        quasar_svm::{
+            system_program, Account, AccountMeta, ExecutionResult, Instruction, ProgramError,
+            Pubkey,
+        },
     };
 }
 
 pub use quasar_svm;
-
-/// Define a program test with a freshly loaded [`QuasarTest`] world.
-///
-/// The program id defaults to `crate::ID`:
-///
-/// ```rust,ignore
-/// quasar_test! {
-///     fn rejects_zero_deposit(q) {
-///         q.send(make_instruction(0)).fails_with(EscrowError::InvalidAmount);
-///     }
-/// }
-/// ```
-///
-/// Use `program_id = expression` before the function for an external program.
-#[allow(clippy::crate_in_macro_def)]
-#[macro_export]
-macro_rules! quasar_test {
-    ($(#[$meta:meta])* fn $name:ident($world:ident) $body:block) => {
-        $(#[$meta])*
-        #[test]
-        fn $name() {
-            let mut $world = $crate::QuasarTest::new(crate::ID);
-            $body
-        }
-    };
-    (program_id = $program_id:expr; $(#[$meta:meta])* fn $name:ident($world:ident) $body:block) => {
-        $(#[$meta])*
-        #[test]
-        fn $name() {
-            let mut $world = $crate::QuasarTest::new($program_id);
-            $body
-        }
-    };
-}
 
 #[cfg(test)]
 mod tests {
@@ -740,6 +944,22 @@ mod tests {
         assert_eq!(
             resolve_program_path_from(&nested).unwrap(),
             deploy.join("example.so")
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn resolves_the_named_crate_among_many_programs() {
+        let root = temp_dir("named");
+        let deploy = root.join("target/deploy");
+        fs::create_dir_all(&deploy).unwrap();
+        fs::write(deploy.join("my_program.so"), b"elf").unwrap();
+        fs::write(deploy.join("other_program.so"), b"elf").unwrap();
+
+        assert_eq!(
+            super::resolve_program_path_from_named(&root, Some("my-program")).unwrap(),
+            deploy.join("my_program.so")
         );
 
         fs::remove_dir_all(root).unwrap();

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -37,6 +37,7 @@ pub struct QuasarTest {
     svm: QuasarSvm,
     program_id: Pubkey,
     program_path: PathBuf,
+    fresh_addresses: u64,
 }
 
 impl QuasarTest {
@@ -121,6 +122,7 @@ impl QuasarTest {
             svm,
             program_id,
             program_path: path,
+            fresh_addresses: 0,
         })
     }
 
@@ -207,8 +209,21 @@ impl QuasarTest {
 
     /// Create a funded actor at a fresh address with an explicit balance.
     pub fn actor_with_lamports(&mut self, lamports: u64) -> Pubkey {
-        let address = Pubkey::new_unique();
+        let address = self.fresh_address();
         self.fund(address, lamports)
+    }
+
+    /// A fresh address no earlier fixture in this world has used.
+    ///
+    /// Addresses derive from a per-world counter, not a process-global one,
+    /// so a test sees the same addresses on every run regardless of which
+    /// other tests exist or run first. Compute-unit records stay comparable
+    /// without hand-pinned address constants.
+    pub fn fresh_address(&mut self) -> Pubkey {
+        self.fresh_addresses += 1;
+        let mut bytes = *b"quasar-test/fresh-address\0\0\0\0\0\0\0";
+        bytes[24..].copy_from_slice(&self.fresh_addresses.to_le_bytes());
+        Pubkey::new_from_array(bytes)
     }
 
     /// Create or replace a system account and return its address.
@@ -231,7 +246,7 @@ impl QuasarTest {
 
     /// Create a six-decimal mint with an explicit supply at a fresh address.
     pub fn mint_with_supply(&mut self, authority: Pubkey, supply: u64) -> Pubkey {
-        let address = Pubkey::new_unique();
+        let address = self.fresh_address();
         self.mint_at(address, authority, supply, 6)
     }
 
@@ -251,7 +266,7 @@ impl QuasarTest {
 
     /// Create an SPL Token account at a fresh address.
     pub fn token_account(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
-        let address = Pubkey::new_unique();
+        let address = self.fresh_address();
         self.token_account_at(address, owner, mint, amount)
     }
 

--- a/tests/programs/test-misc/Cargo.toml
+++ b/tests/programs/test-misc/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-test = false
 doctest = false
 
 [lints]
@@ -21,3 +20,6 @@ idl-build = ["quasar-lang/idl-build"]
 [dependencies]
 quasar-lang = { path = "../../../lang" }
 quasar-derive = { path = "../../../derive" }
+
+[dev-dependencies]
+quasar-test = { path = "../../../testing" }

--- a/tests/programs/test-misc/src/dx_tests.rs
+++ b/tests/programs/test-misc/src/dx_tests.rs
@@ -9,7 +9,7 @@ use {
         state::{SimpleAccount, SimpleAccountData},
     },
     quasar_lang::prelude::QuasarError,
-    quasar_test::{prelude::*, quasar_svm::system_program},
+    quasar_test::prelude::*,
 };
 
 #[quasar_test]
@@ -17,13 +17,8 @@ fn initialize_stores_typed_state(q: &mut QuasarTest) {
     let payer = q.actor();
     let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&payer));
 
-    q.send(InitializeInstruction {
-        payer,
-        account,
-        system_program: system_program::ID,
-        value: 42,
-    })
-    .succeeds();
+    q.send(InitializeInstruction { payer, value: 42 })
+        .succeeds();
 
     let state = q.read::<SimpleAccount>(account);
     assert_eq!(state.authority, payer);
@@ -44,7 +39,7 @@ fn close_returns_the_account_to_the_system(q: &mut QuasarTest) {
         },
     );
 
-    q.send(CloseAccountInstruction { authority, account })
+    q.send(CloseAccountInstruction { authority })
         .succeeds()
         .is_closed(account);
 }
@@ -62,9 +57,14 @@ fn close_rejects_a_foreign_authority(q: &mut QuasarTest) {
         },
     );
 
-    q.send(CloseAccountInstruction {
-        authority: intruder,
-        account,
-    })
+    // The client derives the PDA from the passed authority; swapping in the
+    // owner's account is the mismatch under test.
+    let intruder_pda = q.pda(SimpleAccount::seeds(&intruder));
+    q.send(
+        CloseAccountInstruction {
+            authority: intruder,
+        }
+        .swap_account(intruder_pda, account),
+    )
     .fails_with(QuasarError::InvalidPda as u32);
 }

--- a/tests/programs/test-misc/src/dx_tests.rs
+++ b/tests/programs/test-misc/src/dx_tests.rs
@@ -66,5 +66,5 @@ fn close_rejects_a_foreign_authority(q: &mut QuasarTest) {
         }
         .swap_account(intruder_pda, account),
     )
-    .fails_with(QuasarError::InvalidPda as u32);
+    .fails_with(QuasarError::InvalidPda);
 }

--- a/tests/programs/test-misc/src/dx_tests.rs
+++ b/tests/programs/test-misc/src/dx_tests.rs
@@ -1,0 +1,70 @@
+//! On-chain unit tests written like plain Rust tests.
+//!
+//! Everything typed comes from the program itself: instructions from the
+//! generated client, addresses from `#[seeds]`, state from `#[account]`.
+
+use {
+    crate::{
+        cpi::{CloseAccountInstruction, InitializeInstruction},
+        state::{SimpleAccount, SimpleAccountData},
+    },
+    quasar_lang::prelude::QuasarError,
+    quasar_test::{prelude::*, quasar_svm::system_program},
+};
+
+#[quasar_test]
+fn initialize_stores_typed_state(q: &mut QuasarTest) {
+    let payer = q.actor();
+    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&payer));
+
+    q.send(InitializeInstruction {
+        payer,
+        account,
+        system_program: system_program::ID,
+        value: 42,
+    })
+    .succeeds();
+
+    let state = q.read::<SimpleAccount>(account);
+    assert_eq!(state.authority, payer);
+    assert_eq!(state.value, 42);
+    assert_eq!(state.bump, bump);
+}
+
+#[quasar_test]
+fn close_returns_the_account_to_the_system(q: &mut QuasarTest) {
+    let authority = q.actor();
+    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&authority));
+    q.write::<SimpleAccount>(
+        account,
+        SimpleAccountData {
+            authority,
+            value: 7.into(),
+            bump,
+        },
+    );
+
+    q.send(CloseAccountInstruction { authority, account })
+        .succeeds()
+        .is_closed(account);
+}
+
+#[quasar_test]
+fn close_rejects_a_foreign_authority(q: &mut QuasarTest) {
+    let [owner, intruder] = q.actors();
+    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&owner));
+    q.write::<SimpleAccount>(
+        account,
+        SimpleAccountData {
+            authority: owner,
+            value: 7.into(),
+            bump,
+        },
+    );
+
+    q.send(CloseAccountInstruction {
+        authority: intruder,
+        account,
+    })
+    .fails_with(QuasarError::InvalidPda as u32);
+}

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -1,10 +1,12 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![allow(dead_code)]
 
 use quasar_lang::prelude::*;
 
 mod instructions;
 use instructions::*;
+#[cfg(test)]
+mod dx_tests;
 pub mod errors;
 pub mod state;
 declare_id!("44444444444444444444444444444444444444444444");

--- a/tests/suite/src/account_validation.rs
+++ b/tests/suite/src/account_validation.rs
@@ -285,9 +285,8 @@ fn system_account_owned_by_program() {
 #[test]
 fn program_success() {
     let mut svm = svm_errors();
-    let program = quasar_svm::system_program::ID;
+    let ix: Instruction = ProgramCheckInstruction {}.into();
 
-    let ix: Instruction = ProgramCheckInstruction { program }.into();
     let result = svm.process_instruction(&ix, &[]);
     assert!(result.is_ok(), "program check: {:?}", result.raw_result);
 }
@@ -296,8 +295,11 @@ fn program_success() {
 fn program_wrong_id() {
     let mut svm = svm_errors();
     let wrong = Pubkey::new_unique();
+    // The client fills the canonical Program<T> address; point the meta at a
+    // wrong executable on purpose.
+    let mut ix: Instruction = ProgramCheckInstruction {}.into();
+    ix.accounts[0].pubkey = wrong;
 
-    let ix: Instruction = ProgramCheckInstruction { program: wrong }.into();
     let result = svm.process_instruction(
         &ix,
         &[Account {
@@ -316,8 +318,8 @@ fn program_wrong_id() {
 fn program_not_executable() {
     let mut svm = svm_errors();
     let system = quasar_svm::system_program::ID;
+    let ix: Instruction = ProgramCheckInstruction {}.into();
 
-    let ix: Instruction = ProgramCheckInstruction { program: system }.into();
     let result = svm.process_instruction(
         &ix,
         &[Account {

--- a/tests/suite/src/close.rs
+++ b/tests/suite/src/close.rs
@@ -11,7 +11,7 @@ fn success() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", authority.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = CloseAccountInstruction { authority, account }.into();
+    let ix: Instruction = CloseAccountInstruction { authority }.into();
 
     let result = svm.process_instruction(
         &ix,
@@ -45,7 +45,7 @@ fn lamports_transferred() {
     let account_lamports = 2_000_000u64;
     let authority_lamports = 1_000_000u64;
 
-    let ix: Instruction = CloseAccountInstruction { authority, account }.into();
+    let ix: Instruction = CloseAccountInstruction { authority }.into();
 
     let result = svm.process_instruction(
         &ix,
@@ -86,7 +86,7 @@ fn destination_balance_additive() {
     let x = 50_000_000u64;
     let y = 3_000_000u64;
 
-    let ix: Instruction = CloseAccountInstruction { authority, account }.into();
+    let ix: Instruction = CloseAccountInstruction { authority }.into();
 
     let result = svm.process_instruction(
         &ix,
@@ -121,11 +121,14 @@ fn wrong_authority() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", real_authority.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = CloseAccountInstruction {
+    // The client derives the PDA from the passed authority; point the meta
+    // back at the real account: wrong authority against it is the case under
+    // test.
+    let mut ix: Instruction = CloseAccountInstruction {
         authority: wrong_authority,
-        account,
     }
     .into();
+    ix.accounts[1].pubkey = account;
 
     let result = svm.process_instruction(
         &ix,
@@ -148,7 +151,7 @@ fn authority_not_signer() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", authority.as_ref()], &quasar_test_misc::ID);
 
-    let mut ix: Instruction = CloseAccountInstruction { authority, account }.into();
+    let mut ix: Instruction = CloseAccountInstruction { authority }.into();
     ix.accounts[0].is_signer = false;
 
     let result = svm.process_instruction(

--- a/tests/suite/src/constraints.rs
+++ b/tests/suite/src/constraints.rs
@@ -13,7 +13,7 @@ fn has_one_success() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", authority.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = UpdateHasOneInstruction { authority, account }.into();
+    let ix: Instruction = UpdateHasOneInstruction { authority }.into();
     let result = svm.process_instruction(
         &ix,
         &[
@@ -32,11 +32,13 @@ fn has_one_mismatch() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", real_authority.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = UpdateHasOneInstruction {
+    // The client derives the PDA from the passed authority; point the meta
+    // back at the real account.
+    let mut ix: Instruction = UpdateHasOneInstruction {
         authority: wrong_authority,
-        account,
     }
     .into();
+    ix.accounts[1].pubkey = account;
     let result = svm.process_instruction(
         &ix,
         &[
@@ -61,7 +63,7 @@ fn has_one_zeroed_authority() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", authority.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = UpdateHasOneInstruction { authority, account }.into();
+    let ix: Instruction = UpdateHasOneInstruction { authority }.into();
     // Stored authority is zeroed
     let result = svm.process_instruction(
         &ix,
@@ -88,7 +90,7 @@ fn has_one_single_bit_diff() {
     bad_bytes[0] ^= 1;
     let bad_authority = Pubkey::from(bad_bytes);
 
-    let ix: Instruction = UpdateHasOneInstruction { authority, account }.into();
+    let ix: Instruction = UpdateHasOneInstruction { authority }.into();
     let result = svm.process_instruction(
         &ix,
         &[
@@ -114,7 +116,7 @@ fn has_one_last_byte_diff() {
     bad_bytes[31] ^= 0xFF;
     let bad_authority = Pubkey::from(bad_bytes);
 
-    let ix: Instruction = UpdateHasOneInstruction { authority, account }.into();
+    let ix: Instruction = UpdateHasOneInstruction { authority }.into();
     let result = svm.process_instruction(
         &ix,
         &[
@@ -139,11 +141,13 @@ fn has_one_default_passed() {
     );
 
     // Passed authority = default, stored = real
-    let ix: Instruction = UpdateHasOneInstruction {
+    // The client derives the PDA from the passed authority; point the meta
+    // back at the real account.
+    let mut ix: Instruction = UpdateHasOneInstruction {
         authority: default_authority,
-        account,
     }
     .into();
+    ix.accounts[1].pubkey = account;
     let result = svm.process_instruction(
         &ix,
         &[

--- a/tests/suite/src/cpi_pointer_safety.rs
+++ b/tests/suite/src/cpi_pointer_safety.rs
@@ -28,7 +28,6 @@ fn mut_readback_data_and_lamports() {
     let ix: Instruction = CpiMutReadbackInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_value: 999,
     }
     .into();
@@ -61,7 +60,6 @@ fn mut_readback_wrapping_overflow() {
     let ix: Instruction = CpiMutReadbackInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_value: u64::MAX,
     }
     .into();
@@ -90,7 +88,6 @@ fn mut_readback_zero_value() {
     let ix: Instruction = CpiMutReadbackInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_value: 0,
     }
     .into();

--- a/tests/suite/src/cpi_return.rs
+++ b/tests/suite/src/cpi_return.rs
@@ -3,10 +3,7 @@ use {crate::helpers::*, quasar_svm::Instruction, quasar_test_misc::cpi::*};
 #[test]
 fn cpi_invoke_with_return_round_trips_u64() {
     let mut svm = svm_misc();
-    let ix: Instruction = CpiInvokeWithReturnInstruction {
-        program: quasar_test_misc::ID,
-    }
-    .into();
+    let ix: Instruction = CpiInvokeWithReturnInstruction {}.into();
 
     let result = svm.process_instruction(&ix, &[]);
     assert!(result.is_ok(), "u64 return: {:?}", result.raw_result);
@@ -15,10 +12,7 @@ fn cpi_invoke_with_return_round_trips_u64() {
 #[test]
 fn cpi_invoke_with_return_round_trips_struct() {
     let mut svm = svm_misc();
-    let ix: Instruction = CpiInvokeStructReturnInstruction {
-        program: quasar_test_misc::ID,
-    }
-    .into();
+    let ix: Instruction = CpiInvokeStructReturnInstruction {}.into();
 
     let result = svm.process_instruction(&ix, &[]);
     assert!(result.is_ok(), "struct return: {:?}", result.raw_result);
@@ -27,10 +21,7 @@ fn cpi_invoke_with_return_round_trips_struct() {
 #[test]
 fn cpi_plain_invoke_ignores_return_data() {
     let mut svm = svm_misc();
-    let ix: Instruction = CpiInvokeIgnoreReturnInstruction {
-        program: quasar_test_misc::ID,
-    }
-    .into();
+    let ix: Instruction = CpiInvokeIgnoreReturnInstruction {}.into();
 
     let result = svm.process_instruction(&ix, &[]);
     assert!(result.is_ok(), "plain invoke: {:?}", result.raw_result);
@@ -39,10 +30,7 @@ fn cpi_plain_invoke_ignores_return_data() {
 #[test]
 fn cpi_invoke_with_return_detects_missing_return_after_prior_success() {
     let mut svm = svm_misc();
-    let ix: Instruction = CpiInvokeMissingReturnInstruction {
-        program: quasar_test_misc::ID,
-    }
-    .into();
+    let ix: Instruction = CpiInvokeMissingReturnInstruction {}.into();
 
     let result = svm.process_instruction(&ix, &[]);
     assert!(result.is_ok(), "missing return: {:?}", result.raw_result);
@@ -61,10 +49,7 @@ fn cpi_missing_return_data_rejects() {
     // Callee succeeds but sets no return data: invoke_with_return must fail
     // with MissingReturnData rather than hand back stale bytes.
     let mut svm = svm_errors();
-    let ix: Instruction = err_cpi::CpiMissingReturnInstruction {
-        program: quasar_test_errors::ID,
-    }
-    .into();
+    let ix: Instruction = err_cpi::CpiMissingReturnInstruction {}.into();
     let result = svm.process_instruction(&ix, &[]);
     result.assert_error(ProgramError::Custom(QuasarError::MissingReturnData as u32));
 }
@@ -74,10 +59,7 @@ fn cpi_return_length_mismatch_rejects() {
     // Callee returns 12 bytes; caller decodes u64 (8 bytes): the typed decode
     // must fail with InvalidReturnData rather than read a prefix.
     let mut svm = svm_errors();
-    let ix: Instruction = err_cpi::CpiDecodeMismatchInstruction {
-        program: quasar_test_errors::ID,
-    }
-    .into();
+    let ix: Instruction = err_cpi::CpiDecodeMismatchInstruction {}.into();
     let result = svm.process_instruction(&ix, &[]);
     result.assert_error(ProgramError::Custom(QuasarError::InvalidReturnData as u32));
 }
@@ -89,7 +71,6 @@ fn cpi_return_data_from_wrong_program_rejects() {
     // with ReturnDataFromWrongProgram rather than trust foreign bytes.
     let mut svm = svm_errors_with_misc();
     let ix: Instruction = err_cpi::CpiWrongReturnProgramInstruction {
-        program: quasar_test_errors::ID,
         misc_program: quasar_test_misc::ID,
     }
     .into();

--- a/tests/suite/src/cpi_system.rs
+++ b/tests/suite/src/cpi_system.rs
@@ -16,7 +16,6 @@ fn create_success() {
     let ix: Instruction = CreateAccountTestInstruction {
         payer,
         new_account,
-        system_program: quasar_svm::system_program::ID,
         lamports: 1_000_000,
         space: 100,
         owner,
@@ -45,7 +44,6 @@ fn create_zero_space() {
     let ix: Instruction = CreateAccountTestInstruction {
         payer,
         new_account,
-        system_program: quasar_svm::system_program::ID,
         lamports: 890_880, // rent for 0 bytes
         space: 0,
         owner,
@@ -69,7 +67,6 @@ fn create_large_space() {
     let ix: Instruction = CreateAccountTestInstruction {
         payer,
         new_account,
-        system_program: quasar_svm::system_program::ID,
         lamports: 100_000_000,
         space: 10_000,
         owner,
@@ -94,7 +91,6 @@ fn create_insufficient_funds() {
     let ix: Instruction = CreateAccountTestInstruction {
         payer,
         new_account,
-        system_program: quasar_svm::system_program::ID,
         lamports: 100_000_000,
         space: 100,
         owner: Pubkey::new_unique(),
@@ -129,7 +125,6 @@ fn transfer_success() {
     let ix: Instruction = TransferTestInstruction {
         from,
         to,
-        system_program: quasar_svm::system_program::ID,
         amount: 500_000,
     }
     .into();
@@ -147,7 +142,6 @@ fn transfer_zero() {
     let ix: Instruction = TransferTestInstruction {
         from,
         to,
-        system_program: quasar_svm::system_program::ID,
         amount: 0,
     }
     .into();
@@ -166,7 +160,6 @@ fn transfer_full_balance() {
     let ix: Instruction = TransferTestInstruction {
         from,
         to,
-        system_program: quasar_svm::system_program::ID,
         amount: balance,
     }
     .into();
@@ -198,7 +191,6 @@ fn transfer_to_self_borrow_fail() {
     let ix: Instruction = TransferTestInstruction {
         from: account,
         to: account,
-        system_program: quasar_svm::system_program::ID,
         amount: 100,
     }
     .into();
@@ -224,7 +216,6 @@ fn assign_success() {
 
     let ix: Instruction = AssignTestInstruction {
         account,
-        system_program: quasar_svm::system_program::ID,
         owner: new_owner,
     }
     .into();
@@ -243,7 +234,6 @@ fn assign_to_system_program() {
 
     let ix: Instruction = AssignTestInstruction {
         account,
-        system_program: quasar_svm::system_program::ID,
         owner: quasar_svm::system_program::ID,
     }
     .into();
@@ -261,7 +251,6 @@ fn transfer_rejects_insufficient_funds() {
     let ix: Instruction = TransferTestInstruction {
         from,
         to,
-        system_program: quasar_svm::system_program::ID,
         amount: 500_000,
     }
     .into();
@@ -291,7 +280,6 @@ fn transfer_rejects_missing_signer() {
     let mut ix: Instruction = TransferTestInstruction {
         from,
         to,
-        system_program: quasar_svm::system_program::ID,
         amount: 500_000,
     }
     .into();

--- a/tests/suite/src/discriminator.rs
+++ b/tests/suite/src/discriminator.rs
@@ -165,13 +165,7 @@ fn no_disc_init_success() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"nodisc", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitNoDiscInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitNoDiscInstruction { payer, value: 42 }.into();
 
     let result =
         svm.process_instruction(&ix, &[rich_signer_account(payer), empty_account(account)]);
@@ -191,13 +185,7 @@ fn no_disc_read_after_init() {
         Pubkey::find_program_address(&[b"nodisc", payer.as_ref()], &quasar_test_misc::ID);
 
     // Init first
-    let ix1: Instruction = InitNoDiscInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 99,
-    }
-    .into();
+    let ix1: Instruction = InitNoDiscInstruction { payer, value: 99 }.into();
     let r1 = svm.process_instruction(&ix1, &[rich_signer_account(payer), empty_account(account)]);
     assert!(r1.is_ok(), "init: {:?}", r1.raw_result);
 

--- a/tests/suite/src/events.rs
+++ b/tests/suite/src/events.rs
@@ -83,7 +83,6 @@ fn test_emit_cpi_success() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -112,7 +111,6 @@ fn test_emit_cpi_different_value() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 999,
     }
     .into();
@@ -141,7 +139,6 @@ fn test_emit_cpi_cu() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -165,7 +162,6 @@ fn test_emit_cpi_wrong_authority() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority: wrong_authority,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -278,7 +274,6 @@ fn test_emit_cpi_with_extra_accounts() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 77,
     }
     .into();
@@ -299,13 +294,19 @@ fn test_emit_cpi_wrong_program() {
     let (event_authority, _) =
         Address::find_program_address(&[b"__event_authority"], &quasar_test_events::ID);
     let wrong_program = Address::new_unique();
-    let instruction = EmitViaCpiInstruction {
+    // The client fills the canonical program address; point the meta at a
+    // wrong executable on purpose.
+    let mut instruction: solana_instruction::Instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: wrong_program,
         value: 42,
     }
     .into();
+    for meta in &mut instruction.accounts {
+        if meta.pubkey == quasar_test_events::ID {
+            meta.pubkey = wrong_program;
+        }
+    }
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -342,7 +343,6 @@ fn test_emit_cpi_missing_event_authority() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority: random_account,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -367,7 +367,6 @@ fn test_emit_cpi_authority_not_signer() {
     let mut instruction: solana_instruction::Instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -395,7 +394,6 @@ fn test_emit_cpi_cu_budget() {
     let instruction = EmitViaCpiInstruction {
         signer,
         event_authority,
-        program: quasar_test_events::ID,
         value: 42,
     }
     .into();
@@ -498,7 +496,6 @@ fn test_emit_cpi_aliased_program_field_reaches_log() {
     let instruction: quasar_svm::Instruction = EmitViaCpiAliasedInstruction {
         signer,
         event_authority,
-        emitter: quasar_test_events::ID,
         value: 42,
     }
     .into();

--- a/tests/suite/src/helpers.rs
+++ b/tests/suite/src/helpers.rs
@@ -53,10 +53,6 @@ pub fn token_2022_program_id() -> Pubkey {
     quasar_svm::SPL_TOKEN_2022_PROGRAM_ID
 }
 
-pub fn ata_program_id() -> Pubkey {
-    quasar_svm::SPL_ASSOCIATED_TOKEN_PROGRAM_ID
-}
-
 pub fn with_signers(mut ix: Instruction, indices: &[usize]) -> Instruction {
     for &i in indices {
         ix.accounts[i].is_signer = true;

--- a/tests/suite/src/init.rs
+++ b/tests/suite/src/init.rs
@@ -13,13 +13,7 @@ fn fresh_account() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
 
     let result =
         svm.process_instruction(&ix, &[rich_signer_account(payer), empty_account(account)]);
@@ -40,13 +34,7 @@ fn prefunded_partial_rent() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 7,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 7 }.into();
 
     // Account has some lamports but less than rent-exempt minimum
     let prefund = 500_000u64;
@@ -92,13 +80,7 @@ fn prefunded_excess_rent() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 7,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 7 }.into();
 
     // Account already has more than enough lamports
     let result = svm.process_instruction(
@@ -123,33 +105,17 @@ fn after_close() {
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
     // First init
-    let ix1: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix1: Instruction = InitializeInstruction { payer, value: 42 }.into();
     let r1 = svm.process_instruction(&ix1, &[rich_signer_account(payer), empty_account(account)]);
     assert!(r1.is_ok(), "first init: {:?}", r1.raw_result);
 
     // Close
-    let ix2: Instruction = CloseAccountInstruction {
-        authority: payer,
-        account,
-    }
-    .into();
+    let ix2: Instruction = CloseAccountInstruction { authority: payer }.into();
     let r2 = svm.process_instruction(&ix2, &[]);
     assert!(r2.is_ok(), "close: {:?}", r2.raw_result);
 
     // Re-init
-    let ix3: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 99,
-    }
-    .into();
+    let ix3: Instruction = InitializeInstruction { payer, value: 99 }.into();
     let r3 = svm.process_instruction(&ix3, &[]);
     assert!(r3.is_ok(), "re-init: {:?}", r3.raw_result);
 
@@ -164,13 +130,7 @@ fn space_override() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"spacetest", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = SpaceOverrideInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = SpaceOverrideInstruction { payer, value: 42 }.into();
 
     let result =
         svm.process_instruction(&ix, &[rich_signer_account(payer), empty_account(account)]);
@@ -187,13 +147,7 @@ fn explicit_payer() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"explicit", funder.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = ExplicitPayerInstruction {
-        funder,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = ExplicitPayerInstruction { funder, value: 42 }.into();
 
     let result =
         svm.process_instruction(&ix, &[rich_signer_account(funder), empty_account(account)]);
@@ -213,13 +167,7 @@ fn already_initialized() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
 
     // Account already owned by program with valid data
     let result = svm.process_instruction(
@@ -240,13 +188,7 @@ fn owned_by_other_program() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
 
     // Account owned by random program
     let result = svm.process_instruction(
@@ -270,13 +212,7 @@ fn payer_not_signer() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let mut ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let mut ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
     ix.accounts[0].is_signer = false;
 
     let result =
@@ -292,13 +228,7 @@ fn payer_insufficient_funds() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
 
     // Payer with only 1 lamport
     let result = svm.process_instruction(
@@ -324,13 +254,10 @@ fn wrong_pda_seeds() {
     let payer = Pubkey::new_unique();
     let wrong_account = Pubkey::new_unique(); // not a valid PDA
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account: wrong_account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let mut ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    ix.accounts[1].pubkey = wrong_account;
 
     let result = svm.process_instruction(
         &ix,
@@ -348,13 +275,7 @@ fn zero_data_owned_by_program() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
 
     // All-zero data but owned by our program
     let result = svm.process_instruction(
@@ -378,13 +299,7 @@ fn prefunded_exact_no_topup() {
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
     let payer_lamports = 10_000_000_000u64;
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 7,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 7 }.into();
 
     // Pre-fund with 10 SOL, well above rent-exempt minimum, so no transfer CPI.
     let result = svm.process_instruction(
@@ -418,13 +333,7 @@ fn prefunded_one_lamport() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 7,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 7 }.into();
 
     // Pre-fund with just 1 lamport; payer must top up almost all rent.
     let result = svm.process_instruction(

--- a/tests/suite/src/init_if_needed.rs
+++ b/tests/suite/src/init_if_needed.rs
@@ -13,13 +13,7 @@ fn new_account() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     let result =
         svm.process_instruction(&ix, &[rich_signer_account(payer), empty_account(account)]);
@@ -38,13 +32,7 @@ fn existing_valid() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 99,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 99 }.into();
 
     // Already initialized with correct owner/disc/size
     let result = svm.process_instruction(
@@ -64,13 +52,7 @@ fn existing_value_updated() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 99,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 99 }.into();
 
     let payer_lamports_before = 100_000_000_000u64;
     let account_lamports_before = 1_000_000u64;
@@ -111,13 +93,7 @@ fn new_prefunded() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     // System-owned with lamports uses the pre-funded init path.
     let result = svm.process_instruction(
@@ -143,13 +119,7 @@ fn wrong_owner() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     // Owned by random program (not system, not ours)
     let result = svm.process_instruction(
@@ -171,13 +141,7 @@ fn wrong_discriminator() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     // Correct owner, wrong discriminator
     let mut data = vec![0u8; 42];
@@ -200,13 +164,7 @@ fn data_too_small() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     // Correct owner + disc but data too small
     let mut data = vec![0u8; 10]; // too small (42 needed)
@@ -229,13 +187,7 @@ fn not_writable() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let mut ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let mut ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
     ix.accounts[1].is_writable = false;
 
     let result =
@@ -253,13 +205,7 @@ fn payer_insufficient_funds() {
     let (account, _bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 42 }.into();
 
     let result = svm.process_instruction(
         &ix,
@@ -294,13 +240,7 @@ fn front_running_attacker_data() {
     let (account, bump) =
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
-    let ix: Instruction = InitIfNeededInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 99,
-    }
-    .into();
+    let ix: Instruction = InitIfNeededInstruction { payer, value: 99 }.into();
 
     // Account already initialized by "attacker" with correct owner, disc, and
     // size, but authority = attacker (not payer).

--- a/tests/suite/src/optional_args.rs
+++ b/tests/suite/src/optional_args.rs
@@ -180,7 +180,6 @@ fn optional_dynamic_args_some_some_use_compact_tail_payloads() {
 #[test]
 fn optional_dynamic_generated_client_uses_compact_header_then_tail_layout() {
     let ix: Instruction = OptionalDynamicArgInstruction {
-        program: quasar_test_misc::ID,
         maybe_name: Some(DynString::<u8>::from("quasar")),
         maybe_addrs: Some(DynVec::<Pubkey, u16>::from(vec![
             quasar_test_misc::EXPECTED_ADDRESS,

--- a/tests/suite/src/pda.rs
+++ b/tests/suite/src/pda.rs
@@ -1024,7 +1024,7 @@ fn test_typed_seed_deserialized_field() {
     // Step 3: Verify the ScopedItem using config.namespace as seed
     let verify_ix: Instruction = VerifyScopedItemInstruction {
         config: config_pda,
-        item: item_pda,
+        config_namespace_seed: namespace,
     }
     .into();
 
@@ -1076,7 +1076,7 @@ fn test_init_typed_seed_from_account_field() {
     let init_from_config_ix: Instruction = InitScopedItemFromConfigInstruction {
         payer,
         config: config_pda,
-        item: item_pda,
+        config_namespace_seed: namespace,
     }
     .into();
 

--- a/tests/suite/src/pda.rs
+++ b/tests/suite/src/pda.rs
@@ -35,12 +35,7 @@ fn test_literal_seed_init() {
     let payer = Address::new_unique();
     let (config, _) = Address::find_program_address(&[b"config"], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitLiteralSeedInstruction {
-        payer,
-        config,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitLiteralSeedInstruction { payer }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -70,13 +65,7 @@ fn test_pubkey_seed_init() {
     let payer = Address::new_unique();
     let (user, _) = Address::find_program_address(&[b"user", payer.as_ref()], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitPubkeySeedInstruction {
-        payer,
-        user,
-        system_program,
-        value: 42,
-    }
-    .into();
+    let instruction: Instruction = InitPubkeySeedInstruction { payer, value: 42 }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -115,8 +104,6 @@ fn test_instruction_seed_init() {
     let instruction: Instruction = InitInstructionSeedInstruction {
         payer,
         authority,
-        item,
-        system_program,
         id: 123,
     }
     .into();
@@ -160,8 +147,6 @@ fn test_multi_seed_init() {
     let instruction: Instruction = InitMultiSeedsInstruction {
         payer,
         authority,
-        complex,
-        system_program,
         amount: 500,
     }
     .into();
@@ -203,7 +188,6 @@ fn test_update_pda_success() {
 
     let instruction: Instruction = UpdatePdaInstruction {
         authority,
-        user: pda,
         new_value: 100,
     }
     .into();
@@ -247,12 +231,14 @@ fn test_update_pda_wrong_seeds() {
 
     let account_data = build_user_account_data(authority, 42, bump);
 
-    let instruction: Instruction = UpdatePdaInstruction {
+    let mut instruction: Instruction = UpdatePdaInstruction {
         authority,
-        user: wrong_pda,
         new_value: 100,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = wrong_pda;
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -289,12 +275,14 @@ fn test_update_pda_wrong_authority() {
 
     let account_data = build_user_account_data(authority, 42, bump);
 
-    let instruction: Instruction = UpdatePdaInstruction {
+    let mut instruction: Instruction = UpdatePdaInstruction {
         authority: wrong_authority,
-        user: pda,
         new_value: 100,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = pda;
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -335,11 +323,7 @@ fn test_close_pda() {
     let authority_lamports: u64 = 500_000;
     let account_data = build_user_account_data(authority, 42, bump);
 
-    let instruction: Instruction = ClosePdaInstruction {
-        authority,
-        user: pda,
-    }
-    .into();
+    let instruction: Instruction = ClosePdaInstruction { authority }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -387,7 +371,6 @@ fn test_pda_signer_transfer() {
 
     let instruction: Instruction = PdaTransferInstruction {
         authority,
-        pda,
         recipient,
         amount: transfer_amount,
     }
@@ -433,13 +416,15 @@ fn test_pda_signer_wrong_seeds() {
 
     let account_data = build_user_account_data(authority, 42, bump);
 
-    let instruction: Instruction = PdaTransferInstruction {
+    let mut instruction: Instruction = PdaTransferInstruction {
         authority: wrong_authority,
-        pda,
         recipient,
         amount: 100,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = pda;
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -478,13 +463,7 @@ fn test_pda_bump_from_account() {
     let (pda, expected_bump) =
         Address::find_program_address(&[b"user", payer.as_ref()], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitPubkeySeedInstruction {
-        payer,
-        user: pda,
-        system_program,
-        value: 99,
-    }
-    .into();
+    let instruction: Instruction = InitPubkeySeedInstruction { payer, value: 99 }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -512,12 +491,7 @@ fn test_pda_cu() {
     let payer = Address::new_unique();
     let (config, _) = Address::find_program_address(&[b"config"], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitLiteralSeedInstruction {
-        payer,
-        config,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitLiteralSeedInstruction { payer }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -538,12 +512,7 @@ fn test_empty_seed() {
     let payer = Address::new_unique();
     let (empty, _) = Address::find_program_address(&[b""], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitEmptySeedInstruction {
-        payer,
-        empty,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitEmptySeedInstruction { payer }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -573,12 +542,7 @@ fn test_max_seed_length() {
     let (max_seed, _) =
         Address::find_program_address(&[b"abcdefghijklmnopqrstuvwxyz012345"], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitMaxSeedLengthInstruction {
-        payer,
-        max_seed,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMaxSeedLengthInstruction { payer }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -612,8 +576,6 @@ fn test_seed_with_special_chars() {
     let instruction: Instruction = InitInstructionSeedInstruction {
         payer,
         authority: special_key,
-        item,
-        system_program,
         id: 0xFF_FF_FF_FF_FF_FF_FF_FF,
     }
     .into();
@@ -650,7 +612,6 @@ fn test_pda_account_wrong_owner() {
 
     let instruction: Instruction = UpdatePdaInstruction {
         authority,
-        user: pda,
         new_value: 100,
     }
     .into();
@@ -687,12 +648,7 @@ fn test_pda_account_not_writable_on_init() {
     let payer = Address::new_unique();
     let (config, _) = Address::find_program_address(&[b"config"], &quasar_test_pda::ID);
 
-    let mut instruction: Instruction = InitLiteralSeedInstruction {
-        payer,
-        config,
-        system_program,
-    }
-    .into();
+    let mut instruction: Instruction = InitLiteralSeedInstruction { payer }.into();
 
     instruction.accounts[1].is_writable = false;
 
@@ -727,8 +683,6 @@ fn test_multi_seed_three_components() {
         payer,
         first,
         second,
-        triple,
-        system_program,
     }
     .into();
 
@@ -764,13 +718,7 @@ fn test_max_multi_seeds() {
     let authority = Address::new_unique();
     let (complex, _) = Address::find_program_address(&[b"max_multi_seeds"], &quasar_test_pda::ID);
 
-    let instruction: Instruction = InitMaxMultiSeedsInstruction {
-        payer,
-        authority,
-        complex,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMaxMultiSeedsInstruction { payer, authority }.into();
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -803,8 +751,6 @@ fn test_multi_seed_with_address_and_literal() {
     let instruction: Instruction = InitMultiSeedsInstruction {
         payer,
         authority,
-        complex,
-        system_program,
         amount: 12345,
     }
     .into();
@@ -846,14 +792,15 @@ fn test_multi_seed_order_matters() {
         &quasar_test_pda::ID,
     );
 
-    let instruction: Instruction = InitThreeSeedsInstruction {
+    let mut instruction: Instruction = InitThreeSeedsInstruction {
         payer,
         first,
         second,
-        triple: triple_swapped,
-        system_program,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[3].pubkey = triple_swapped;
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -888,7 +835,6 @@ fn test_pda_signer_cpi_success() {
 
     let instruction: Instruction = PdaTransferInstruction {
         authority,
-        pda,
         recipient,
         amount: transfer_amount,
     }
@@ -932,13 +878,15 @@ fn test_pda_signer_wrong_authority_cpi() {
 
     let account_data = build_user_account_data(authority, 42, bump);
 
-    let instruction: Instruction = PdaTransferInstruction {
+    let mut instruction: Instruction = PdaTransferInstruction {
         authority: wrong_authority,
-        pda,
         recipient,
         amount: 100,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = pda;
 
     let result = mollusk.process_instruction(
         &instruction,
@@ -988,7 +936,6 @@ fn test_typed_seed_ix_data_init() {
         payer,
         authority,
         item: item_pda,
-        system_program,
         index,
     }
     .into();
@@ -1032,13 +979,7 @@ fn test_typed_seed_deserialized_field() {
     // Step 1: Create the NamespaceConfig
     let (config_pda, _) = Address::find_program_address(&[b"ns_config"], &quasar_test_pda::ID);
 
-    let init_config_ix: Instruction = InitNsConfigInstruction {
-        payer,
-        config: config_pda,
-        system_program,
-        namespace,
-    }
-    .into();
+    let init_config_ix: Instruction = InitNsConfigInstruction { payer, namespace }.into();
 
     let result = mollusk.process_instruction(
         &init_config_ix,
@@ -1064,7 +1005,6 @@ fn test_typed_seed_deserialized_field() {
     let init_item_ix: Instruction = InitScopedItemInstruction {
         payer,
         item: item_pda,
-        system_program,
         namespace,
     }
     .into();
@@ -1118,13 +1058,7 @@ fn test_init_typed_seed_from_account_field() {
     // Step 1: Create the NamespaceConfig
     let (config_pda, _) = Address::find_program_address(&[b"ns_config"], &quasar_test_pda::ID);
 
-    let init_config_ix: Instruction = InitNsConfigInstruction {
-        payer,
-        config: config_pda,
-        system_program,
-        namespace,
-    }
-    .into();
+    let init_config_ix: Instruction = InitNsConfigInstruction { payer, namespace }.into();
 
     let result = mollusk.process_instruction(
         &init_config_ix,
@@ -1149,7 +1083,6 @@ fn test_init_typed_seed_from_account_field() {
         payer,
         config: config_pda,
         item: item_pda,
-        system_program,
     }
     .into();
 
@@ -1190,12 +1123,10 @@ fn test_wrong_seed_addresses_rejected() {
         ("pda of a different literal", different_literal),
     ] {
         let payer = Address::new_unique();
-        let instruction: Instruction = InitLiteralSeedInstruction {
-            payer,
-            config: wrong_pda,
-            system_program,
-        }
-        .into();
+        let mut instruction: Instruction = InitLiteralSeedInstruction { payer }.into();
+        // The client derives the canonical PDA meta; repoint it at the
+        // address under test.
+        instruction.accounts[1].pubkey = wrong_pda;
         let result = mollusk.process_instruction(
             &instruction,
             &[
@@ -1236,7 +1167,6 @@ fn test_wrong_stored_bumps_rejected() {
         let account_data = build_user_account_data(authority, 42, wrong_bump);
         let instruction: Instruction = UpdatePdaInstruction {
             authority,
-            user: pda,
             new_value: 100,
         }
         .into();

--- a/tests/suite/src/pda.rs
+++ b/tests/suite/src/pda.rs
@@ -935,7 +935,6 @@ fn test_typed_seed_ix_data_init() {
     let instruction: Instruction = InitIxDataSeedInstruction {
         payer,
         authority,
-        item: item_pda,
         index,
     }
     .into();
@@ -1002,12 +1001,7 @@ fn test_typed_seed_deserialized_field() {
     let (item_pda, _) =
         Address::find_program_address(&[b"scoped", &namespace.to_le_bytes()], &quasar_test_pda::ID);
 
-    let init_item_ix: Instruction = InitScopedItemInstruction {
-        payer,
-        item: item_pda,
-        namespace,
-    }
-    .into();
+    let init_item_ix: Instruction = InitScopedItemInstruction { payer, namespace }.into();
 
     let payer_after_config = result.resulting_accounts[0].1.clone();
     let result2 = mollusk.process_instruction(

--- a/tests/suite/src/realloc.rs
+++ b/tests/suite/src/realloc.rs
@@ -10,13 +10,7 @@ fn setup_account(svm: &mut quasar_svm::QuasarSvm) -> (Pubkey, Pubkey, Pubkey) {
         Pubkey::find_program_address(&[b"simple", payer.as_ref()], &quasar_test_misc::ID);
 
     // Init first
-    let ix: Instruction = InitializeInstruction {
-        payer,
-        account,
-        system_program: quasar_svm::system_program::ID,
-        value: 42,
-    }
-    .into();
+    let ix: Instruction = InitializeInstruction { payer, value: 42 }.into();
     let r = svm.process_instruction(&ix, &[rich_signer_account(payer), empty_account(account)]);
     assert!(r.is_ok(), "setup init: {:?}", r.raw_result);
     (payer, account, quasar_svm::system_program::ID)
@@ -31,7 +25,6 @@ fn realloc(
     let ix: Instruction = ReallocCheckInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_space,
     }
     .into();
@@ -156,7 +149,6 @@ fn realloc_rejects_wrong_owner() {
     let ix: Instruction = ReallocCheckInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_space: 100,
     }
     .into();
@@ -192,7 +184,6 @@ fn realloc_rejects_underfunded_grow() {
     let ix: Instruction = ReallocCheckInstruction {
         account,
         payer,
-        system_program: quasar_svm::system_program::ID,
         new_space: 10_000,
     }
     .into();

--- a/tests/suite/src/sysvar.rs
+++ b/tests/suite/src/sysvar.rs
@@ -25,12 +25,7 @@ fn test_read_clock_syscall() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -59,12 +54,7 @@ fn test_read_clock_default_slot() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -91,12 +81,7 @@ fn test_read_rent_syscall() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"rent"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadRentInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadRentInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -142,7 +127,6 @@ fn test_read_clock_from_account() {
     let instruction: Instruction = ReadClockFromAccountInstruction {
         _payer: payer,
         snapshot,
-        clock,
     }
     .into();
     let result = mollusk.process_instruction(
@@ -172,12 +156,7 @@ fn test_clock_custom_slot() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -207,12 +186,7 @@ fn test_clock_unix_timestamp() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -240,12 +214,7 @@ fn test_clock_epoch() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -273,12 +242,7 @@ fn test_clock_epoch_start_timestamp() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -309,12 +273,7 @@ fn test_clock_leader_schedule_epoch() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -346,12 +305,7 @@ fn test_clock_all_fields() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -396,12 +350,7 @@ fn test_clock_large_values() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -436,13 +385,7 @@ fn test_rent_lamports_per_byte() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"rent_calc"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadRentCalcInstruction {
-        payer,
-        snapshot,
-        system_program,
-        data_len: 1,
-    }
-    .into();
+    let instruction: Instruction = ReadRentCalcInstruction { payer, data_len: 1 }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -479,12 +422,7 @@ fn test_clock_syscall_vs_account_consistent() {
     let payer_account = Account::new(1_000_000_000, 0, &system_program);
     let (snapshot, _) = Address::find_program_address(&[b"clock_full"], &quasar_test_sysvar::ID);
     let snapshot_account = Account::default();
-    let instruction: Instruction = ReadClockFullInstruction {
-        payer,
-        snapshot,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = ReadClockFullInstruction { payer }.into();
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -513,7 +451,6 @@ fn test_clock_syscall_vs_account_consistent() {
     let instruction: Instruction = ReadClockFullFromAccountInstruction {
         _payer: payer,
         snapshot,
-        clock,
     }
     .into();
     let result = mollusk.process_instruction(
@@ -567,14 +504,20 @@ fn test_read_clock_rejects_spoofed_sysvar_account() {
     let (mollusk, payer, payer_account, snapshot, snapshot_account) =
         spoof_setup(CLOCK_SNAPSHOT_SIZE, 1);
     let fake_clock = Address::new_unique();
-    let (_, real_clock_account) = mollusk.sysvars.keyed_account_for_clock_sysvar();
+    let (real_clock, real_clock_account) = mollusk.sysvars.keyed_account_for_clock_sysvar();
 
-    let instruction: Instruction = ReadClockFromAccountInstruction {
+    // The client fills the canonical sysvar address; spoof the meta on
+    // purpose.
+    let mut instruction: Instruction = ReadClockFromAccountInstruction {
         _payer: payer,
         snapshot,
-        clock: fake_clock,
     }
     .into();
+    for meta in &mut instruction.accounts {
+        if meta.pubkey == real_clock {
+            meta.pubkey = fake_clock;
+        }
+    }
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -601,14 +544,20 @@ fn test_read_clock_full_rejects_spoofed_sysvar_account() {
     let (mollusk, payer, payer_account, snapshot, snapshot_account) =
         spoof_setup(CLOCK_FULL_SNAPSHOT_SIZE, 3);
     let fake_clock = Address::new_unique();
-    let (_, real_clock_account) = mollusk.sysvars.keyed_account_for_clock_sysvar();
+    let (real_clock, real_clock_account) = mollusk.sysvars.keyed_account_for_clock_sysvar();
 
-    let instruction: Instruction = ReadClockFullFromAccountInstruction {
+    // The client fills the canonical sysvar address; spoof the meta on
+    // purpose.
+    let mut instruction: Instruction = ReadClockFullFromAccountInstruction {
         _payer: payer,
         snapshot,
-        clock: fake_clock,
     }
     .into();
+    for meta in &mut instruction.accounts {
+        if meta.pubkey == real_clock {
+            meta.pubkey = fake_clock;
+        }
+    }
     let result = mollusk.process_instruction(
         &instruction,
         &[
@@ -636,13 +585,7 @@ fn test_rent_minimum_balance_matches_rent_sysvar() {
 
     for data_len in [0u64, 100, 10_000] {
         let payer = Address::new_unique();
-        let instruction: Instruction = ReadRentCalcInstruction {
-            payer,
-            snapshot,
-            system_program,
-            data_len,
-        }
-        .into();
+        let instruction: Instruction = ReadRentCalcInstruction { payer, data_len }.into();
         let result = mollusk.process_instruction(
             &instruction,
             &[

--- a/tests/suite/src/test_close_attr.rs
+++ b/tests/suite/src/test_close_attr.rs
@@ -20,7 +20,6 @@ fn close_attr_spl_happy() {
         token_account: account_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -55,7 +54,6 @@ fn close_attr_spl_wrong_authority() {
         token_account: account_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -86,7 +84,6 @@ fn close_attr_spl_wrong_mint() {
         token_account: account_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -118,7 +115,6 @@ fn close_attr_t22_happy() {
         token_account: account_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -153,7 +149,6 @@ fn close_attr_t22_wrong_authority() {
         token_account: account_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 

--- a/tests/suite/src/test_cpi_approve_revoke.rs
+++ b/tests/suite/src/test_cpi_approve_revoke.rs
@@ -19,7 +19,6 @@ fn approve_spl() {
         authority,
         source: source_key,
         delegate: delegate_key,
-        token_program,
         amount: 500,
     }
     .into();
@@ -54,7 +53,6 @@ fn approve_t22() {
         authority,
         source: source_key,
         delegate: delegate_key,
-        token_program,
         amount: 500,
     }
     .into();
@@ -123,7 +121,6 @@ fn revoke_spl() {
     let instruction: Instruction = RevokeInstruction {
         authority,
         source: source_key,
-        token_program,
     }
     .into();
 
@@ -208,7 +205,6 @@ fn approve_rejects_wrong_owner() {
         authority,
         source: source_key,
         delegate: delegate_key,
-        token_program,
         amount: 500,
     }
     .into();
@@ -240,7 +236,6 @@ fn revoke_rejects_wrong_owner() {
     let instruction: Instruction = RevokeInstruction {
         authority,
         source: source_key,
-        token_program,
     }
     .into();
     let result = svm.process_instruction(

--- a/tests/suite/src/test_cpi_close.rs
+++ b/tests/suite/src/test_cpi_close.rs
@@ -16,7 +16,6 @@ fn close_spl() {
         authority,
         account: account_key,
         destination: authority,
-        token_program,
     }
     .into();
 
@@ -46,7 +45,6 @@ fn close_t22() {
         authority,
         account: account_key,
         destination: authority,
-        token_program,
     }
     .into();
 
@@ -110,7 +108,6 @@ fn close_rejects_non_zero_balance() {
         authority,
         account: account_key,
         destination: authority,
-        token_program,
     }
     .into();
     let result = svm.process_instruction(
@@ -137,7 +134,6 @@ fn close_rejects_wrong_owner() {
         authority,
         account: account_key,
         destination: authority,
-        token_program,
     }
     .into();
     let result = svm.process_instruction(

--- a/tests/suite/src/test_cpi_mint_burn.rs
+++ b/tests/suite/src/test_cpi_mint_burn.rs
@@ -18,7 +18,6 @@ fn mint_to_spl() {
         authority,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 5000,
     }
     .into();
@@ -52,7 +51,6 @@ fn mint_to_t22() {
         authority,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 5000,
     }
     .into();
@@ -120,7 +118,6 @@ fn burn_spl() {
         authority,
         from: from_key,
         mint: mint_key,
-        token_program,
         amount: 500,
     }
     .into();
@@ -192,7 +189,6 @@ fn mint_to_rejects_wrong_mint_authority() {
         authority,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 5000,
     }
     .into();
@@ -221,7 +217,6 @@ fn burn_rejects_more_than_balance() {
         authority,
         from: from_key,
         mint: mint_key,
-        token_program,
         amount: 500,
     }
     .into();

--- a/tests/suite/src/test_cpi_transfer.rs
+++ b/tests/suite/src/test_cpi_transfer.rs
@@ -20,7 +20,6 @@ fn transfer_checked_spl() {
         from: from_key,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 200,
         decimals: 9,
     }
@@ -58,7 +57,6 @@ fn transfer_checked_t22() {
         from: from_key,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 200,
         decimals: 9,
     }
@@ -170,7 +168,6 @@ fn transfer_checked_rejects_insufficient_funds() {
         from: from_key,
         mint: mint_key,
         to: to_key,
-        token_program,
         amount: 200,
         decimals: 9,
     }

--- a/tests/suite/src/test_init_ata.rs
+++ b/tests/suite/src/test_init_ata.rs
@@ -20,7 +20,6 @@ fn init_ata_spl_happy() {
 
     let instruction: Instruction = InitAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -55,7 +54,6 @@ fn init_ata_spl_already_initialized() {
 
     let instruction: Instruction = InitAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -88,7 +86,6 @@ fn init_ata_t22_happy() {
 
     let instruction: Instruction = InitAtaT22Instruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -123,7 +120,6 @@ fn init_ata_t22_already_initialized() {
 
     let instruction: Instruction = InitAtaT22Instruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -156,7 +152,6 @@ fn init_if_needed_ata_spl_happy_new() {
 
     let instruction: Instruction = InitIfNeededAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -193,7 +188,6 @@ fn init_if_needed_ata_spl_existing_valid() {
 
     let instruction: Instruction = InitIfNeededAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -240,7 +234,6 @@ fn init_if_needed_ata_spl_existing_wrong_mint() {
 
     let instruction: Instruction = InitIfNeededAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -272,7 +265,6 @@ fn init_if_needed_ata_spl_existing_wrong_authority() {
 
     let instruction: Instruction = InitIfNeededAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -303,7 +295,6 @@ fn init_if_needed_ata_spl_existing_wrong_owner() {
 
     let instruction: Instruction = InitIfNeededAtaInstruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }
@@ -343,7 +334,6 @@ fn init_if_needed_ata_t22_happy_new() {
 
     let instruction: Instruction = InitIfNeededAtaT22Instruction {
         payer,
-        ata: ata_key,
         wallet,
         mint: mint_key,
     }

--- a/tests/suite/src/test_init_ata.rs
+++ b/tests/suite/src/test_init_ata.rs
@@ -15,7 +15,6 @@ fn init_ata_spl_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -24,9 +23,6 @@ fn init_ata_spl_happy() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -54,7 +50,6 @@ fn init_ata_spl_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -63,9 +58,6 @@ fn init_ata_spl_already_initialized() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -91,7 +83,6 @@ fn init_ata_t22_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -100,9 +91,6 @@ fn init_ata_t22_happy() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -130,7 +118,6 @@ fn init_ata_t22_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -139,9 +126,6 @@ fn init_ata_t22_already_initialized() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -167,7 +151,6 @@ fn init_if_needed_ata_spl_happy_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -176,9 +159,6 @@ fn init_if_needed_ata_spl_happy_new() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -208,7 +188,6 @@ fn init_if_needed_ata_spl_existing_valid() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -217,9 +196,6 @@ fn init_if_needed_ata_spl_existing_valid() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -259,7 +235,6 @@ fn init_if_needed_ata_spl_existing_wrong_mint() {
     let wrong_mint = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -268,9 +243,6 @@ fn init_if_needed_ata_spl_existing_wrong_mint() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -295,7 +267,6 @@ fn init_if_needed_ata_spl_existing_wrong_authority() {
     let wrong_wallet = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -304,9 +275,6 @@ fn init_if_needed_ata_spl_existing_wrong_authority() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -330,7 +298,6 @@ fn init_if_needed_ata_spl_existing_wrong_owner() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -339,9 +306,6 @@ fn init_if_needed_ata_spl_existing_wrong_owner() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 
@@ -374,7 +338,6 @@ fn init_if_needed_ata_t22_happy_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let ata_program = ata_program_id();
     let (ata_key, _) =
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
@@ -383,9 +346,6 @@ fn init_if_needed_ata_t22_happy_new() {
         ata: ata_key,
         wallet,
         mint: mint_key,
-        token_program,
-        system_program: quasar_svm::system_program::ID,
-        ata_program,
     }
     .into();
 

--- a/tests/suite/src/test_init_interface.rs
+++ b/tests/suite/src/test_init_interface.rs
@@ -14,14 +14,12 @@ fn init_token_interface_spl_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenInterfaceInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
         token_program,
-        system_program,
     }
     .into();
 
@@ -48,14 +46,12 @@ fn init_token_interface_t22_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenInterfaceInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
         token_program,
-        system_program,
     }
     .into();
 
@@ -84,7 +80,6 @@ fn init_if_needed_token_interface_spl_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededTokenInterfaceInstruction {
@@ -92,7 +87,6 @@ fn init_if_needed_token_interface_spl_new() {
             token_account: token_key,
             mint: mint_key,
             token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -121,7 +115,6 @@ fn init_if_needed_token_interface_t22_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededTokenInterfaceInstruction {
@@ -129,7 +122,6 @@ fn init_if_needed_token_interface_t22_new() {
             token_account: token_key,
             mint: mint_key,
             token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -158,14 +150,12 @@ fn init_if_needed_token_interface_existing_valid() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInterfaceInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
         token_program,
-        system_program,
     }
     .into();
 
@@ -202,14 +192,12 @@ fn init_if_needed_token_interface_existing_wrong_mint() {
     let wrong_mint = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInterfaceInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
         token_program,
-        system_program,
     }
     .into();
 
@@ -233,14 +221,12 @@ fn init_mint_interface_spl_happy() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintInterfaceInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         token_program,
-        system_program,
     }
     .into();
 
@@ -266,14 +252,12 @@ fn init_mint_interface_t22_happy() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintInterfaceInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         token_program,
-        system_program,
     }
     .into();
 
@@ -301,7 +285,6 @@ fn init_if_needed_mint_interface_spl_new() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintInterfaceInstruction {
@@ -309,7 +292,6 @@ fn init_if_needed_mint_interface_spl_new() {
             mint: mint_key,
             mint_authority: authority,
             token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -337,7 +319,6 @@ fn init_if_needed_mint_interface_t22_new() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintInterfaceInstruction {
@@ -345,7 +326,6 @@ fn init_if_needed_mint_interface_t22_new() {
             mint: mint_key,
             mint_authority: authority,
             token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -373,14 +353,12 @@ fn init_if_needed_mint_interface_existing_valid() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInterfaceInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         token_program,
-        system_program,
     }
     .into();
 
@@ -416,14 +394,12 @@ fn init_if_needed_mint_interface_existing_wrong_authority() {
     let authority = Pubkey::new_unique();
     let wrong_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInterfaceInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         token_program,
-        system_program,
     }
     .into();
 

--- a/tests/suite/src/test_init_mint.rs
+++ b/tests/suite/src/test_init_mint.rs
@@ -12,15 +12,11 @@ fn init_mint_spl_happy() {
     let payer = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -46,14 +42,11 @@ fn init_mint_spl_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -76,15 +69,11 @@ fn init_mint_t22_happy() {
     let payer = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintT22Instruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -110,14 +99,11 @@ fn init_mint_t22_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitMintT22Instruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -140,16 +126,12 @@ fn init_if_needed_mint_spl_happy_new() {
     let payer = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintInstruction {
             payer,
             mint: mint_key,
             mint_authority: authority,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -177,14 +159,11 @@ fn init_if_needed_mint_spl_existing_valid() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -219,14 +198,11 @@ fn init_if_needed_mint_spl_wrong_decimals() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -249,14 +225,11 @@ fn init_if_needed_mint_spl_wrong_authority() {
     let authority = Pubkey::new_unique();
     let wrong_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -277,15 +250,11 @@ fn init_if_needed_mint_spl_wrong_owner() {
     let payer = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -315,7 +284,6 @@ fn init_if_needed_mint_spl_unexpected_freeze() {
     let authority = Pubkey::new_unique();
     let freeze_auth = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     // Use the no-freeze handler but provide a mint that has freeze_authority set.
     // validate_mint with freeze_authority=None rejects mints that have one
@@ -324,8 +292,6 @@ fn init_if_needed_mint_spl_unexpected_freeze() {
         payer,
         mint: mint_key,
         mint_authority: authority,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -348,16 +314,12 @@ fn init_if_needed_mint_t22_happy_new() {
     let payer = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
-    let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintT22Instruction {
             payer,
             mint: mint_key,
             mint_authority: authority,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -387,8 +349,6 @@ fn init_if_needed_mint_freeze_spl_happy_new() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let freeze_auth = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintWithFreezeInstruction {
@@ -396,8 +356,6 @@ fn init_if_needed_mint_freeze_spl_happy_new() {
             mint: mint_key,
             mint_authority: authority,
             freeze_authority: freeze_auth,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -427,15 +385,12 @@ fn init_if_needed_mint_freeze_spl_existing_valid() {
     let authority = Pubkey::new_unique();
     let freeze_auth = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -473,15 +428,12 @@ fn init_if_needed_mint_freeze_spl_wrong_freeze_authority() {
     let freeze_auth = Pubkey::new_unique();
     let wrong_freeze = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
         payer,
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -505,7 +457,6 @@ fn init_if_needed_mint_freeze_spl_missing_freeze_authority() {
     let authority = Pubkey::new_unique();
     let freeze_auth = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     // Existing mint has no freeze_authority, but the handler expects one.
     let instruction: Instruction = InitIfNeededMintWithFreezeInstruction {
@@ -513,8 +464,6 @@ fn init_if_needed_mint_freeze_spl_missing_freeze_authority() {
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -539,8 +488,6 @@ fn init_if_needed_mint_freeze_t22_happy_new() {
     let mint_key = Pubkey::new_unique();
     let authority = Pubkey::new_unique();
     let freeze_auth = Pubkey::new_unique();
-    let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededMintWithFreezeT22Instruction {
@@ -548,8 +495,6 @@ fn init_if_needed_mint_freeze_t22_happy_new() {
             mint: mint_key,
             mint_authority: authority,
             freeze_authority: freeze_auth,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],

--- a/tests/suite/src/test_init_mint_pda.rs
+++ b/tests/suite/src/test_init_mint_pda.rs
@@ -10,19 +10,11 @@ use {
 fn init_mint_pda_spl_happy() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (mint_pda, _bump) =
         Pubkey::find_program_address(&[b"mint", payer.as_ref()], &quasar_test_token_init::ID);
 
-    let instruction: Instruction = InitMintPdaInstruction {
-        payer,
-        mint: mint_pda,
-        token_program,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMintPdaInstruction { payer }.into();
 
     let result = svm.process_instruction(
         &instruction,
@@ -39,18 +31,13 @@ fn init_mint_pda_spl_happy() {
 fn init_mint_pda_spl_wrong_address() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let wrong_key = Pubkey::new_unique();
 
-    let instruction: Instruction = InitMintPdaInstruction {
-        payer,
-        mint: wrong_key,
-        token_program,
-        system_program,
-    }
-    .into();
+    let mut instruction: Instruction = InitMintPdaInstruction { payer }.into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = wrong_key;
 
     let result = svm.process_instruction(
         &instruction,
@@ -67,19 +54,11 @@ fn init_mint_pda_spl_wrong_address() {
 fn init_mint_pda_t22_happy() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
-    let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (mint_pda, _bump) =
         Pubkey::find_program_address(&[b"mint", payer.as_ref()], &quasar_test_token_init::ID);
 
-    let instruction: Instruction = InitMintPdaT22Instruction {
-        payer,
-        mint: mint_pda,
-        token_program,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMintPdaT22Instruction { payer }.into();
 
     let result = svm.process_instruction(
         &instruction,
@@ -98,19 +77,11 @@ fn init_mint_pda_t22_happy() {
 fn init_mint_pda_spl_prefunded_partial() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (mint_pda, _bump) =
         Pubkey::find_program_address(&[b"mint", payer.as_ref()], &quasar_test_token_init::ID);
 
-    let instruction: Instruction = InitMintPdaInstruction {
-        payer,
-        mint: mint_pda,
-        token_program,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMintPdaInstruction { payer }.into();
 
     let prefund = 500_000u64;
     let payer_lamports = 100_000_000_000u64;
@@ -145,20 +116,12 @@ fn init_mint_pda_spl_prefunded_partial() {
 fn init_mint_pda_spl_prefunded_excess() {
     let mut svm = svm_init();
     let payer = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (mint_pda, _bump) =
         Pubkey::find_program_address(&[b"mint", payer.as_ref()], &quasar_test_token_init::ID);
 
     let payer_lamports = 100_000_000_000u64;
-    let instruction: Instruction = InitMintPdaInstruction {
-        payer,
-        mint: mint_pda,
-        token_program,
-        system_program,
-    }
-    .into();
+    let instruction: Instruction = InitMintPdaInstruction { payer }.into();
 
     let result = svm.process_instruction(
         &instruction,

--- a/tests/suite/src/test_init_token.rs
+++ b/tests/suite/src/test_init_token.rs
@@ -14,14 +14,11 @@ fn init_token_spl_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -48,14 +45,11 @@ fn init_token_spl_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -80,14 +74,11 @@ fn init_token_t22_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenT22Instruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -114,14 +105,11 @@ fn init_token_t22_already_initialized() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitTokenT22Instruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -146,15 +134,12 @@ fn init_if_needed_token_spl_happy_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededTokenInstruction {
             payer,
             token_account: token_key,
             mint: mint_key,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],
@@ -185,14 +170,11 @@ fn init_if_needed_token_spl_existing_valid() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -231,14 +213,11 @@ fn init_if_needed_token_spl_existing_wrong_mint() {
     let wrong_mint = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -262,14 +241,11 @@ fn init_if_needed_token_spl_existing_wrong_authority() {
     let wrong_authority = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -292,14 +268,11 @@ fn init_if_needed_token_spl_existing_wrong_owner() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction: Instruction = InitIfNeededTokenInstruction {
         payer,
         token_account: token_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -331,15 +304,12 @@ fn init_if_needed_token_t22_happy_new() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let instruction = with_signers(
         InitIfNeededTokenT22Instruction {
             payer,
             token_account: token_key,
             mint: mint_key,
-            token_program,
-            system_program,
         }
         .into(),
         &[1],

--- a/tests/suite/src/test_init_token_pda.rs
+++ b/tests/suite/src/test_init_token_pda.rs
@@ -13,7 +13,6 @@ fn init_token_pda_spl_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     // Derive the PDA: seeds = [b"token", payer]
     let (token_pda, _bump) =
@@ -21,10 +20,7 @@ fn init_token_pda_spl_happy() {
 
     let instruction: Instruction = InitTokenPdaInstruction {
         payer,
-        token_account: token_pda,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -50,18 +46,17 @@ fn init_token_pda_spl_wrong_address() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let wrong_key = Pubkey::new_unique();
 
-    let instruction: Instruction = InitTokenPdaInstruction {
+    let mut instruction: Instruction = InitTokenPdaInstruction {
         payer,
-        token_account: wrong_key,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
+    // The client derives the canonical PDA meta; repoint it at the address
+    // under test.
+    instruction.accounts[1].pubkey = wrong_key;
 
     let result = svm.process_instruction(
         &instruction,
@@ -85,17 +80,13 @@ fn init_token_pda_t22_happy() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = token_2022_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (token_pda, _bump) =
         Pubkey::find_program_address(&[b"token", payer.as_ref()], &quasar_test_token_init::ID);
 
     let instruction: Instruction = InitTokenPdaT22Instruction {
         payer,
-        token_account: token_pda,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -123,17 +114,13 @@ fn init_token_pda_spl_prefunded_partial() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (token_pda, _bump) =
         Pubkey::find_program_address(&[b"token", payer.as_ref()], &quasar_test_token_init::ID);
 
     let instruction: Instruction = InitTokenPdaInstruction {
         payer,
-        token_account: token_pda,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 
@@ -174,7 +161,6 @@ fn init_token_pda_spl_prefunded_excess() {
     let mint_key = Pubkey::new_unique();
     let mint_authority = Pubkey::new_unique();
     let token_program = spl_token_program_id();
-    let system_program = quasar_svm::system_program::ID;
 
     let (token_pda, _bump) =
         Pubkey::find_program_address(&[b"token", payer.as_ref()], &quasar_test_token_init::ID);
@@ -182,10 +168,7 @@ fn init_token_pda_spl_prefunded_excess() {
     let payer_lamports = 100_000_000_000u64;
     let instruction: Instruction = InitTokenPdaInstruction {
         payer,
-        token_account: token_pda,
         mint: mint_key,
-        token_program,
-        system_program,
     }
     .into();
 

--- a/tests/suite/src/test_migrate.rs
+++ b/tests/suite/src/test_migrate.rs
@@ -45,7 +45,6 @@ fn migrate_v1_to_v2() {
 
     let ix: Instruction = MigrateConfigInstruction {
         payer,
-        system_program: quasar_svm::system_program::ID,
         config,
         authority,
     }
@@ -112,7 +111,6 @@ fn assert_migration_zeroes_padding(source_size: usize) {
 
     let ix: Instruction = MigratePaddedInstruction {
         payer,
-        system_program: quasar_svm::system_program::ID,
         config,
         authority: new_authority,
         value: 777,
@@ -194,7 +192,6 @@ fn migrate_wrong_authority_fails() {
 
     let ix: Instruction = MigrateConfigInstruction {
         payer,
-        system_program: quasar_svm::system_program::ID,
         config,
         authority: wrong_authority,
     }
@@ -221,7 +218,6 @@ fn migrate_with_config(config_state: quasar_svm::Account) -> quasar_svm::Executi
 
     let ix: Instruction = MigrateConfigInstruction {
         payer,
-        system_program: quasar_svm::system_program::ID,
         config,
         authority,
     }

--- a/tests/suite/src/test_sweep.rs
+++ b/tests/suite/src/test_sweep.rs
@@ -21,7 +21,6 @@ fn sweep_spl_happy() {
         source: source_key,
         receiver: receiver_key,
         mint: mint_key,
-        token_program,
     }
     .into();
 
@@ -72,7 +71,6 @@ fn sweep_spl_zero_balance() {
         source: source_key,
         receiver: receiver_key,
         mint: mint_key,
-        token_program,
     }
     .into();
 
@@ -116,7 +114,6 @@ fn sweep_spl_wrong_authority() {
         source: source_key,
         receiver: receiver_key,
         mint: mint_key,
-        token_program,
     }
     .into();
 
@@ -148,7 +145,6 @@ fn sweep_t22_happy() {
         source: source_key,
         receiver: receiver_key,
         mint: mint_key,
-        token_program,
     }
     .into();
 
@@ -287,7 +283,6 @@ fn sweep_and_close_spl_happy() {
         receiver: receiver_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -338,7 +333,6 @@ fn sweep_and_close_spl_zero_balance() {
         receiver: receiver_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -390,7 +384,6 @@ fn sweep_and_close_spl_wrong_mint_receiver() {
         receiver: receiver_key,
         mint: mint_key,
         destination,
-        token_program,
     }
     .into();
 
@@ -510,11 +503,9 @@ fn pda_sweep_and_close_runs_token_exits_before_authority_close() {
 
     let instruction: Instruction = PdaSweepAndCloseInstruction {
         owner,
-        authority,
         source: source_key,
         receiver: receiver_key,
         mint: mint_key,
-        token_program,
     }
     .into();
 

--- a/tests/suite/src/test_validate_ata.rs
+++ b/tests/suite/src/test_validate_ata.rs
@@ -21,7 +21,6 @@ fn ata_spl_happy() {
         ata: ata_key,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 
@@ -49,7 +48,6 @@ fn ata_spl_wrong_address() {
         ata: wrong_ata,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 
@@ -79,7 +77,6 @@ fn ata_spl_wrong_mint() {
         ata: ata_key,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 
@@ -109,7 +106,6 @@ fn ata_spl_wrong_authority() {
         ata: ata_key,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 
@@ -138,7 +134,6 @@ fn ata_spl_wrong_owner() {
         ata: ata_key,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 
@@ -176,7 +171,6 @@ fn ata_t22_happy() {
         ata: ata_key,
         mint: mint_key,
         wallet,
-        token_program,
     }
     .into();
 

--- a/tests/suite/src/test_validate_ata.rs
+++ b/tests/suite/src/test_validate_ata.rs
@@ -195,7 +195,6 @@ fn ata_interface_spl_happy() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
         token_program,
@@ -222,13 +221,15 @@ fn ata_interface_spl_wrong_address() {
     let token_program = spl_token_program_id();
     let wrong_ata = Pubkey::new_unique();
 
-    let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: wrong_ata,
+    let mut instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
         mint: mint_key,
         wallet,
         token_program,
     }
     .into();
+    // The client derives the canonical ATA meta; repoint it at the address
+    // under test.
+    instruction.accounts[0].pubkey = wrong_ata;
 
     let result = svm.process_instruction(
         &instruction,
@@ -253,7 +254,6 @@ fn ata_interface_spl_wrong_mint() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
         token_program,
@@ -283,7 +283,6 @@ fn ata_interface_spl_wrong_authority() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
         token_program,
@@ -312,7 +311,6 @@ fn ata_interface_spl_wrong_owner() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
         token_program,
@@ -350,7 +348,6 @@ fn ata_interface_t22_happy() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaInterfaceCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
         token_program,

--- a/tests/suite/src/test_validate_ata.rs
+++ b/tests/suite/src/test_validate_ata.rs
@@ -18,7 +18,6 @@ fn ata_spl_happy() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
     }
@@ -44,12 +43,14 @@ fn ata_spl_wrong_address() {
     let token_program = spl_token_program_id();
     let wrong_ata = Pubkey::new_unique();
 
-    let instruction: Instruction = ValidateAtaCheckInstruction {
-        ata: wrong_ata,
+    let mut instruction: Instruction = ValidateAtaCheckInstruction {
         mint: mint_key,
         wallet,
     }
     .into();
+    // The client derives the canonical ATA meta; repoint it at the address
+    // under test.
+    instruction.accounts[0].pubkey = wrong_ata;
 
     let result = svm.process_instruction(
         &instruction,
@@ -74,7 +75,6 @@ fn ata_spl_wrong_mint() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
     }
@@ -103,7 +103,6 @@ fn ata_spl_wrong_authority() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
     }
@@ -131,7 +130,6 @@ fn ata_spl_wrong_owner() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAtaCheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
     }
@@ -168,7 +166,6 @@ fn ata_t22_happy() {
         get_associated_token_address_with_program_const(&wallet, &mint_key, &token_program);
 
     let instruction: Instruction = ValidateAta2022CheckInstruction {
-        ata: ata_key,
         mint: mint_key,
         wallet,
     }

--- a/tests/suite/src/test_validate_metadata.rs
+++ b/tests/suite/src/test_validate_metadata.rs
@@ -17,10 +17,6 @@ fn derive_metadata_pda(mint: &Pubkey) -> Pubkey {
     Pubkey::from(addr.to_bytes())
 }
 
-fn rent_sysvar() -> Pubkey {
-    Pubkey::from(Address::from_str_const("SysvarRent111111111111111111111111111111111").to_bytes())
-}
-
 fn derive_master_edition_pda(mint: &Pubkey) -> Pubkey {
     let program = Address::new_from_array(METADATA_PROGRAM_BYTES);
     let (addr, _) = Address::find_program_address(
@@ -234,7 +230,6 @@ fn metadata_check_happy() {
     let meta_key = derive_metadata_pda(&mint);
 
     let instruction: Instruction = ValidateMetadataCheckInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         metadata: meta_key,
     }
@@ -261,7 +256,6 @@ fn metadata_check_wrong_mint_in_data() {
     let meta_key = derive_metadata_pda(&mint);
 
     let instruction: Instruction = ValidateMetadataCheckInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         metadata: meta_key,
     }
@@ -286,7 +280,6 @@ fn metadata_check_wrong_pda() {
     let wrong_key = Pubkey::new_unique();
 
     let instruction: Instruction = ValidateMetadataCheckInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         metadata: wrong_key,
     }
@@ -314,7 +307,6 @@ fn metadata_with_ua_happy() {
     let meta_key = derive_metadata_pda(&mint);
 
     let instruction: Instruction = ValidateMetadataWithUaInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         update_authority: ua,
         metadata: meta_key,
@@ -343,7 +335,6 @@ fn metadata_with_ua_wrong_authority() {
     let meta_key = derive_metadata_pda(&mint);
 
     let instruction: Instruction = ValidateMetadataWithUaInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         update_authority: ua,
         metadata: meta_key,
@@ -372,7 +363,6 @@ fn master_edition_check_happy() {
     let me_key = derive_master_edition_pda(&mint);
 
     let instruction: Instruction = ValidateMasterEditionCheckInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         master_edition: me_key,
     }
@@ -396,7 +386,6 @@ fn master_edition_check_wrong_pda() {
     let wrong_key = Pubkey::new_unique();
 
     let instruction: Instruction = ValidateMasterEditionCheckInstruction {
-        metadata_program: metadata_program_id(),
         mint,
         master_edition: wrong_key,
     }
@@ -429,9 +418,6 @@ fn init_metadata_happy() {
 
     let instruction: Instruction = InitMetadataTestInstruction {
         payer,
-        metadata_program: metadata_program_id(),
-        system_program: quasar_svm::system_program::ID,
-        rent: rent_sysvar(),
         mint: mint_key,
         mint_authority,
         update_authority,
@@ -474,13 +460,9 @@ fn init_master_edition_happy() {
     // Both metadata_account and master_edition are init'd by derive behaviors.
     let instruction: Instruction = InitMasterEditionTestInstruction {
         payer,
-        metadata_program: metadata_program_id(),
-        system_program: quasar_svm::system_program::ID,
-        rent: rent_sysvar(),
         mint: mint_key,
         update_authority,
         mint_authority,
-        token_program,
         metadata_account: meta_key,
         master_edition: me_key,
     }

--- a/tests/suite/src/test_validate_mint.rs
+++ b/tests/suite/src/test_validate_mint.rs
@@ -57,7 +57,6 @@ fn mint_spl_happy() {
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -82,7 +81,6 @@ fn mint_spl_wrong_authority() {
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -106,7 +104,6 @@ fn mint_spl_wrong_decimals() {
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -125,12 +122,10 @@ fn mint_spl_wrong_owner() {
     let mut svm = svm_validate();
     let authority = Pubkey::new_unique();
     let mint_key = Pubkey::new_unique();
-    let token_program = spl_token_program_id();
 
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -161,7 +156,6 @@ fn mint_spl_uninitialized() {
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -185,7 +179,6 @@ fn mint_spl_data_too_small() {
     let instruction: Instruction = ValidateMintCheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -211,7 +204,6 @@ fn mint_t22_happy() {
     let instruction: Instruction = ValidateMint2022CheckInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program,
     }
     .into();
 
@@ -417,7 +409,6 @@ fn mint_no_program_happy() {
     let instruction: Instruction = ValidateMintNoProgramInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 
@@ -442,7 +433,6 @@ fn mint_no_program_wrong_authority() {
     let instruction: Instruction = ValidateMintNoProgramInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 
@@ -466,7 +456,6 @@ fn mint_no_program_wrong_decimals() {
     let instruction: Instruction = ValidateMintNoProgramInstruction {
         mint: mint_key,
         mint_authority: authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 
@@ -494,7 +483,6 @@ fn mint_spl_freeze_happy() {
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
     }
     .into();
 
@@ -522,7 +510,6 @@ fn mint_spl_freeze_wrong_freeze_authority() {
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
     }
     .into();
 
@@ -549,7 +536,6 @@ fn mint_spl_freeze_missing_on_chain() {
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
     }
     .into();
 
@@ -579,7 +565,6 @@ fn mint_t22_freeze_happy() {
         mint: mint_key,
         mint_authority: authority,
         freeze_authority: freeze_auth,
-        token_program,
     }
     .into();
 

--- a/tests/suite/src/test_validate_token.rs
+++ b/tests/suite/src/test_validate_token.rs
@@ -18,7 +18,6 @@ fn account_token_happy() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -46,7 +45,6 @@ fn account_token_wrong_mint() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -74,7 +72,6 @@ fn account_token_wrong_authority() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -101,7 +98,6 @@ fn account_token_wrong_owner() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -136,7 +132,6 @@ fn account_token_uninitialized() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -163,7 +158,6 @@ fn account_token_data_too_small() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -192,7 +186,6 @@ fn account_token2022_happy() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program,
     }
     .into();
 
@@ -456,7 +449,6 @@ fn no_program_happy() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 
@@ -484,7 +476,6 @@ fn no_program_wrong_mint() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 
@@ -512,7 +503,6 @@ fn no_program_wrong_authority() {
         token_account: token_key,
         mint: mint_key,
         authority,
-        token_program: quasar_spl::SPL_TOKEN_ID,
     }
     .into();
 


### PR DESCRIPTION
Stacked on #478. Makes program tests read like plain Rust unit tests, in two layers.

## The test world (`quasar-test`)

- **`#[quasar_test]`** attribute (new `quasar-test-derive` crate) replaces the `quasar_test!` macro_rules: a plain `#[test]` with the world injected, full rust-analyzer/rustfmt support, and program resolution by crate name (`target/deploy/{crate}.so` via `CARGO_PKG_NAME`) so `cargo test` works in a workspace that builds many programs. `#[quasar_test(program_id = EXPR)]` for external programs.
- **Typed state I/O**: `q.read::<T>(addr)` returns a snapshot deref-ing to `T`'s data layout after running the framework's own discriminator/owner/size/validity checks; `q.write::<T>(addr, TData { .. })` registers a rent-exempt account with `T`'s discriminator and owner. Raw-byte assertions and hand-serialized fixtures are gone.
- **Seeded PDAs**: `q.pda(T::seeds(&payer))` / `q.pda_with_bump(..)` derive addresses from the same `#[seeds]` definition the program validates against (new `SeedSlices` trait, implemented by generated seed sets).
- `send` backs missing writable instruction accounts with empty system accounts, so init targets need no `q.empty(..)` setup, and freshly created accounts survive into follow-up sends and reads.

## Self-deriving clients (`quasar-derive`)

Generated instruction structs drop every field the framework can compute:

- `Program<T>` / `Sysvar<T>` accounts resolve to their canonical address through hidden consts on the accounts struct.
- Typed-seeds PDA fields (`address = T::seeds(other_field)`) are derived client-side via `find_program_address_const` through a hidden fn, so the seeds definition is the single source of truth.

Both resolve at the accounts struct's definition site (same mechanism as `__QUASAR_ACCOUNT_SIGNERS`), keeping the exported macro scope-safe; `super::` paths make the cpi expansion shadow-proof against same-named client structs.

Tests that deliberately deviate from the canonical call (wrong PDA, spoofed sysvar, missing signature) now say so explicitly via the new `InstructionExt` (`swap_account` / `signed_by`) instead of smuggling the wrong address through a struct field — all 14 suite spoof tests converted with their exact error oracles intact.

## Before / after (scaffold Full template)

```rust
// before: 40 lines of hand-rolled Instruction/AccountMeta/raw-byte asserts
// after:
#[quasar_test]
fn initialize(q: &mut QuasarTest) {
    let payer = q.actor();
    let (my_account, bump) = q.pda_with_bump(MyAccount::seeds(&payer));

    q.send(InitializeInstruction { payer, value: VALUE }).succeeds();

    let state = q.read::<MyAccount>(my_account);
    assert_eq!(state.authority, payer);
    assert_eq!(state.value, VALUE);
    assert_eq!(state.bump, bump);
}
```

The escrow example moved off hand-rolled Mollusk fixtures onto the world as proof: net **-587 lines** across the repo while adding the features.

## Verification

- Suite 554/554; escrow/vault/multisig demos green; `quasar-test` unit tests green.
- Tracked CU and `.so` sizes **byte-identical** to baseline (hidden client helpers strip out of SBF).
- clippy clean; unsafe-policy, test-silence, suite-oracle, metadata, README-inventory, release-train gates green.
- Derive snapshots, proc-macro expansion baselines, and public-API baselines re-blessed.
- `quasar-test-derive` wired through publish metadata and the release workflow tiers (`quasar-test` now publishes after `quasar-lang`).
- Local failures limited to the 6 environment-gated cli smoke tests (pinned Caravel checkout + Python `solders`), which run in CI's toolchain job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)