### PR TITLE
test: extend optional mut account coverage

### DIFF
--- a/lang/tests/miri.rs
+++ b/lang/tests/miri.rs
@@ -1723,6 +1723,102 @@ fn parse_dup_rejects_duplicate_without_dup_flag_even_readonly() {
 }
 
 #[test]
+fn parse_dup_of_none_sentinel_allowed_for_optional() {
+    // Two optional fields both passed as the None sentinel (program_id): the
+    // SVM dedups the second into a dup entry. The dup must parse (resolving
+    // to None downstream), not fail with AccountBorrowFailed.
+    let program_id = Address::new_from_array([9; 32]);
+    let mut buf = MultiAccountBuffer::new(&[
+        MultiAccountEntry::Full {
+            address: [9; 32],
+            owner: [2; 32],
+            lamports: 10,
+            data_len: 0,
+            data: None,
+            is_signer: false,
+            is_writable: false,
+        },
+        MultiAccountEntry::Duplicate { original_index: 0 },
+    ]);
+    let mut views = MaybeUninit::<[AccountView; 2]>::uninit();
+    let base = views.as_mut_ptr() as *mut AccountView;
+
+    let optional_mut_flags = ParseFlags {
+        expected: quasar_lang::__internal::NODUP_MUT,
+        mask: 0x00FF_FFFF,
+        flag_mask: 0x00FF_0000,
+        is_optional: true,
+        is_ref_mut: true,
+        allow_dup: false,
+    };
+
+    let first = unsafe {
+        quasar_lang::__internal::parse_account_dup(
+            buf.as_mut_ptr(),
+            base,
+            0,
+            &program_id,
+            optional_mut_flags,
+        )
+        .unwrap()
+    };
+    unsafe {
+        quasar_lang::__internal::parse_account_dup(first, base, 1, &program_id, optional_mut_flags)
+            .unwrap();
+    }
+
+    let parsed = unsafe { views.assume_init() };
+    assert_eq!(parsed[1].address(), &program_id);
+}
+
+#[test]
+fn parse_dup_of_real_account_still_rejected_for_optional() {
+    // A present (non-sentinel) account duplicated across two optional fields
+    // is still aliasing and must be rejected without #[account(dup)].
+    let program_id = Address::new_from_array([9; 32]);
+    let mut buf = MultiAccountBuffer::new(&[
+        MultiAccountEntry::Full {
+            address: [1; 32],
+            owner: [2; 32],
+            lamports: 10,
+            data_len: 0,
+            data: None,
+            is_signer: false,
+            is_writable: true,
+        },
+        MultiAccountEntry::Duplicate { original_index: 0 },
+    ]);
+    let mut views = MaybeUninit::<[AccountView; 2]>::uninit();
+    let base = views.as_mut_ptr() as *mut AccountView;
+
+    let optional_mut_flags = ParseFlags {
+        expected: quasar_lang::__internal::NODUP_MUT,
+        mask: 0x00FF_FFFF,
+        flag_mask: 0x00FF_0000,
+        is_optional: true,
+        is_ref_mut: true,
+        allow_dup: false,
+    };
+
+    let first = unsafe {
+        quasar_lang::__internal::parse_account_dup(
+            buf.as_mut_ptr(),
+            base,
+            0,
+            &program_id,
+            optional_mut_flags,
+        )
+        .unwrap()
+    };
+    let err = unsafe {
+        quasar_lang::__internal::parse_account_dup(first, base, 1, &program_id, optional_mut_flags)
+            .unwrap_err()
+    };
+
+    assert_eq!(err, ProgramError::AccountBorrowFailed);
+}
+
+#[test]
 fn uninit_sysvar_maybeuninit_write_bytes_assume_init() {
     use quasar_lang::sysvars::rent::Rent;
 

--- a/tests/suite/src/optional_accounts.rs
+++ b/tests/suite/src/optional_accounts.rs
@@ -178,3 +178,99 @@ fn multiple_mut_optional_none_sentinels() {
         result.raw_result
     );
 }
+
+#[test]
+fn multiple_mut_optional_all_present() {
+    let mut svm = svm_misc();
+    let authority = Pubkey::new_unique();
+    let first = Pubkey::new_unique();
+    let second = Pubkey::new_unique();
+    let third = Pubkey::new_unique();
+
+    let ix: Instruction = OptionalMutAccountsInstruction {
+        authority,
+        first,
+        second,
+        third,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            signer_account(authority),
+            simple_account(first, authority, 1, 0),
+            simple_account(second, authority, 2, 0),
+            simple_account(third, authority, 3, 0),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "all mut optionals present: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
+fn multiple_mut_optional_mixed() {
+    // None sentinel sandwiched between two present mut optionals: index
+    // accounting must not drift across the skipped slot.
+    let mut svm = svm_misc();
+    let authority = Pubkey::new_unique();
+    let first = Pubkey::new_unique();
+    let third = Pubkey::new_unique();
+    let sentinel = quasar_test_misc::ID;
+
+    let ix: Instruction = OptionalMutAccountsInstruction {
+        authority,
+        first,
+        second: sentinel,
+        third,
+    }
+    .into();
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            signer_account(authority),
+            simple_account(first, authority, 1, 0),
+            simple_account(third, authority, 3, 0),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "mixed present/sentinel mut optionals: {:?}",
+        result.raw_result
+    );
+}
+
+#[test]
+fn mut_optional_present_not_writable() {
+    // The writable check is skipped only for the None sentinel; a PRESENT
+    // optional marked non-writable must still be rejected.
+    let mut svm = svm_misc();
+    let authority = Pubkey::new_unique();
+    let first = Pubkey::new_unique();
+    let sentinel = quasar_test_misc::ID;
+
+    let mut ix: Instruction = OptionalMutAccountsInstruction {
+        authority,
+        first,
+        second: sentinel,
+        third: sentinel,
+    }
+    .into();
+    ix.accounts[1].is_writable = false; // demote the present mut optional
+
+    let result = svm.process_instruction(
+        &ix,
+        &[
+            signer_account(authority),
+            simple_account(first, authority, 1, 0),
+        ],
+    );
+    assert!(
+        result.is_err(),
+        "present mut optional without writable flag must fail"
+    );
+}


### PR DESCRIPTION
Upstream fix 93d9800f (#226) allows dup entries aliasing the None sentinel on optional accounts but only tests the all-None case. This adds the missing coverage:

- **Suite**: `multiple_mut_optional_all_present`, `multiple_mut_optional_mixed` (None sentinel sandwiched between two present mut optionals — index accounting must not drift across the skipped slot), and `mut_optional_present_not_writable` (the writable check must still apply when the optional is present).
- **Miri** (Tree Borrows + symbolic alignment): `parse_dup_of_none_sentinel_allowed_for_optional` and `parse_dup_of_real_account_still_rejected_for_optional`, exercising both sides of the dup branch in `parse_account_dup`.

Test-only change: suite 622/622, Miri 104/74/13, tracked CU benchmarks unaffected.