### PR TITLE
fix: ensure Address types in instruction args pass account validation

### DIFF
--- a/derive/src/seed_param.rs
+++ b/derive/src/seed_param.rs
@@ -19,7 +19,7 @@ impl SeedType {
     /// The field storage type in generated SeedSet structs.
     pub(crate) fn field_type(&self) -> proc_macro2::TokenStream {
         match self {
-            SeedType::Address => quote! { &'__quasar_seed quasar_lang::prelude::Address },
+            SeedType::Address => quote! { quasar_lang::prelude::Address },
             SeedType::U8 => quote! { [u8; 1] },
             SeedType::U16 => quote! { [u8; 2] },
             SeedType::U32 => quote! { [u8; 4] },
@@ -31,7 +31,9 @@ impl SeedType {
     /// The public constructor parameter type for a typed seed.
     pub(crate) fn param_type(&self) -> proc_macro2::TokenStream {
         match self {
-            SeedType::Address => quote! { &'__quasar_seed quasar_lang::prelude::Address },
+            SeedType::Address => quote! {
+                impl core::borrow::Borrow<quasar_lang::prelude::Address>
+            },
             SeedType::U8 => quote! { u8 },
             SeedType::U16 => quote! { u16 },
             SeedType::U32 => quote! { u32 },
@@ -43,7 +45,8 @@ impl SeedType {
     /// Expression to store the constructor parameter in the SeedSet field.
     pub(crate) fn to_stored_expr(&self, param: &Ident) -> proc_macro2::TokenStream {
         match self {
-            SeedType::Address | SeedType::Bytes(_) => quote! { #param },
+            SeedType::Address => quote! { *core::borrow::Borrow::borrow(&#param) },
+            SeedType::Bytes(_) => quote! { #param },
             SeedType::U8 => quote! { [#param] },
             SeedType::U16 | SeedType::U32 | SeedType::U64 => quote! { #param.to_le_bytes() },
         }

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -202,20 +202,8 @@ pub(crate) fn generate_seeds_impl(
         .map(|expr| quote! { quasar_lang::cpi::Seed::from(#expr) })
         .collect();
 
-    let has_address_param = seeds_attr
-        .params
-        .iter()
-        .any(|param| matches!(param.ty, SeedType::Address));
-    let phantom_field = if has_address_param {
-        quote! {}
-    } else {
-        quote! { _lt: core::marker::PhantomData<&'__quasar_seed ()>, }
-    };
-    let phantom_init = if has_address_param {
-        quote! {}
-    } else {
-        quote! { _lt: core::marker::PhantomData, }
-    };
+    let phantom_field = quote! { _lt: core::marker::PhantomData<&'__quasar_seed ()>, };
+    let phantom_init = quote! { _lt: core::marker::PhantomData, };
 
     quote! {
         impl #impl_generics quasar_lang::traits::HasSeeds for #name #ty_generics #where_clause {

--- a/derive/tests/compile_pass/instruction_address_validation.rs
+++ b/derive/tests/compile_pass/instruction_address_validation.rs
@@ -1,0 +1,25 @@
+#![allow(unexpected_cfgs)]
+extern crate alloc;
+
+use quasar_derive::Accounts;
+use quasar_lang::prelude::*;
+
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+#[seeds(b"vault", authority: Address)]
+pub struct Vault {
+    pub authority: Address,
+}
+
+#[derive(Accounts)]
+#[instruction(authority: Address)]
+pub struct ValidateAddressArg {
+    #[account(
+        address = Vault::seeds(authority),
+        constraints(vault.authority == authority),
+    )]
+    pub vault: Account<Vault>,
+}
+
+fn main() {}


### PR DESCRIPTION
Got a bug when passing instruction args into account validation. This PR resolves that issue. 

I wanted to do the following:

```rust
#[derive(Accounts)]
#[instruction(
    mint_x: Address, 
    mint_y: Address
)]
pub struct Initialize {
    // ...
    #[account(
        init, 
        payer = payer, 
        address = Config::seeds(payer.address(), mint_x, mint_y) 
    )]
    pub config: Config, 
}
```

but was being asked to use `&mint_x`, but that returns an out of scope error. The other proposed solution was to use 

```rust
#[derive(Accounts)]
#[instruction(
    mint_x: [u8; 32], 
    mint_y: [u8; 32]
)]
```

but I feel like the ergonomics aren't that great for the user if they mean to use an `Address`. 

This PR fixes this issue. 

