### PR TITLE
chore: remove compiler builtins license remnants

### DIFF
--- a/solana-compiler-builtins/LICENSE-APACHE
+++ b/solana-compiler-builtins/LICENSE-APACHE
@@ -1,1 +1,0 @@
-../LICENSE-APACHE

--- a/solana-compiler-builtins/LICENSE-MIT
+++ b/solana-compiler-builtins/LICENSE-MIT
@@ -1,1 +1,0 @@
-../LICENSE-MIT


### PR DESCRIPTION
The compiler builtins crate was folded into quasar-lang in #482, but its two tracked license symlinks survived and kept the old directory visible. Remove those final remnants. Git tracked-file audit confirms no solana-compiler-builtins path remains.