### PR TITLE
feat(test): gold-standard quasar-test API

### DIFF
--- a/api-baselines/v0.1.0/quasar-lang.all-features.txt
+++ b/api-baselines/v0.1.0/quasar-lang.all-features.txt
@@ -3310,6 +3310,8 @@ pub const quasar_lang::traits::AccountCount::NEEDS_EVENT_CPI: bool
 impl<T, const N: usize> quasar_lang::traits::AccountCount for quasar_lang::accounts::AccountsArray<T, N> where T: quasar_lang::traits::AccountCount
 pub const quasar_lang::accounts::AccountsArray<T, N>::COUNT: usize
 pub const quasar_lang::accounts::AccountsArray<T, N>::NEEDS_EVENT_CPI: bool
+pub trait quasar_lang::traits::AccountData
+pub type quasar_lang::traits::AccountData::Wrapper
 pub trait quasar_lang::traits::AsAccountView
 pub fn quasar_lang::traits::AsAccountView::address(&self) -> &solana_address::Address
 pub fn quasar_lang::traits::AsAccountView::to_account_view(&self) -> &solana_account_view::AccountView

--- a/api-baselines/v0.1.0/quasar-lang.txt
+++ b/api-baselines/v0.1.0/quasar-lang.txt
@@ -3209,6 +3209,8 @@ pub const quasar_lang::traits::AccountCount::NEEDS_EVENT_CPI: bool
 impl<T, const N: usize> quasar_lang::traits::AccountCount for quasar_lang::accounts::AccountsArray<T, N> where T: quasar_lang::traits::AccountCount
 pub const quasar_lang::accounts::AccountsArray<T, N>::COUNT: usize
 pub const quasar_lang::accounts::AccountsArray<T, N>::NEEDS_EVENT_CPI: bool
+pub trait quasar_lang::traits::AccountData
+pub type quasar_lang::traits::AccountData::Wrapper
 pub trait quasar_lang::traits::AsAccountView
 pub fn quasar_lang::traits::AsAccountView::address(&self) -> &solana_address::Address
 pub fn quasar_lang::traits::AsAccountView::to_account_view(&self) -> &solana_account_view::AccountView

--- a/api-baselines/v0.1.0/quasar-test.txt
+++ b/api-baselines/v0.1.0/quasar-test.txt
@@ -1,5 +1,6 @@
 pub mod quasar_test
 pub use quasar_test::Account
+pub use quasar_test::ProgramError
 pub use quasar_test::Pubkey
 pub use quasar_test::QuasarSvm
 pub use quasar_test::QuasarSvmConfig
@@ -28,45 +29,35 @@ pub use quasar_test::prelude::quasar_test
 pub use quasar_test::prelude::system_program
 pub struct quasar_test::prelude::QuasarTest
 impl quasar_test::QuasarTest
-pub fn quasar_test::QuasarTest::actor(&mut self) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actor_at(&mut self, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
-pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::ata_address(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallet(&mut self) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallet_with_lamports(&mut self, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallets<const N: usize>(&mut self) -> [solana_address::Address; N]
+pub fn quasar_test::QuasarTest::builder(impl core::convert::Into<solana_address::Address>) -> quasar_test::QuasarTestBuilder
+pub fn quasar_test::QuasarTest::derive_ata(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::derive_pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
+pub fn quasar_test::QuasarTest::derive_pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
 pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
-pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::from_program_path_with_config(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::fund(&mut self, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::into_inner(self) -> quasar_svm::svm::QuasarSvm
-pub fn quasar_test::QuasarTest::mint(&mut self, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
-pub fn quasar_test::QuasarTest::mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::lamports(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::load_program(&mut self, &solana_address::Address, &[u8])
 pub fn quasar_test::QuasarTest::new(impl core::convert::Into<solana_address::Address>) -> Self
-pub fn quasar_test::QuasarTest::new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> Self
-pub fn quasar_test::QuasarTest::new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> Self
-pub fn quasar_test::QuasarTest::pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
-pub fn quasar_test::QuasarTest::pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
 pub fn quasar_test::QuasarTest::program_id(&self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::program_path(&self) -> &std::path::Path
 pub fn quasar_test::QuasarTest::read<T>(&self, solana_address::Address) -> quasar_test::Snapshot<T> where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + zeropod::traits::ZcValidate + core::marker::Copy
 pub fn quasar_test::QuasarTest::send(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::send_with(&mut self, impl core::convert::Into<solana_instruction::Instruction>, impl core::iter::traits::collect::IntoIterator<Item = quasar_svm::Account>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::simulate(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
-pub fn quasar_test::QuasarTest::token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::try_new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::try_new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::with_account(self, quasar_svm::Account) -> Self
-pub fn quasar_test::QuasarTest::with_airdrop(self, &solana_address::Address, u64) -> Self
-pub fn quasar_test::QuasarTest::with_compute_budget(self, u64) -> Self
-pub fn quasar_test::QuasarTest::with_create_account(self, &solana_address::Address, usize, &solana_address::Address) -> Self
-pub fn quasar_test::QuasarTest::with_program(self, &solana_address::Address, &[u8]) -> Self
-pub fn quasar_test::QuasarTest::with_program_loader(self, &solana_address::Address, &solana_address::Address, &[u8]) -> Self
-pub fn quasar_test::QuasarTest::with_slot(self, u64) -> Self
-pub fn quasar_test::QuasarTest::write<T>(&mut self, solana_address::Address, <T as core::ops::deref::Deref>::Target) -> solana_address::Address where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + core::marker::Copy
+pub fn quasar_test::QuasarTest::supply(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::tokens(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::SetupError>
+pub fn quasar_test::QuasarTest::write<D>(&mut self, solana_address::Address, D) -> solana_address::Address where D: quasar_lang::traits::AccountData + zeropod::traits::ZcElem + core::marker::Copy, <D as quasar_lang::traits::AccountData>::Wrapper: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner
 impl core::ops::deref::Deref for quasar_test::QuasarTest
 pub type quasar_test::QuasarTest::Target = quasar_svm::svm::QuasarSvm
 pub fn quasar_test::QuasarTest::deref(&self) -> &Self::Target
@@ -94,110 +85,92 @@ impl<T> core::marker::UnsafeUnpin for quasar_test::Snapshot<T> where <T as core:
 impl<T> core::panic::unwind_safe::RefUnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::UnwindSafe
 pub trait quasar_test::prelude::ExecutionResultExt
-pub fn quasar_test::prelude::ExecutionResultExt::assert_compute_units_below(&self, u64)
-pub fn quasar_test::prelude::ExecutionResultExt::assert_custom_error<E>(&self, E) where E: core::convert::Into<u32>
-pub fn quasar_test::prelude::ExecutionResultExt::assert_lamports(&self, &solana_address::Address, u64)
-pub fn quasar_test::prelude::ExecutionResultExt::assert_mint_supply(&self, &solana_address::Address, u64)
-pub fn quasar_test::prelude::ExecutionResultExt::assert_token_balance(&self, &solana_address::Address, u64)
 pub fn quasar_test::prelude::ExecutionResultExt::cu_below(&self, u64) -> &Self
+pub fn quasar_test::prelude::ExecutionResultExt::fails(&self, quasar_svm::error::ProgramError) -> &Self
 pub fn quasar_test::prelude::ExecutionResultExt::fails_with<E>(&self, E) -> &Self where E: core::convert::Into<u32>
 pub fn quasar_test::prelude::ExecutionResultExt::has_lamports(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::prelude::ExecutionResultExt::has_supply(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::prelude::ExecutionResultExt::has_tokens(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::prelude::ExecutionResultExt::is_closed(&self, solana_address::Address) -> &Self
 pub fn quasar_test::prelude::ExecutionResultExt::lamports(&self, &solana_address::Address) -> u64
-pub fn quasar_test::prelude::ExecutionResultExt::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_test::prelude::ExecutionResultExt::succeeds(&self) -> &Self
-pub fn quasar_test::prelude::ExecutionResultExt::token_balance(&self, &solana_address::Address) -> u64
+pub fn quasar_test::prelude::ExecutionResultExt::supply(&self, &solana_address::Address) -> u64
+pub fn quasar_test::prelude::ExecutionResultExt::tokens(&self, &solana_address::Address) -> u64
 impl quasar_test::ExecutionResultExt for quasar_svm::svm::ExecutionResult
-pub fn quasar_svm::svm::ExecutionResult::assert_compute_units_below(&self, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_custom_error<E>(&self, E) where E: core::convert::Into<u32>
-pub fn quasar_svm::svm::ExecutionResult::assert_lamports(&self, &solana_address::Address, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_mint_supply(&self, &solana_address::Address, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_token_balance(&self, &solana_address::Address, u64)
 pub fn quasar_svm::svm::ExecutionResult::cu_below(&self, u64) -> &Self
+pub fn quasar_svm::svm::ExecutionResult::fails(&self, quasar_svm::error::ProgramError) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::fails_with<E>(&self, E) -> &Self where E: core::convert::Into<u32>
 pub fn quasar_svm::svm::ExecutionResult::has_lamports(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::has_supply(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::has_tokens(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::is_closed(&self, solana_address::Address) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::lamports(&self, &solana_address::Address) -> u64
-pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
-pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
+pub fn quasar_svm::svm::ExecutionResult::supply(&self, &solana_address::Address) -> u64
+pub fn quasar_svm::svm::ExecutionResult::tokens(&self, &solana_address::Address) -> u64
 pub trait quasar_test::prelude::InstructionExt: core::marker::Sized
 pub fn quasar_test::prelude::InstructionExt::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
 pub fn quasar_test::prelude::InstructionExt::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
 impl<T: core::convert::Into<solana_instruction::Instruction>> quasar_test::InstructionExt for T
 pub fn T::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
 pub fn T::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
-#[non_exhaustive] pub enum quasar_test::ProjectError
-pub quasar_test::ProjectError::AmbiguousPrograms
-pub quasar_test::ProjectError::AmbiguousPrograms::deploy: std::path::PathBuf
-pub quasar_test::ProjectError::AmbiguousPrograms::programs: alloc::vec::Vec<std::path::PathBuf>
-pub quasar_test::ProjectError::ConfiguredProgramMissing
-pub quasar_test::ProjectError::ConfiguredProgramMissing::path: std::path::PathBuf
-pub quasar_test::ProjectError::CurrentDirectory(std::io::error::Error)
-pub quasar_test::ProjectError::ProgramNotFound
-pub quasar_test::ProjectError::ProgramNotFound::checked: alloc::vec::Vec<std::path::PathBuf>
-pub quasar_test::ProjectError::ProgramNotFound::start: std::path::PathBuf
-pub quasar_test::ProjectError::ReadProgram
-pub quasar_test::ProjectError::ReadProgram::path: std::path::PathBuf
-pub quasar_test::ProjectError::ReadProgram::source: std::io::error::Error
-impl core::error::Error for quasar_test::ProjectError
-pub fn quasar_test::ProjectError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-impl core::fmt::Debug for quasar_test::ProjectError
-pub fn quasar_test::ProjectError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for quasar_test::ProjectError
-pub fn quasar_test::ProjectError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for quasar_test::ProjectError
-impl core::marker::Send for quasar_test::ProjectError
-impl core::marker::Sync for quasar_test::ProjectError
-impl core::marker::Unpin for quasar_test::ProjectError
-impl core::marker::UnsafeUnpin for quasar_test::ProjectError
-impl !core::panic::unwind_safe::RefUnwindSafe for quasar_test::ProjectError
-impl !core::panic::unwind_safe::UnwindSafe for quasar_test::ProjectError
+#[non_exhaustive] pub enum quasar_test::SetupError
+pub quasar_test::SetupError::AmbiguousPrograms
+pub quasar_test::SetupError::AmbiguousPrograms::deploy: std::path::PathBuf
+pub quasar_test::SetupError::AmbiguousPrograms::programs: alloc::vec::Vec<std::path::PathBuf>
+pub quasar_test::SetupError::ConfiguredProgramMissing
+pub quasar_test::SetupError::ConfiguredProgramMissing::path: std::path::PathBuf
+pub quasar_test::SetupError::CurrentDirectory(std::io::error::Error)
+pub quasar_test::SetupError::ProgramNotFound
+pub quasar_test::SetupError::ProgramNotFound::checked: alloc::vec::Vec<std::path::PathBuf>
+pub quasar_test::SetupError::ProgramNotFound::start: std::path::PathBuf
+pub quasar_test::SetupError::ReadProgram
+pub quasar_test::SetupError::ReadProgram::path: std::path::PathBuf
+pub quasar_test::SetupError::ReadProgram::source: std::io::error::Error
+impl core::error::Error for quasar_test::SetupError
+pub fn quasar_test::SetupError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for quasar_test::SetupError
+pub fn quasar_test::SetupError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for quasar_test::SetupError
+pub fn quasar_test::SetupError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for quasar_test::SetupError
+impl core::marker::Send for quasar_test::SetupError
+impl core::marker::Sync for quasar_test::SetupError
+impl core::marker::Unpin for quasar_test::SetupError
+impl core::marker::UnsafeUnpin for quasar_test::SetupError
+impl !core::panic::unwind_safe::RefUnwindSafe for quasar_test::SetupError
+impl !core::panic::unwind_safe::UnwindSafe for quasar_test::SetupError
 pub struct quasar_test::QuasarTest
 impl quasar_test::QuasarTest
-pub fn quasar_test::QuasarTest::actor(&mut self) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actor_at(&mut self, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actor_with_lamports(&mut self, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::actors<const N: usize>(&mut self) -> [solana_address::Address; N]
-pub fn quasar_test::QuasarTest::ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::ata_address(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::empty(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_ata(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint(&mut self, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallet(&mut self) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallet_with_lamports(&mut self, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::add_wallets<const N: usize>(&mut self) -> [solana_address::Address; N]
+pub fn quasar_test::QuasarTest::builder(impl core::convert::Into<solana_address::Address>) -> quasar_test::QuasarTestBuilder
+pub fn quasar_test::QuasarTest::derive_ata(&self, solana_address::Address, solana_address::Address) -> solana_address::Address
+pub fn quasar_test::QuasarTest::derive_pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
+pub fn quasar_test::QuasarTest::derive_pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
 pub fn quasar_test::QuasarTest::fresh_address(&mut self) -> solana_address::Address
-pub fn quasar_test::QuasarTest::from_program_path(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::from_program_path_with_config(impl core::convert::Into<solana_address::Address>, impl core::convert::AsRef<std::path::Path>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
 pub fn quasar_test::QuasarTest::fund(&mut self, solana_address::Address, u64) -> solana_address::Address
 pub fn quasar_test::QuasarTest::into_inner(self) -> quasar_svm::svm::QuasarSvm
-pub fn quasar_test::QuasarTest::mint(&mut self, solana_address::Address) -> solana_address::Address
-pub fn quasar_test::QuasarTest::mint_at(&mut self, solana_address::Address, solana_address::Address, u64, u8) -> solana_address::Address
-pub fn quasar_test::QuasarTest::mint_with_supply(&mut self, solana_address::Address, u64) -> solana_address::Address
+pub fn quasar_test::QuasarTest::lamports(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::load_program(&mut self, &solana_address::Address, &[u8])
 pub fn quasar_test::QuasarTest::new(impl core::convert::Into<solana_address::Address>) -> Self
-pub fn quasar_test::QuasarTest::new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> Self
-pub fn quasar_test::QuasarTest::new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> Self
-pub fn quasar_test::QuasarTest::pda(&self, impl quasar_lang::traits::SeedSlices) -> solana_address::Address
-pub fn quasar_test::QuasarTest::pda_with_bump(&self, impl quasar_lang::traits::SeedSlices) -> (solana_address::Address, u8)
 pub fn quasar_test::QuasarTest::program_id(&self) -> solana_address::Address
 pub fn quasar_test::QuasarTest::program_path(&self) -> &std::path::Path
 pub fn quasar_test::QuasarTest::read<T>(&self, solana_address::Address) -> quasar_test::Snapshot<T> where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + zeropod::traits::ZcValidate + core::marker::Copy
 pub fn quasar_test::QuasarTest::send(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::send_with(&mut self, impl core::convert::Into<solana_instruction::Instruction>, impl core::iter::traits::collect::IntoIterator<Item = quasar_svm::Account>) -> quasar_svm::svm::ExecutionResult
 pub fn quasar_test::QuasarTest::simulate(&mut self, impl core::convert::Into<solana_instruction::Instruction>) -> quasar_svm::svm::ExecutionResult
-pub fn quasar_test::QuasarTest::token_account(&mut self, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::token_account_at(&mut self, solana_address::Address, solana_address::Address, solana_address::Address, u64) -> solana_address::Address
-pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::try_new_for_crate(impl core::convert::Into<solana_address::Address>, &str) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::try_new_with_config(impl core::convert::Into<solana_address::Address>, quasar_svm::svm::QuasarSvmConfig) -> core::result::Result<Self, quasar_test::ProjectError>
-pub fn quasar_test::QuasarTest::with_account(self, quasar_svm::Account) -> Self
-pub fn quasar_test::QuasarTest::with_airdrop(self, &solana_address::Address, u64) -> Self
-pub fn quasar_test::QuasarTest::with_compute_budget(self, u64) -> Self
-pub fn quasar_test::QuasarTest::with_create_account(self, &solana_address::Address, usize, &solana_address::Address) -> Self
-pub fn quasar_test::QuasarTest::with_program(self, &solana_address::Address, &[u8]) -> Self
-pub fn quasar_test::QuasarTest::with_program_loader(self, &solana_address::Address, &solana_address::Address, &[u8]) -> Self
-pub fn quasar_test::QuasarTest::with_slot(self, u64) -> Self
-pub fn quasar_test::QuasarTest::write<T>(&mut self, solana_address::Address, <T as core::ops::deref::Deref>::Target) -> solana_address::Address where T: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner + core::ops::deref::Deref, <T as core::ops::deref::Deref>::Target: zeropod::traits::ZcElem + core::marker::Copy
+pub fn quasar_test::QuasarTest::supply(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::tokens(&self, solana_address::Address) -> u64
+pub fn quasar_test::QuasarTest::try_new(impl core::convert::Into<solana_address::Address>) -> core::result::Result<Self, quasar_test::SetupError>
+pub fn quasar_test::QuasarTest::write<D>(&mut self, solana_address::Address, D) -> solana_address::Address where D: quasar_lang::traits::AccountData + zeropod::traits::ZcElem + core::marker::Copy, <D as quasar_lang::traits::AccountData>::Wrapper: quasar_lang::traits::Discriminator + quasar_lang::traits::Owner
 impl core::ops::deref::Deref for quasar_test::QuasarTest
 pub type quasar_test::QuasarTest::Target = quasar_svm::svm::QuasarSvm
 pub fn quasar_test::QuasarTest::deref(&self) -> &Self::Target
@@ -210,6 +183,19 @@ impl core::marker::Unpin for quasar_test::QuasarTest
 impl core::marker::UnsafeUnpin for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::RefUnwindSafe for quasar_test::QuasarTest
 impl !core::panic::unwind_safe::UnwindSafe for quasar_test::QuasarTest
+pub struct quasar_test::QuasarTestBuilder
+impl quasar_test::QuasarTestBuilder
+pub fn quasar_test::QuasarTestBuilder::build(self) -> core::result::Result<quasar_test::QuasarTest, quasar_test::SetupError>
+pub fn quasar_test::QuasarTestBuilder::config(self, quasar_svm::svm::QuasarSvmConfig) -> Self
+pub fn quasar_test::QuasarTestBuilder::crate_name(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn quasar_test::QuasarTestBuilder::program_path(self, impl core::convert::Into<std::path::PathBuf>) -> Self
+impl core::marker::Freeze for quasar_test::QuasarTestBuilder
+impl core::marker::Send for quasar_test::QuasarTestBuilder
+impl core::marker::Sync for quasar_test::QuasarTestBuilder
+impl core::marker::Unpin for quasar_test::QuasarTestBuilder
+impl core::marker::UnsafeUnpin for quasar_test::QuasarTestBuilder
+impl core::panic::unwind_safe::RefUnwindSafe for quasar_test::QuasarTestBuilder
+impl core::panic::unwind_safe::UnwindSafe for quasar_test::QuasarTestBuilder
 pub struct quasar_test::Snapshot<T: core::ops::deref::Deref> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
 impl<T: core::ops::deref::Deref> quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::Copy
 pub fn quasar_test::Snapshot<T>::address(&self) -> solana_address::Address
@@ -224,45 +210,35 @@ impl<T> core::marker::Unpin for quasar_test::Snapshot<T> where <T as core::ops::
 impl<T> core::marker::UnsafeUnpin for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for quasar_test::Snapshot<T> where <T as core::ops::deref::Deref>::Target: core::marker::Sized + core::panic::unwind_safe::UnwindSafe
-pub const quasar_test::DEFAULT_ACTOR_LAMPORTS: u64
+pub const quasar_test::DEFAULT_WALLET_LAMPORTS: u64
 pub const quasar_test::PROGRAM_PATH_ENV: &str
 pub trait quasar_test::ExecutionResultExt
-pub fn quasar_test::ExecutionResultExt::assert_compute_units_below(&self, u64)
-pub fn quasar_test::ExecutionResultExt::assert_custom_error<E>(&self, E) where E: core::convert::Into<u32>
-pub fn quasar_test::ExecutionResultExt::assert_lamports(&self, &solana_address::Address, u64)
-pub fn quasar_test::ExecutionResultExt::assert_mint_supply(&self, &solana_address::Address, u64)
-pub fn quasar_test::ExecutionResultExt::assert_token_balance(&self, &solana_address::Address, u64)
 pub fn quasar_test::ExecutionResultExt::cu_below(&self, u64) -> &Self
+pub fn quasar_test::ExecutionResultExt::fails(&self, quasar_svm::error::ProgramError) -> &Self
 pub fn quasar_test::ExecutionResultExt::fails_with<E>(&self, E) -> &Self where E: core::convert::Into<u32>
 pub fn quasar_test::ExecutionResultExt::has_lamports(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::ExecutionResultExt::has_supply(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::ExecutionResultExt::has_tokens(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_test::ExecutionResultExt::is_closed(&self, solana_address::Address) -> &Self
 pub fn quasar_test::ExecutionResultExt::lamports(&self, &solana_address::Address) -> u64
-pub fn quasar_test::ExecutionResultExt::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_test::ExecutionResultExt::succeeds(&self) -> &Self
-pub fn quasar_test::ExecutionResultExt::token_balance(&self, &solana_address::Address) -> u64
+pub fn quasar_test::ExecutionResultExt::supply(&self, &solana_address::Address) -> u64
+pub fn quasar_test::ExecutionResultExt::tokens(&self, &solana_address::Address) -> u64
 impl quasar_test::ExecutionResultExt for quasar_svm::svm::ExecutionResult
-pub fn quasar_svm::svm::ExecutionResult::assert_compute_units_below(&self, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_custom_error<E>(&self, E) where E: core::convert::Into<u32>
-pub fn quasar_svm::svm::ExecutionResult::assert_lamports(&self, &solana_address::Address, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_mint_supply(&self, &solana_address::Address, u64)
-pub fn quasar_svm::svm::ExecutionResult::assert_token_balance(&self, &solana_address::Address, u64)
 pub fn quasar_svm::svm::ExecutionResult::cu_below(&self, u64) -> &Self
+pub fn quasar_svm::svm::ExecutionResult::fails(&self, quasar_svm::error::ProgramError) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::fails_with<E>(&self, E) -> &Self where E: core::convert::Into<u32>
 pub fn quasar_svm::svm::ExecutionResult::has_lamports(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::has_supply(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::has_tokens(&self, solana_address::Address, u64) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::is_closed(&self, solana_address::Address) -> &Self
 pub fn quasar_svm::svm::ExecutionResult::lamports(&self, &solana_address::Address) -> u64
-pub fn quasar_svm::svm::ExecutionResult::mint_supply(&self, &solana_address::Address) -> u64
 pub fn quasar_svm::svm::ExecutionResult::succeeds(&self) -> &Self
-pub fn quasar_svm::svm::ExecutionResult::token_balance(&self, &solana_address::Address) -> u64
+pub fn quasar_svm::svm::ExecutionResult::supply(&self, &solana_address::Address) -> u64
+pub fn quasar_svm::svm::ExecutionResult::tokens(&self, &solana_address::Address) -> u64
 pub trait quasar_test::InstructionExt: core::marker::Sized
 pub fn quasar_test::InstructionExt::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
 pub fn quasar_test::InstructionExt::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
 impl<T: core::convert::Into<solana_instruction::Instruction>> quasar_test::InstructionExt for T
 pub fn T::signed_by(self, &[solana_address::Address]) -> solana_instruction::Instruction
 pub fn T::swap_account(self, solana_address::Address, solana_address::Address) -> solana_instruction::Instruction
-pub fn quasar_test::resolve_program_path() -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>
-pub fn quasar_test::resolve_program_path_named(&str) -> core::result::Result<std::path::PathBuf, quasar_test::ProjectError>

--- a/cli/src/init/scaffold.rs
+++ b/cli/src/init/scaffold.rs
@@ -427,7 +427,7 @@ const client = new {class_name}Client();
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes", async () => {{
     const q = await QuasarTest.load(PROGRAM_ADDRESS);
-    const payer = await q.actor();
+    const payer = await q.add_wallet();
 
     const result = await q.send(client.createInitializeInstruction({{ payer }}));
 
@@ -449,7 +449,7 @@ const client = new {class_name}Client();
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes", async () => {{
     const q = await QuasarTest.load({class_name}Client.programId);
-    const payer = await q.actor();
+    const payer = await q.add_wallet();
 
     const result = await q.send(client.createInitializeInstruction({{ payer }}));
 
@@ -481,7 +481,7 @@ const client = new {class_name}Client();
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes state", async () => {{
     const q = await QuasarTest.load(PROGRAM_ADDRESS);
-    const payer = await q.actor();
+    const payer = await q.add_wallet();
     const myAccount = await findMyAccountAddress(payer);
     q.empty(myAccount);
     const value = 42n;
@@ -514,7 +514,7 @@ const client = new {class_name}Client();
 describe.concurrent("{class_name} Program", async () => {{
   it("initializes state", async () => {{
     const q = await QuasarTest.load({class_name}Client.programId);
-    const payer = await q.actor();
+    const payer = await q.add_wallet();
     const myAccount = await findMyAccountAddress(payer);
     q.empty(myAccount);
     const value = 42n;
@@ -663,7 +663,7 @@ fn test_initialize() {{
 
 #[quasar_test]
 fn initialize(q: &mut QuasarTest) {
-    let payer = q.actor();
+    let payer = q.add_wallet();
     q.send(InitializeInstruction { payer }).succeeds();
 }
 "#
@@ -678,8 +678,8 @@ const VALUE: u64 = 42;
 
 #[quasar_test]
 fn initialize(q: &mut QuasarTest) {
-    let payer = q.actor();
-    let (my_account, bump) = q.pda_with_bump(MyAccount::seeds(&payer));
+    let payer = q.add_wallet();
+    let (my_account, bump) = q.derive_pda_with_bump(MyAccount::seeds(&payer));
 
     q.send(InitializeInstruction { payer, value: VALUE }).succeeds();
 
@@ -1037,7 +1037,7 @@ mod tests {
             let framework = RustFramework::QuasarSVM;
             let full = generate_tests_rs("demo", framework, Template::Full, Toolchain::Solana);
             assert!(full.contains("#[quasar_test]"));
-            assert!(full.contains("q.pda_with_bump(MyAccount::seeds(&payer))"));
+            assert!(full.contains("q.derive_pda_with_bump(MyAccount::seeds(&payer))"));
             assert!(full.contains("q.send(InitializeInstruction {"));
             assert!(full.contains("q.read::<MyAccount>(my_account)"));
             assert!(!full.contains("fixtures::"));
@@ -1046,7 +1046,7 @@ mod tests {
             let minimal =
                 generate_tests_rs("demo", framework, Template::Minimal, Toolchain::Solana);
             assert!(minimal.contains("#[quasar_test]"));
-            assert!(minimal.contains("let payer = q.actor();"));
+            assert!(minimal.contains("let payer = q.add_wallet();"));
             assert!(!minimal.contains("MyAccount"));
         }
 

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/account_dynamic.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/account_dynamic.rs
@@ -7,6 +7,9 @@ pub struct DynamicAccount {
 Use this type when constructing account data values (e.g., for `Migrate` implementations).*/
 pub type DynamicAccountData = __dynamic_account_zc::DynamicAccountZc;
 unsafe impl ::quasar_lang::traits::StaticView for DynamicAccount {}
+impl ::quasar_lang::traits::AccountData for __dynamic_account_zc::DynamicAccountZc {
+    type Wrapper = DynamicAccount;
+}
 impl ::quasar_lang::traits::AsAccountView for DynamicAccount {
     #[inline(always)]
     fn to_account_view(&self) -> &::quasar_lang::__internal::AccountView {

--- a/compatibility-baselines/v0.1.0/proc-macros/expansions/account_fixed.rs
+++ b/compatibility-baselines/v0.1.0/proc-macros/expansions/account_fixed.rs
@@ -7,6 +7,9 @@ pub struct MixedAccount {
 Use this type when constructing account data values (e.g., for `Migrate` implementations).*/
 pub type MixedAccountData = __mixed_account_zc::MixedAccountZc;
 unsafe impl ::quasar_lang::traits::StaticView for MixedAccount {}
+impl ::quasar_lang::traits::AccountData for __mixed_account_zc::MixedAccountZc {
+    type Wrapper = MixedAccount;
+}
 impl ::quasar_lang::traits::AsAccountView for MixedAccount {
     #[inline(always)]
     fn to_account_view(&self) -> &::quasar_lang::__internal::AccountView {

--- a/derive/src/account/layout.rs
+++ b/derive/src/account/layout.rs
@@ -209,6 +209,10 @@ pub(super) fn emit_account_wrapper(
 
         unsafe impl #krate::traits::StaticView for #name {}
 
+        impl #krate::traits::AccountData for #zc_path {
+            type Wrapper = #name;
+        }
+
         impl #krate::traits::AsAccountView for #name {
             #[inline(always)]
             fn to_account_view(&self) -> &#krate::__internal::AccountView {

--- a/examples/escrow/src/tests.rs
+++ b/examples/escrow/src/tests.rs
@@ -4,7 +4,7 @@ use {
         cpi::*,
         state::{Escrow, EscrowData},
     },
-    quasar_test::prelude::*,
+    quasar_test::{prelude::*, DEFAULT_WALLET_LAMPORTS},
 };
 
 #[path = "../../cu_bench.rs"]
@@ -25,15 +25,15 @@ const WRONG_OWNER: Pubkey = Pubkey::new_from_array([10; 32]);
 
 /// Register the maker and both mints.
 fn base_world(q: &mut QuasarTest) {
-    q.actor_at(MAKER);
-    q.mint_at(MINT_A, MAKER, 1_000_000_000, 9);
-    q.mint_at(MINT_B, MAKER, 1_000_000_000, 9);
+    q.fund(MAKER, DEFAULT_WALLET_LAMPORTS);
+    q.add_mint_at(MINT_A, MAKER, 1_000_000_000, 9);
+    q.add_mint_at(MINT_B, MAKER, 1_000_000_000, 9);
 }
 
 /// Register a live escrow holding 1337 vault tokens, as `make` leaves it.
 fn live_escrow(q: &mut QuasarTest) -> Pubkey {
-    let (escrow, bump) = q.pda_with_bump(Escrow::seeds(&MAKER));
-    q.write::<Escrow>(
+    let (escrow, bump) = q.derive_pda_with_bump(Escrow::seeds(&MAKER));
+    q.write(
         escrow,
         EscrowData {
             maker: MAKER,
@@ -44,15 +44,15 @@ fn live_escrow(q: &mut QuasarTest) -> Pubkey {
             bump,
         },
     );
-    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 1337);
+    q.add_token_account_at(VAULT_TA_A, escrow, MINT_A, 1337);
     escrow
 }
 
 #[quasar_test]
 fn test_make_cu(q: &mut QuasarTest) {
     base_world(q);
-    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
-    let (escrow, bump) = q.pda_with_bump(Escrow::seeds(&MAKER));
+    q.add_token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let (escrow, bump) = q.derive_pda_with_bump(Escrow::seeds(&MAKER));
 
     let result = q.send(MakeInstruction {
         maker: MAKER,
@@ -77,9 +77,9 @@ fn test_make_cu(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_take_cu(q: &mut QuasarTest) {
     base_world(q);
-    q.actor_at(TAKER);
+    q.fund(TAKER, DEFAULT_WALLET_LAMPORTS);
     live_escrow(q);
-    q.token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
+    q.add_token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
 
     let result = q.send(TakeInstruction {
         taker: TAKER,
@@ -115,10 +115,10 @@ fn test_refund_cu(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_make_existing_token_accounts(q: &mut QuasarTest) {
     base_world(q);
-    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
-    let escrow = q.pda(Escrow::seeds(&MAKER));
-    q.token_account_at(MAKER_TA_B, MAKER, MINT_B, 0);
-    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+    q.add_token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.derive_pda(Escrow::seeds(&MAKER));
+    q.add_token_account_at(MAKER_TA_B, MAKER, MINT_B, 0);
+    q.add_token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
 
     q.send(MakeInstruction {
         maker: MAKER,
@@ -136,10 +136,10 @@ fn test_make_existing_token_accounts(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_make_existing_maker_ta_b_wrong_mint(q: &mut QuasarTest) {
     base_world(q);
-    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
-    let escrow = q.pda(Escrow::seeds(&MAKER));
-    q.token_account_at(MAKER_TA_B, MAKER, MINT_A, 0); // wrong mint
-    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+    q.add_token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.derive_pda(Escrow::seeds(&MAKER));
+    q.add_token_account_at(MAKER_TA_B, MAKER, MINT_A, 0); // wrong mint
+    q.add_token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
 
     let result = q.send(MakeInstruction {
         maker: MAKER,
@@ -160,10 +160,10 @@ fn test_make_existing_maker_ta_b_wrong_mint(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_make_existing_maker_ta_b_wrong_owner(q: &mut QuasarTest) {
     base_world(q);
-    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
-    let escrow = q.pda(Escrow::seeds(&MAKER));
-    q.token_account_at(MAKER_TA_B, WRONG_OWNER, MINT_B, 0); // wrong owner
-    q.token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
+    q.add_token_account_at(MAKER_TA_A, MAKER, MINT_A, 1_000_000);
+    let escrow = q.derive_pda(Escrow::seeds(&MAKER));
+    q.add_token_account_at(MAKER_TA_B, WRONG_OWNER, MINT_B, 0); // wrong owner
+    q.add_token_account_at(VAULT_TA_A, escrow, MINT_A, 0);
 
     let result = q.send(MakeInstruction {
         maker: MAKER,
@@ -184,11 +184,11 @@ fn test_make_existing_maker_ta_b_wrong_owner(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_take_existing_token_accounts(q: &mut QuasarTest) {
     base_world(q);
-    q.actor_at(TAKER);
+    q.fund(TAKER, DEFAULT_WALLET_LAMPORTS);
     live_escrow(q);
-    q.token_account_at(TAKER_TA_A, TAKER, MINT_A, 0);
-    q.token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
-    q.token_account_at(MAKER_TA_B, MAKER, MINT_B, 500);
+    q.add_token_account_at(TAKER_TA_A, TAKER, MINT_A, 0);
+    q.add_token_account_at(TAKER_TA_B, TAKER, MINT_B, 10_000);
+    q.add_token_account_at(MAKER_TA_B, MAKER, MINT_B, 500);
 
     q.send(TakeInstruction {
         taker: TAKER,
@@ -206,7 +206,7 @@ fn test_take_existing_token_accounts(q: &mut QuasarTest) {
 #[quasar_test]
 fn test_refund_existing_maker_ta_a(q: &mut QuasarTest) {
     base_world(q);
-    q.token_account_at(MAKER_TA_A, MAKER, MINT_A, 5_000);
+    q.add_token_account_at(MAKER_TA_A, MAKER, MINT_A, 5_000);
     live_escrow(q);
 
     q.send(RefundInstruction {

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -322,6 +322,17 @@ pub trait HasSeeds {
     type WithBump<'seed>;
 }
 
+/// Links an account's generated data layout (`{Name}Data`) back to its
+/// wrapper type.
+///
+/// Implemented by: `#[account]` for the data layout it generates.
+/// Used by: `quasar-test`'s `write`, so the wrapper never has to be named
+/// twice (`q.write(addr, VaultData { .. })`).
+pub trait AccountData {
+    /// The `#[account]` wrapper this layout belongs to.
+    type Wrapper;
+}
+
 /// Owned type of one `#[seeds(...)]` dynamic parameter, by position.
 ///
 /// Implemented by: seeds codegen for each dynamic seed.

--- a/testing/API.md
+++ b/testing/API.md
@@ -1,0 +1,79 @@
+# quasar-test API standard
+
+The rules the `quasar-test` surface is held to. New methods must fit one of
+the shapes below or argue for a new shape here first; a method that can be
+expressed through an existing shape does not get its own name.
+
+## The shapes
+
+**Construction** is `new` / `try_new` / `builder` — nothing else. The blessed
+path takes exactly the program id; every setup knob (config, artifact path,
+crate name) lives on `QuasarTestBuilder`. No `new_with_x`, `from_x`, or
+`x_for_y` constructor variants: each knob added that way multiplies the whole
+constructor family.
+
+**Nouns answer questions; verbs change the world.** A method that registers
+state is a verb — `add_wallet`, `add_mint`, `add_token_account`, `add_ata`,
+`fund`, `write`, `load_program` — takes `&mut self`, and returns the
+address it registered. A method that only computes or reads is a noun —
+`derive_pda`, `derive_ata`, `fresh_address`, `read`, `lamports` — and never
+mutates. The
+same word never does both. A derivation keeps the bare noun unless a
+registering `add_` sibling shares it — then it takes `derive_`, so the pair
+cannot be misread: `derive_ata(owner, mint)` computes, `add_ata(owner, mint,
+amount)` registers, while `pda` stays bare because nothing registers PDAs.
+
+```rust
+let maker = q.add_wallet();
+let mint = q.add_mint(maker);
+let vault = q.derive_ata(escrow, mint);   // derive only: an init target
+let funded = q.add_ata(maker, mint, 10);  // register
+```
+
+- The base form uses sensible defaults at a fresh, per-world-deterministic
+  address.
+- `_at(address, ...)` pins the address and exposes the family's full
+  parameters; it is the maximal form, not a third naming axis.
+- `_with_x(...)` exists only when `x` is the point of the scenario
+  (`add_wallet_with_lamports`), never as general configuration.
+- One name per concept: an `_at`/`_with` variant whose reason to exist has
+  lapsed is deleted, not kept for symmetry.
+
+**Addresses** come from declarations, not arithmetic: `pda(T::seeds(..))` /
+`pda_with_bump`, `derive_ata(owner, mint)`, `fresh_address()`. Tests never hand-roll
+seed bytes.
+
+**Typed state** is the symmetric pair `read::<T>(address) -> Snapshot<T>` /
+`write(address, TData { .. })`, running the framework's own validation in
+both directions. `write` infers the owning type from the data value
+(`AccountData::Wrapper`); a type is never named twice in one call.
+
+**Execution** is `send` / `send_with` / `simulate`. `send` is the default and
+commits; the other two are the two escape hatches (extra accounts, no
+commit). All three are `#[must_use]`: an executed-but-unasserted instruction
+is a silent test, and the compiler rejects it. Deliberate deviations from the
+canonical call are made on the built instruction (`swap_account`,
+`signed_by`), visibly, at the construction site.
+
+**Results** are fluent asserts plus noun getters, and the two families rhyme:
+`has_lamports` / `has_tokens` / `has_supply` assert what `lamports` /
+`tokens` / `supply` return — on the result for post-execution values and on
+the world for current state. `fails_with` takes typed custom errors;
+`fails` takes a plain `ProgramError`. Asserting methods chain (`&Self`);
+there are no `assert_x` doubles of fluent methods, and failure messages name
+the account and the expectation.
+
+## The boundaries
+
+- `QuasarTest` derefs to `QuasarSvm`: the VM's own API is the ejection hatch
+  and is never re-exported method-for-method. A `QuasarTest` method must add
+  test vocabulary (defaults, derivation, typed access), not forwarding.
+- Machinery a user never calls stays out of sight: macro-only entry points go
+  through the builder, resolution helpers are private, `PROGRAM_PATH_ENV` is
+  the one documented contract with the CLI.
+- Panics are the assertion mechanism (this is a test crate); `try_` and
+  `SetupError` exist only where a test legitimately handles failure —
+  world setup.
+- The prelude exports what a test file actually names: the world, the
+  attribute, the two extension traits, the wire types, and the token program
+  ids. Nothing speculative.

--- a/testing/README.md
+++ b/testing/README.md
@@ -19,7 +19,7 @@ use {
 
 #[quasar_test]
 fn deposits_into_the_vault(q: &mut QuasarTest) {
-    let authority = q.actor();
+    let authority = q.add_wallet();
 
     q.send(InitializeInstruction { authority }).succeeds();
     q.send(DepositInstruction {
@@ -29,7 +29,7 @@ fn deposits_into_the_vault(q: &mut QuasarTest) {
     .succeeds()
     .cu_below(10_000);
 
-    let state = q.read::<Vault>(q.pda(Vault::seeds(&authority)));
+    let state = q.read::<Vault>(q.derive_pda(Vault::seeds(&authority)));
     assert_eq!(state.balance, 1_000_000_000);
 }
 ```
@@ -38,10 +38,11 @@ A `#[quasar_test]` function is a plain `#[test]` whose world is loaded from
 the crate's compiled program. Everything typed comes from the program itself:
 instructions from the generated client (which fills in `Program<T>`/
 `Sysvar<T>` addresses and derives `#[seeds]` PDA accounts, so neither appears
-in the struct), addresses via `pda` from `#[seeds]`, state via `read`/`write`
-from `#[account]`. `actor`, `actors`, `actor_at`, `mint`, `ata`, and `empty`
-put common fixtures directly into the test world, and `send` backs missing
-writable accounts with empty system accounts so init targets need no setup.
+in the struct), addresses via `derive_pda` from `#[seeds]`, state via `read`/`write`
+from `#[account]`. `add_wallet`, `add_mint`, `add_token_account`, `add_ata`,
+and `fund` put common fixtures directly into the test world, and `send` backs
+missing writable accounts with empty system accounts so init targets need no
+setup.
 The returned result supports fluent success, typed error, compute-unit,
 balance, supply, and account-closure checks. For a deliberate deviation from
 the canonical call — a spoofed PDA, a missing signature — adjust the built
@@ -54,8 +55,9 @@ available for unusual cases.
 `target/deploy/{crate_name}.so` in the nearest ancestor target directory and
 otherwise require a single unambiguous `.so`, so a test cannot silently
 execute the wrong binary. Use `#[quasar_test(program_id = EXPR)]` for an
-external program and `QuasarTest::from_program_path` for an explicit
-artifact.
+external program and `QuasarTest::builder(id)` (config, explicit artifact
+path, crate name) when setup needs control. The API's shapes and naming
+rules live in [API.md](API.md).
 
 `QuasarTest` dereferences to `QuasarSvm`, so the complete VM API remains
 available. Use `quasar-svm` directly only when you are testing the VM itself or

--- a/testing/derive/src/lib.rs
+++ b/testing/derive/src/lib.rs
@@ -70,8 +70,10 @@ pub fn quasar_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         #(#attrs)*
         #[test]
         fn #name() {
-            let mut __quasar_world =
-                ::quasar_test::QuasarTest::new_for_crate(#program_id, env!("CARGO_PKG_NAME"));
+            let mut __quasar_world = ::quasar_test::QuasarTest::builder(#program_id)
+                .crate_name(env!("CARGO_PKG_NAME"))
+                .build()
+                .unwrap_or_else(|error| ::core::panic!("{error}"));
             let #world_name: #world_ty = &mut __quasar_world;
             #body
         }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -8,7 +8,7 @@
 use {
     quasar_lang::{
         __zeropod::{ZcElem, ZcValidate},
-        traits::{Discriminator, Owner, SeedSlices},
+        traits::{AccountData, Discriminator, Owner, SeedSlices},
     },
     std::{
         env,
@@ -19,15 +19,15 @@ use {
     },
 };
 pub use {
-    quasar_svm::{Account, Pubkey, QuasarSvm, QuasarSvmConfig},
+    quasar_svm::{Account, ProgramError, Pubkey, QuasarSvm, QuasarSvmConfig},
     quasar_test_derive::quasar_test,
 };
 
 /// Environment variable set by `quasar test` to the freshly built program.
 pub const PROGRAM_PATH_ENV: &str = "QUASAR_PROGRAM_PATH";
 
-/// Default balance assigned by [`QuasarTest::actor`]: ten SOL.
-pub const DEFAULT_ACTOR_LAMPORTS: u64 = 10_000_000_000;
+/// Default balance assigned by [`QuasarTest::add_wallet`]: ten SOL.
+pub const DEFAULT_WALLET_LAMPORTS: u64 = 10_000_000_000;
 
 /// A project-aware wrapper around [`QuasarSvm`].
 ///
@@ -44,8 +44,10 @@ impl QuasarTest {
     /// Load the current project's compiled program.
     ///
     /// `quasar test` supplies the exact artifact through
-    /// [`PROGRAM_PATH_ENV`]. For direct `cargo test` runs, Quasar searches
-    /// ancestor `target/deploy` directories and accepts the only `.so` there.
+    /// [`PROGRAM_PATH_ENV`]. For direct `cargo test` runs, Quasar prefers
+    /// `target/deploy/{crate_name}.so` when a crate name is known (see
+    /// [`QuasarTest::builder`]) and otherwise accepts the only `.so` in an
+    /// ancestor `target/deploy` directory.
     ///
     /// # Panics
     ///
@@ -53,77 +55,31 @@ impl QuasarTest {
     /// located or read. Use [`Self::try_new`] when setup errors should be
     /// handled explicitly.
     pub fn new(program_id: impl Into<Pubkey>) -> Self {
-        Self::try_new(program_id).unwrap_or_else(|error| panic!("{error}"))
-    }
-
-    /// Load the current project's program with explicit SVM configuration.
-    ///
-    /// This is useful when a test wants to disable bundled SPL programs or
-    /// otherwise control the base runtime. See [`QuasarSvmConfig`].
-    pub fn new_with_config(program_id: impl Into<Pubkey>, config: QuasarSvmConfig) -> Self {
-        Self::try_new_with_config(program_id, config).unwrap_or_else(|error| panic!("{error}"))
+        Self::builder(program_id)
+            .build()
+            .unwrap_or_else(|error| panic!("{error}"))
     }
 
     /// Fallible variant of [`Self::new`].
-    pub fn try_new(program_id: impl Into<Pubkey>) -> Result<Self, ProjectError> {
-        Self::try_new_with_config(program_id, QuasarSvmConfig::default())
+    pub fn try_new(program_id: impl Into<Pubkey>) -> Result<Self, SetupError> {
+        Self::builder(program_id).build()
     }
 
-    /// Load a crate's compiled program by name.
+    /// Customize world setup before loading the program.
     ///
-    /// Prefers `target/deploy/{crate_name}.so` (with `-` mapped to `_`) over
-    /// the only-artifact rule, so tests resolve their own program in a
-    /// workspace that builds several. `#[quasar_test]` calls this with
-    /// `env!("CARGO_PKG_NAME")`.
-    pub fn new_for_crate(program_id: impl Into<Pubkey>, crate_name: &str) -> Self {
-        Self::try_new_for_crate(program_id, crate_name).unwrap_or_else(|error| panic!("{error}"))
-    }
-
-    /// Fallible variant of [`Self::new_for_crate`].
-    pub fn try_new_for_crate(
-        program_id: impl Into<Pubkey>,
-        crate_name: &str,
-    ) -> Result<Self, ProjectError> {
-        let path = resolve_program_path_named(crate_name)?;
-        Self::from_program_path_with_config(program_id, path, QuasarSvmConfig::default())
-    }
-
-    /// Fallible variant of [`Self::new_with_config`].
-    pub fn try_new_with_config(
-        program_id: impl Into<Pubkey>,
-        config: QuasarSvmConfig,
-    ) -> Result<Self, ProjectError> {
-        let path = resolve_program_path()?;
-        Self::from_program_path_with_config(program_id, path, config)
-    }
-
-    /// Load a program from an explicit artifact path.
-    pub fn from_program_path(
-        program_id: impl Into<Pubkey>,
-        path: impl AsRef<Path>,
-    ) -> Result<Self, ProjectError> {
-        Self::from_program_path_with_config(program_id, path, QuasarSvmConfig::default())
-    }
-
-    /// Load a program from an explicit artifact path and SVM configuration.
-    pub fn from_program_path_with_config(
-        program_id: impl Into<Pubkey>,
-        path: impl AsRef<Path>,
-        config: QuasarSvmConfig,
-    ) -> Result<Self, ProjectError> {
-        let path = path.as_ref().to_path_buf();
-        let elf = fs::read(&path).map_err(|source| ProjectError::ReadProgram {
-            path: path.clone(),
-            source,
-        })?;
-        let program_id = program_id.into();
-        let svm = QuasarSvm::new_with_config(config).with_program(&program_id, &elf);
-        Ok(Self {
-            svm,
-            program_id,
-            program_path: path,
-            fresh_addresses: 0,
-        })
+    /// ```rust,ignore
+    /// let mut q = QuasarTest::builder(other_program::ID)
+    ///     .crate_name("other-program")
+    ///     .config(QuasarSvmConfig::default())
+    ///     .build()?;
+    /// ```
+    pub fn builder(program_id: impl Into<Pubkey>) -> QuasarTestBuilder {
+        QuasarTestBuilder {
+            program_id: program_id.into(),
+            config: QuasarSvmConfig::default(),
+            program_path: None,
+            crate_name: None,
+        }
     }
 
     /// The program under test.
@@ -141,74 +97,31 @@ impl QuasarTest {
         self.svm
     }
 
-    /// Load an additional CPI target while retaining the project wrapper.
-    pub fn with_program(self, program_id: &Pubkey, elf: &[u8]) -> Self {
+    /// Load an additional program (a CPI target) into the world.
+    pub fn load_program(&mut self, program_id: &Pubkey, elf: &[u8]) {
         self.svm
             .add_program(program_id, &quasar_svm::loader_keys::LOADER_V3, elf);
-        self
     }
 
-    /// Load an additional CPI target with an explicit loader.
-    pub fn with_program_loader(self, program_id: &Pubkey, loader: &Pubkey, elf: &[u8]) -> Self {
-        self.svm.add_program(program_id, loader, elf);
-        self
-    }
-
-    /// Pre-populate an account while retaining the project wrapper.
-    pub fn with_account(mut self, account: Account) -> Self {
-        self.svm.set_account(account);
-        self
-    }
-
-    /// Set the clock slot while retaining the project wrapper.
-    pub fn with_slot(mut self, slot: u64) -> Self {
-        self.svm.sysvars.warp_to_slot(slot);
-        self
-    }
-
-    /// Set the transaction compute budget while retaining the project wrapper.
-    pub fn with_compute_budget(mut self, max_units: u64) -> Self {
-        self.svm.compute_budget.compute_unit_limit = max_units;
-        self
-    }
-
-    /// Airdrop lamports while retaining the project wrapper.
-    pub fn with_airdrop(mut self, address: &Pubkey, lamports: u64) -> Self {
-        self.svm.airdrop(address, lamports);
-        self
-    }
-
-    /// Create a rent-exempt account while retaining the project wrapper.
-    pub fn with_create_account(mut self, address: &Pubkey, space: usize, owner: &Pubkey) -> Self {
-        self.svm.create_account(address, space, owner);
-        self
-    }
-
-    /// Create a funded actor at a fresh address.
+    /// Register a funded wallet at a fresh address.
     ///
-    /// The default balance is [`DEFAULT_ACTOR_LAMPORTS`]. Use
-    /// [`Self::actor_with_lamports`] when the balance is part of the test.
-    pub fn actor(&mut self) -> Pubkey {
-        self.actor_with_lamports(DEFAULT_ACTOR_LAMPORTS)
+    /// The default balance is [`DEFAULT_WALLET_LAMPORTS`]. Use
+    /// [`Self::add_wallet_with_lamports`] when the balance is part of the
+    /// test.
+    pub fn add_wallet(&mut self) -> Pubkey {
+        self.add_wallet_with_lamports(DEFAULT_WALLET_LAMPORTS)
     }
 
-    /// Create several funded actors at fresh addresses.
+    /// Register several funded wallets at fresh addresses.
     ///
     /// Array destructuring keeps named multi-party scenarios compact:
-    /// `let [maker, taker] = q.actors();`.
-    pub fn actors<const N: usize>(&mut self) -> [Pubkey; N] {
-        std::array::from_fn(|_| self.actor())
+    /// `let [maker, taker] = q.add_wallets();`.
+    pub fn add_wallets<const N: usize>(&mut self) -> [Pubkey; N] {
+        std::array::from_fn(|_| self.add_wallet())
     }
 
-    /// Fund a chosen address with the default actor balance.
-    ///
-    /// Use this when deterministic addresses make a scenario easier to read.
-    pub fn actor_at(&mut self, address: Pubkey) -> Pubkey {
-        self.fund(address, DEFAULT_ACTOR_LAMPORTS)
-    }
-
-    /// Create a funded actor at a fresh address with an explicit balance.
-    pub fn actor_with_lamports(&mut self, lamports: u64) -> Pubkey {
+    /// Register a funded wallet at a fresh address with an explicit balance.
+    pub fn add_wallet_with_lamports(&mut self, lamports: u64) -> Pubkey {
         let address = self.fresh_address();
         self.fund(address, lamports)
     }
@@ -233,25 +146,20 @@ impl QuasarTest {
         address
     }
 
-    /// Add an empty system account for an instruction that initializes it.
-    pub fn empty(&mut self, address: Pubkey) -> Pubkey {
-        self.svm.set_account(fixtures::empty_account(address));
-        address
+    /// Register a six-decimal mint with zero supply at a fresh address.
+    pub fn add_mint(&mut self, authority: Pubkey) -> Pubkey {
+        self.add_mint_with_supply(authority, 0)
     }
 
-    /// Create a six-decimal mint with zero supply at a fresh address.
-    pub fn mint(&mut self, authority: Pubkey) -> Pubkey {
-        self.mint_with_supply(authority, 0)
-    }
-
-    /// Create a six-decimal mint with an explicit supply at a fresh address.
-    pub fn mint_with_supply(&mut self, authority: Pubkey, supply: u64) -> Pubkey {
+    /// Register a six-decimal mint with an explicit supply at a fresh
+    /// address.
+    pub fn add_mint_with_supply(&mut self, authority: Pubkey, supply: u64) -> Pubkey {
         let address = self.fresh_address();
-        self.mint_at(address, authority, supply, 6)
+        self.add_mint_at(address, authority, supply, 6)
     }
 
-    /// Create a mint at an explicit address and return that address.
-    pub fn mint_at(
+    /// Register a mint at an explicit address and return that address.
+    pub fn add_mint_at(
         &mut self,
         address: Pubkey,
         authority: Pubkey,
@@ -264,14 +172,14 @@ impl QuasarTest {
         address
     }
 
-    /// Create an SPL Token account at a fresh address.
-    pub fn token_account(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
+    /// Register a token account at a fresh address.
+    pub fn add_token_account(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
         let address = self.fresh_address();
-        self.token_account_at(address, owner, mint, amount)
+        self.add_token_account_at(address, owner, mint, amount)
     }
 
-    /// Create an SPL Token account at an explicit address.
-    pub fn token_account_at(
+    /// Register a token account at an explicit address.
+    pub fn add_token_account_at(
         &mut self,
         address: Pubkey,
         owner: Pubkey,
@@ -285,9 +193,10 @@ impl QuasarTest {
 
     /// Derive an associated token address without registering an account.
     ///
-    /// Use this for init targets: [`Self::ata`] would register an existing
-    /// account, which is exactly what an init instruction must not find.
-    pub fn ata_address(&self, owner: Pubkey, mint: Pubkey) -> Pubkey {
+    /// Use this for init targets and assertions: [`Self::add_ata`] would
+    /// register an existing account, which is exactly what an init
+    /// instruction must not find.
+    pub fn derive_ata(&self, owner: Pubkey, mint: Pubkey) -> Pubkey {
         Pubkey::find_program_address(
             &[
                 owner.as_ref(),
@@ -299,8 +208,8 @@ impl QuasarTest {
         .0
     }
 
-    /// Create an associated token account and return its derived address.
-    pub fn ata(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
+    /// Register an associated token account and return its derived address.
+    pub fn add_ata(&mut self, owner: Pubkey, mint: Pubkey, amount: u64) -> Pubkey {
         let account = fixtures::associated_token_account(owner, mint, amount);
         let address = account.address;
         self.svm.set_account(account);
@@ -314,14 +223,14 @@ impl QuasarTest {
     /// validates against:
     ///
     /// ```rust,ignore
-    /// let vault = q.pda(Vault::seeds(&maker));
+    /// let vault = q.derive_pda(Vault::seeds(&maker));
     /// ```
-    pub fn pda(&self, seeds: impl SeedSlices) -> Pubkey {
-        self.pda_with_bump(seeds).0
+    pub fn derive_pda(&self, seeds: impl SeedSlices) -> Pubkey {
+        self.derive_pda_with_bump(seeds).0
     }
 
     /// Derive the canonical PDA and bump for a seed set.
-    pub fn pda_with_bump(&self, seeds: impl SeedSlices) -> (Pubkey, u8) {
+    pub fn derive_pda_with_bump(&self, seeds: impl SeedSlices) -> (Pubkey, u8) {
         seeds.with_slices(|slices| Pubkey::find_program_address(slices, &self.program_id))
     }
 
@@ -387,35 +296,73 @@ impl QuasarTest {
         }
     }
 
+    /// An account's current lamport balance in this world.
+    pub fn lamports(&self, address: Pubkey) -> u64 {
+        self.world_account(address).lamports
+    }
+
+    /// A token account's current balance in this world.
+    pub fn tokens(&self, address: Pubkey) -> u64 {
+        use spl_token::{solana_program::program_pack::Pack, state::Account as TokenAccount};
+
+        let account = self.world_account(address);
+        TokenAccount::unpack(&account.data)
+            .unwrap_or_else(|error| {
+                panic!("could not decode {address} as an SPL Token account: {error}")
+            })
+            .amount
+    }
+
+    /// A mint's current supply in this world.
+    pub fn supply(&self, address: Pubkey) -> u64 {
+        use spl_token::{solana_program::program_pack::Pack, state::Mint};
+
+        let account = self.world_account(address);
+        Mint::unpack(&account.data)
+            .unwrap_or_else(|error| {
+                panic!("could not decode {address} as an SPL Token mint: {error}")
+            })
+            .supply
+    }
+
+    fn world_account(&self, address: Pubkey) -> Account {
+        self.svm
+            .get_account(&address)
+            .unwrap_or_else(|| panic!("no account at {address}"))
+    }
+
     /// Register a rent-exempt program account holding `state`.
     ///
-    /// The account gets `T`'s owner and discriminator, so a follow-up
-    /// [`Self::read`] (or the program itself) accepts it:
+    /// The account gets the owning type's discriminator and owner, so a
+    /// follow-up [`Self::read`] (or the program itself) accepts it:
     ///
     /// ```rust,ignore
-    /// q.write::<Vault>(vault, VaultData { authority: maker, balance: 500.into(), bump });
+    /// q.write(vault, VaultData { authority: maker, balance: 500.into(), bump });
     /// ```
-    pub fn write<T>(&mut self, address: Pubkey, state: T::Target) -> Pubkey
+    pub fn write<D>(&mut self, address: Pubkey, state: D) -> Pubkey
     where
-        T: Discriminator + Owner + Deref,
-        T::Target: ZcElem + Copy,
+        D: AccountData + ZcElem + Copy,
+        D::Wrapper: Discriminator + Owner,
     {
-        let disc = T::DISCRIMINATOR;
-        let size = core::mem::size_of::<T::Target>();
+        let disc = <D::Wrapper as Discriminator>::DISCRIMINATOR;
+        let size = core::mem::size_of::<D>();
         let mut data = vec![0u8; disc.len() + size];
         data[..disc.len()].copy_from_slice(disc);
-        // SAFETY: `T::Target` is `ZcElem` (`#[repr(C)]`, alignment 1, no
-        // padding), so its `size` bytes are initialized and the destination
-        // range was sized for them.
+        // SAFETY: `D` is `ZcElem` (`#[repr(C)]`, alignment 1, no padding),
+        // so its `size` bytes are initialized and the destination range was
+        // sized for them.
         unsafe {
             std::ptr::copy_nonoverlapping(
-                (&state as *const T::Target).cast::<u8>(),
+                (&state as *const D).cast::<u8>(),
                 data[disc.len()..].as_mut_ptr(),
                 size,
             );
         }
-        self.svm
-            .set_account(fixtures::program_account(address, T::OWNER, data));
+        self.svm.set_account(fixtures::program_account(
+            address,
+            <D::Wrapper as Owner>::OWNER,
+            data,
+        ));
         address
     }
 
@@ -423,8 +370,8 @@ impl QuasarTest {
     ///
     /// Writable instruction accounts missing from the world are registered as
     /// empty system accounts first, so freshly initialized accounts survive
-    /// into follow-up sends and [`Self::read`] without an explicit
-    /// [`Self::empty`] call.
+    /// into follow-up sends and [`Self::read`] without any setup.
+    #[must_use = "assert the outcome: .succeeds(), .fails_with(..), or inspect the result"]
     pub fn send(
         &mut self,
         instruction: impl Into<quasar_svm::Instruction>,
@@ -440,6 +387,7 @@ impl QuasarTest {
     /// This escape hatch is useful when the supplied account itself is the
     /// subject of a test. Successful execution commits those accounts to the
     /// world like every other transaction account.
+    #[must_use = "assert the outcome: .succeeds(), .fails_with(..), or inspect the result"]
     pub fn send_with(
         &mut self,
         instruction: impl Into<quasar_svm::Instruction>,
@@ -465,6 +413,7 @@ impl QuasarTest {
     }
 
     /// Simulate one instruction without committing its account changes.
+    #[must_use = "assert the outcome: .succeeds(), .fails_with(..), or inspect the result"]
     pub fn simulate(
         &mut self,
         instruction: impl Into<quasar_svm::Instruction>,
@@ -485,6 +434,57 @@ impl Deref for QuasarTest {
 impl DerefMut for QuasarTest {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.svm
+    }
+}
+
+/// World setup: which program artifact to load and how to configure the VM.
+///
+/// Created by [`QuasarTest::builder`].
+pub struct QuasarTestBuilder {
+    program_id: Pubkey,
+    config: QuasarSvmConfig,
+    program_path: Option<PathBuf>,
+    crate_name: Option<String>,
+}
+
+impl QuasarTestBuilder {
+    /// Base runtime configuration (bundled SPL programs, compute budget).
+    pub fn config(mut self, config: QuasarSvmConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Load an explicit program artifact instead of discovering one.
+    pub fn program_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.program_path = Some(path.into());
+        self
+    }
+
+    /// Prefer `target/deploy/{crate_name}.so` (with `-` mapped to `_`) during
+    /// discovery, so tests resolve their own program in a workspace that
+    /// builds several. `#[quasar_test]` passes `env!("CARGO_PKG_NAME")`.
+    pub fn crate_name(mut self, name: impl Into<String>) -> Self {
+        self.crate_name = Some(name.into());
+        self
+    }
+
+    /// Load the program and start the world.
+    pub fn build(self) -> Result<QuasarTest, SetupError> {
+        let path = match self.program_path {
+            Some(path) => path,
+            None => resolve_program_path(self.crate_name.as_deref())?,
+        };
+        let elf = fs::read(&path).map_err(|source| SetupError::ReadProgram {
+            path: path.clone(),
+            source,
+        })?;
+        let svm = QuasarSvm::new_with_config(self.config).with_program(&self.program_id, &elf);
+        Ok(QuasarTest {
+            svm,
+            program_id: self.program_id,
+            program_path: path,
+            fresh_addresses: 0,
+        })
     }
 }
 
@@ -527,25 +527,17 @@ where
     }
 }
 
-/// Resolve the compiled program path used by [`QuasarTest`].
-pub fn resolve_program_path() -> Result<PathBuf, ProjectError> {
+/// Resolve the compiled program path: the `quasar test` override, then
+/// discovery from the current directory.
+fn resolve_program_path(crate_name: Option<&str>) -> Result<PathBuf, SetupError> {
     if let Some(path) = configured_program_path()? {
         return Ok(path);
     }
-    let current_dir = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
-    resolve_program_path_from(&current_dir)
+    let current_dir = env::current_dir().map_err(SetupError::CurrentDirectory)?;
+    resolve_program_path_from_named(&current_dir, crate_name)
 }
 
-/// Resolve a crate's compiled program path by name.
-pub fn resolve_program_path_named(crate_name: &str) -> Result<PathBuf, ProjectError> {
-    if let Some(path) = configured_program_path()? {
-        return Ok(path);
-    }
-    let current_dir = env::current_dir().map_err(ProjectError::CurrentDirectory)?;
-    resolve_program_path_from_named(&current_dir, Some(crate_name))
-}
-
-fn configured_program_path() -> Result<Option<PathBuf>, ProjectError> {
+fn configured_program_path() -> Result<Option<PathBuf>, SetupError> {
     let Some(path) = env::var_os(PROGRAM_PATH_ENV) else {
         return Ok(None);
     };
@@ -553,17 +545,13 @@ fn configured_program_path() -> Result<Option<PathBuf>, ProjectError> {
     if path.is_file() {
         return Ok(Some(path));
     }
-    Err(ProjectError::ConfiguredProgramMissing { path })
-}
-
-fn resolve_program_path_from(start: &Path) -> Result<PathBuf, ProjectError> {
-    resolve_program_path_from_named(start, None)
+    Err(SetupError::ConfiguredProgramMissing { path })
 }
 
 fn resolve_program_path_from_named(
     start: &Path,
     crate_name: Option<&str>,
-) -> Result<PathBuf, ProjectError> {
+) -> Result<PathBuf, SetupError> {
     let artifact = crate_name.map(|name| format!("{}.so", name.replace('-', "_")));
     let mut checked = Vec::new();
     for ancestor in start.ancestors() {
@@ -588,11 +576,11 @@ fn resolve_program_path_from_named(
             return Ok(programs.remove(0));
         }
         if programs.len() > 1 {
-            return Err(ProjectError::AmbiguousPrograms { deploy, programs });
+            return Err(SetupError::AmbiguousPrograms { deploy, programs });
         }
     }
 
-    Err(ProjectError::ProgramNotFound {
+    Err(SetupError::ProgramNotFound {
         start: start.to_path_buf(),
         checked,
     })
@@ -601,7 +589,7 @@ fn resolve_program_path_from_named(
 /// Failure to locate or load the current project's compiled program.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum ProjectError {
+pub enum SetupError {
     /// The path supplied by `quasar test` no longer exists.
     ConfiguredProgramMissing { path: PathBuf },
     /// The current working directory could not be read.
@@ -623,7 +611,7 @@ pub enum ProjectError {
     },
 }
 
-impl fmt::Display for ProjectError {
+impl fmt::Display for SetupError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ConfiguredProgramMissing { path } => write!(
@@ -675,7 +663,7 @@ impl fmt::Display for ProjectError {
     }
 }
 
-impl Error for ProjectError {
+impl Error for SetupError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::CurrentDirectory(source) | Self::ReadProgram { source, .. } => Some(source),
@@ -796,6 +784,9 @@ impl<T: Into<quasar_svm::Instruction>> InstructionExt for T {
 }
 
 /// Assertions layered on [`quasar_svm::ExecutionResult`].
+///
+/// Asserting methods chain (`.succeeds().has_tokens(vault, 10)`); the noun
+/// forms (`lamports`, `tokens`, `supply`) return the resulting values.
 pub trait ExecutionResultExt {
     /// Assert success and keep the result available for chained expectations.
     fn succeeds(&self) -> &Self;
@@ -804,6 +795,10 @@ pub trait ExecutionResultExt {
     fn fails_with<E>(&self, expected: E) -> &Self
     where
         E: Into<u32>;
+
+    /// Assert a non-custom [`ProgramError`] and keep the result available for
+    /// chaining.
+    fn fails(&self, expected: ProgramError) -> &Self;
 
     /// Assert a compute-unit ceiling and keep the result available for
     /// chaining.
@@ -818,34 +813,18 @@ pub trait ExecutionResultExt {
     /// Assert a mint supply and keep the result available for chaining.
     fn has_supply(&self, address: Pubkey, expected: u64) -> &Self;
 
-    /// Assert that an account has been fully closed.
+    /// Assert that an account has been fully closed: zero lamports, no data,
+    /// system-owned.
     fn is_closed(&self, address: Pubkey) -> &Self;
 
-    /// Assert a program-specific error using a generated client error enum.
-    fn assert_custom_error<E>(&self, expected: E)
-    where
-        E: Into<u32>;
-
-    /// Assert that execution consumed strictly fewer than `limit` units.
-    fn assert_compute_units_below(&self, limit: u64);
-
-    /// Return an account's resulting lamport balance.
+    /// An account's resulting lamport balance.
     fn lamports(&self, address: &Pubkey) -> u64;
 
-    /// Return an SPL Token account's resulting raw token balance.
-    fn token_balance(&self, address: &Pubkey) -> u64;
+    /// A token account's resulting balance.
+    fn tokens(&self, address: &Pubkey) -> u64;
 
-    /// Return an SPL Token mint's resulting supply.
-    fn mint_supply(&self, address: &Pubkey) -> u64;
-
-    /// Assert an account's resulting lamport balance.
-    fn assert_lamports(&self, address: &Pubkey, expected: u64);
-
-    /// Assert an SPL Token account's resulting raw token balance.
-    fn assert_token_balance(&self, address: &Pubkey, expected: u64);
-
-    /// Assert an SPL Token mint's resulting supply.
-    fn assert_mint_supply(&self, address: &Pubkey, expected: u64);
+    /// A mint's resulting supply.
+    fn supply(&self, address: &Pubkey) -> u64;
 }
 
 impl ExecutionResultExt for quasar_svm::ExecutionResult {
@@ -858,27 +837,48 @@ impl ExecutionResultExt for quasar_svm::ExecutionResult {
     where
         E: Into<u32>,
     {
-        self.assert_custom_error(expected);
+        self.assert_error(quasar_svm::ProgramError::Custom(expected.into()));
+        self
+    }
+
+    fn fails(&self, expected: ProgramError) -> &Self {
+        self.assert_error(expected);
         self
     }
 
     fn cu_below(&self, limit: u64) -> &Self {
-        self.assert_compute_units_below(limit);
+        assert!(
+            self.compute_units_consumed < limit,
+            "expected fewer than {limit} compute units, consumed {}",
+            self.compute_units_consumed
+        );
         self
     }
 
     fn has_lamports(&self, address: Pubkey, expected: u64) -> &Self {
-        self.assert_lamports(&address, expected);
+        assert_eq!(
+            self.lamports(&address),
+            expected,
+            "unexpected lamport balance for {address}"
+        );
         self
     }
 
     fn has_tokens(&self, address: Pubkey, expected: u64) -> &Self {
-        self.assert_token_balance(&address, expected);
+        assert_eq!(
+            self.tokens(&address),
+            expected,
+            "unexpected token balance for {address}"
+        );
         self
     }
 
     fn has_supply(&self, address: Pubkey, expected: u64) -> &Self {
-        self.assert_mint_supply(&address, expected);
+        assert_eq!(
+            self.supply(&address),
+            expected,
+            "unexpected mint supply for {address}"
+        );
         self
     }
 
@@ -900,34 +900,11 @@ impl ExecutionResultExt for quasar_svm::ExecutionResult {
         self
     }
 
-    fn assert_custom_error<E>(&self, expected: E)
-    where
-        E: Into<u32>,
-    {
-        self.assert_error(quasar_svm::ProgramError::Custom(expected.into()));
-    }
-
-    fn assert_compute_units_below(&self, limit: u64) {
-        assert!(
-            self.compute_units_consumed < limit,
-            "expected fewer than {limit} compute units, consumed {}",
-            self.compute_units_consumed
-        );
-    }
-
-    fn assert_lamports(&self, address: &Pubkey, expected: u64) {
-        assert_eq!(
-            self.lamports(address),
-            expected,
-            "unexpected lamport balance for {address}"
-        );
-    }
-
     fn lamports(&self, address: &Pubkey) -> u64 {
         result_account(self, address).lamports
     }
 
-    fn token_balance(&self, address: &Pubkey) -> u64 {
+    fn tokens(&self, address: &Pubkey) -> u64 {
         use spl_token::{solana_program::program_pack::Pack, state::Account as TokenAccount};
 
         let account = result_account(self, address);
@@ -937,7 +914,7 @@ impl ExecutionResultExt for quasar_svm::ExecutionResult {
         token_account.amount
     }
 
-    fn mint_supply(&self, address: &Pubkey) -> u64 {
+    fn supply(&self, address: &Pubkey) -> u64 {
         use spl_token::{solana_program::program_pack::Pack, state::Mint};
 
         let account = result_account(self, address);
@@ -945,22 +922,6 @@ impl ExecutionResultExt for quasar_svm::ExecutionResult {
             panic!("could not decode {address} as an SPL Token mint: {error}")
         });
         mint.supply
-    }
-
-    fn assert_token_balance(&self, address: &Pubkey, expected: u64) {
-        assert_eq!(
-            self.token_balance(address),
-            expected,
-            "unexpected token balance for {address}"
-        );
-    }
-
-    fn assert_mint_supply(&self, address: &Pubkey, expected: u64) {
-        assert_eq!(
-            self.mint_supply(address),
-            expected,
-            "unexpected mint supply for {address}"
-        );
     }
 }
 
@@ -989,7 +950,7 @@ pub use quasar_svm;
 #[cfg(test)]
 mod tests {
     use {
-        super::{fixtures, resolve_program_path_from, ExecutionResultExt, ProjectError},
+        super::{fixtures, resolve_program_path_from_named, ExecutionResultExt, SetupError},
         quasar_svm::{ExecutionResult, ExecutionTrace, InstructionError, Pubkey},
         std::{fs, path::PathBuf},
     };
@@ -1012,7 +973,7 @@ mod tests {
         fs::write(deploy.join("example.so"), b"elf").unwrap();
 
         assert_eq!(
-            resolve_program_path_from(&nested).unwrap(),
+            resolve_program_path_from_named(&nested, None).unwrap(),
             deploy.join("example.so")
         );
 
@@ -1044,8 +1005,8 @@ mod tests {
         fs::write(deploy.join("two.so"), b"elf").unwrap();
 
         assert!(matches!(
-            resolve_program_path_from(&root),
-            Err(ProjectError::AmbiguousPrograms { .. })
+            resolve_program_path_from_named(&root, None),
+            Err(SetupError::AmbiguousPrograms { .. })
         ));
 
         fs::remove_dir_all(root).unwrap();

--- a/tests/programs/test-misc/src/dx_tests.rs
+++ b/tests/programs/test-misc/src/dx_tests.rs
@@ -14,8 +14,8 @@ use {
 
 #[quasar_test]
 fn initialize_stores_typed_state(q: &mut QuasarTest) {
-    let payer = q.actor();
-    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&payer));
+    let payer = q.add_wallet();
+    let (account, bump) = q.derive_pda_with_bump(SimpleAccount::seeds(&payer));
 
     q.send(InitializeInstruction { payer, value: 42 })
         .succeeds();
@@ -28,9 +28,9 @@ fn initialize_stores_typed_state(q: &mut QuasarTest) {
 
 #[quasar_test]
 fn close_returns_the_account_to_the_system(q: &mut QuasarTest) {
-    let authority = q.actor();
-    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&authority));
-    q.write::<SimpleAccount>(
+    let authority = q.add_wallet();
+    let (account, bump) = q.derive_pda_with_bump(SimpleAccount::seeds(&authority));
+    q.write(
         account,
         SimpleAccountData {
             authority,
@@ -46,9 +46,9 @@ fn close_returns_the_account_to_the_system(q: &mut QuasarTest) {
 
 #[quasar_test]
 fn close_rejects_a_foreign_authority(q: &mut QuasarTest) {
-    let [owner, intruder] = q.actors();
-    let (account, bump) = q.pda_with_bump(SimpleAccount::seeds(&owner));
-    q.write::<SimpleAccount>(
+    let [owner, intruder] = q.add_wallets();
+    let (account, bump) = q.derive_pda_with_bump(SimpleAccount::seeds(&owner));
+    q.write(
         account,
         SimpleAccountData {
             authority: owner,
@@ -59,7 +59,7 @@ fn close_rejects_a_foreign_authority(q: &mut QuasarTest) {
 
     // The client derives the PDA from the passed authority; swapping in the
     // owner's account is the mismatch under test.
-    let intruder_pda = q.pda(SimpleAccount::seeds(&intruder));
+    let intruder_pda = q.derive_pda(SimpleAccount::seeds(&intruder));
     q.send(
         CloseAccountInstruction {
             authority: intruder,


### PR DESCRIPTION
Applies a written API standard (new `testing/API.md`) to the quasar-test surface: every world-facing method leads with its action.

- **Register**: `add_wallet(s)` / `add_wallet_with_lamports`, `add_mint(_with_supply/_at)`, `add_token_account(_at)`, `add_ata`, `fund`, `write`, `load_program`. Deleted: the `actor` family, all six `with_*` wrappers (deref to QuasarSvm covers them), and `empty` (it was `fund(addr, 0)` wearing a second name).
- **Derive**: `derive_pda` / `derive_pda_with_bump` / `derive_ata`, `fresh_address` — address computation always names the action.
- **Read**: `read::<T>`, plus `lamports` / `tokens` / `supply` on the world and on results, rhyming with the `has_` asserts.
- **Construction**: 8 entry points → `new` / `try_new` / `builder(id).config(..).program_path(..).crate_name(..)`; `ProjectError` → `SetupError`; resolution private.
- **Execution**: `send`/`send_with`/`simulate` are `#[must_use]` — an executed-but-unasserted instruction no longer compiles (the API enforcing TESTING.md's no-silent-tests rule).
- **Results**: no `assert_*` doubles; `fails(ProgramError)` beside `fails_with(code)`.
- `write(addr, VaultData { .. })` infers the wrapper via the new `AccountData` link trait — a call names its type once.

Verification: workspace tests green, suite 554/554, in-repo escrow 9/9 with byte-identical tracked CU (baseline addresses pinned via `fund` after `actor_at`'s deletion), cli 71/71, snapshots + proc-macro + public-API baselines re-blessed, clippy clean, all policy gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)