### PR TITLE
refactor(derive): trim the generated code, and size its inlining to what it emits

### DIFF
--- a/derive/src/account/dynamic.rs
+++ b/derive/src/account/dynamic.rs
@@ -241,9 +241,7 @@ pub(super) fn emit_dyn_writer(
             pub fn commit(&mut self) -> Result<(), #krate::__solana_program_error::ProgramError> {
                 #(#binding_stmts)*
 
-                let __new_total = #disc_len
-                    + <#zc_mod::__Schema as #krate::ZeroPodCompact>::HEADER_SIZE
-                    #(#size_terms)*;
+                let __new_total = #name::MIN_SPACE #(#size_terms)*;
                 let __old_total = self.__view.data_len();
                 if __new_total != __old_total {
                     #krate::accounts::account::realloc_account_raw(
@@ -395,9 +393,7 @@ pub(super) fn emit_compact_mut(
         impl<'a> #guard_name<'a> {
             pub fn save(&mut self) -> Result<(), #krate::__solana_program_error::ProgramError> {
                 let __tail_size: usize = 0 #(#save_size_terms)*;
-                let __new_total = #disc_len
-                    + <#zc_mod::__Schema as #krate::ZeroPodCompact>::HEADER_SIZE
-                    + __tail_size;
+                let __new_total = #name::MIN_SPACE + __tail_size;
 
                 let __old_total = self.__view.data_len();
                 if __new_total != __old_total {

--- a/derive/src/account/dynamic.rs
+++ b/derive/src/account/dynamic.rs
@@ -346,6 +346,11 @@ pub(super) fn emit_compact_mut(
                 .unwrap_or_else(|| ice!("field must be named"))
         })
         .collect();
+    let field_tys: Vec<proc_macro2::TokenStream> = pieces
+        .dyn_fields
+        .iter()
+        .map(|(_, pd)| compact_mut_ty(pd))
+        .collect();
     let save_size_terms: Vec<proc_macro2::TokenStream> = pieces
         .dyn_fields
         .iter()
@@ -418,18 +423,7 @@ pub(super) fn emit_compact_mut(
             }
 
             pub fn reload(&mut self) {
-                let (#(#field_names,)*) = {
-                    // SAFETY: the guard has exclusive access to the account
-                    // wrapper, so no checked borrow can be active here.
-                    let __data = unsafe { self.__view.borrow_unchecked() };
-                    // SAFETY: this guard is only built after AccountLoad
-                    // compact validation, and reload preserves that layout.
-                    let __r = unsafe {
-                        #zc_mod::__SchemaRef::new_unchecked(__data.get_unchecked(#disc_len..))
-                    };
-                    #(#load_stmts)*
-                    (#(#field_names,)*)
-                };
+                let (#(#field_names,)*) = #name::__snapshot_dynamic(self.__view);
                 #(self.#field_names = #field_names;)*
             }
         }
@@ -443,23 +437,31 @@ pub(super) fn emit_compact_mut(
         }
 
         impl #name {
+            /// Read every dynamic field out of the compact tail into owned
+            /// caches. Shared by `as_mut` and the guard's `reload`, which each
+            /// need the identical read.
+            #[inline(always)]
+            fn __snapshot_dynamic(
+                __view: &#krate::__internal::AccountView,
+            ) -> (#(#field_tys,)*) {
+                // SAFETY: every caller holds exclusive access to the account
+                // wrapper, so no checked borrow can be active here.
+                let __data = unsafe { __view.borrow_unchecked() };
+                // SAFETY: the compact layout was validated before this wrapper
+                // became available, and every write path preserves it.
+                let __r = unsafe {
+                    #zc_mod::__SchemaRef::new_unchecked(__data.get_unchecked(#disc_len..))
+                };
+                #(#load_stmts)*
+                (#(#field_names,)*)
+            }
+
             #[inline(always)]
             pub fn as_mut<'a>(
                 &'a mut self,
                 payer: &'a #krate::__internal::AccountView,
             ) -> #guard_name<'a> {
-                let (#(#field_names,)*) = {
-                    // SAFETY: `&'a mut self` gives the guard exclusive access to
-                    // the account wrapper while it loads cached fields.
-                    let __data = unsafe { self.__view.borrow_unchecked() };
-                    // SAFETY: dynamic account construction validated the compact
-                    // layout before this wrapper became available.
-                    let __r = unsafe {
-                        #zc_mod::__SchemaRef::new_unchecked(__data.get_unchecked(#disc_len..))
-                    };
-                    #(#load_stmts)*
-                    (#(#field_names,)*)
-                };
+                let (#(#field_names,)*) = Self::__snapshot_dynamic(&self.__view);
                 // SAFETY: `self.__view` is the transparent account backing store for this
                 // wrapper. Reborrowing it as `&mut AccountView` is sound here because the
                 // guard exclusively owns `&'a mut self` for its full lifetime and does not
@@ -579,10 +581,17 @@ fn writer_compact_set_stmt(name: &syn::Ident) -> proc_macro2::TokenStream {
 }
 
 fn compact_mut_field(name: &syn::Ident, dyn_field: &PodDynField) -> proc_macro2::TokenStream {
+    let ty = compact_mut_ty(dyn_field);
+    quote! { pub #name: #ty }
+}
+
+/// The owned `PodString`/`PodVec` type a dynamic field is cached as, named on
+/// its own so the guard's fields and the snapshot's return tuple stay in step.
+fn compact_mut_ty(dyn_field: &PodDynField) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     match dyn_field {
         PodDynField::Str { max, prefix_bytes } => quote! {
-            pub #name: #krate::pod::PodString<#max, #prefix_bytes>
+            #krate::pod::PodString<#max, #prefix_bytes>
         },
         PodDynField::Vec {
             elem,
@@ -591,7 +600,7 @@ fn compact_mut_field(name: &syn::Ident, dyn_field: &PodDynField) -> proc_macro2:
         } => {
             let mapped = map_to_pod_type(elem);
             quote! {
-                pub #name: #krate::pod::PodVec<#mapped, #max, #prefix_bytes>
+                #krate::pod::PodVec<#mapped, #max, #prefix_bytes>
             }
         }
     }

--- a/derive/src/account/methods.rs
+++ b/derive/src/account/methods.rs
@@ -90,6 +90,18 @@ pub(super) fn emit_set_inner_impl(spec: SetInnerSpec<'_>) -> proc_macro2::TokenS
                 )
             })
             .collect();
+        // A schema whose fields are all dynamic has no fixed header to write, so
+        // materializing the header pointer would bind a value nothing reads.
+        let zc_header_block = if zc_header_stmts.is_empty() {
+            quote! {}
+        } else {
+            quote! {
+                // SAFETY: after the realloc above, the compact header starts
+                // immediately after the discriminator.
+                let __zc = unsafe { &mut *(__ptr.add(#disc_len) as *mut #zc_path) };
+                #(#zc_header_stmts)*
+            }
+        };
         let compact_set_stmts: Vec<proc_macro2::TokenStream> = field_infos
             .iter()
             .filter_map(|fi| {
@@ -151,10 +163,7 @@ pub(super) fn emit_set_inner_impl(spec: SetInnerSpec<'_>) -> proc_macro2::TokenS
                     }
 
                     let __ptr = __view.data_mut_ptr();
-                    // SAFETY: after the realloc above, the compact header starts
-                    // immediately after the discriminator.
-                    let __zc = unsafe { &mut *(__ptr.add(#disc_len) as *mut #zc_path) };
-                    #(#zc_header_stmts)*
+                    #zc_header_block
 
                     // SAFETY: the slice spans the full compact schema region.
                     let __compact_data = unsafe {

--- a/derive/src/account/traits.rs
+++ b/derive/src/account/traits.rs
@@ -74,8 +74,6 @@ pub(super) fn emit_dynamic_account_load(spec: AccountLoadSpec<'_>) -> proc_macro
 
     quote! {
         impl #name {
-            /// The discriminator and compact-layout checks, over data borrowed
-            /// by whichever of the two entry points below the caller reached.
             #[inline(always)]
             fn __quasar_check_data(__data: &[u8]) -> Result<(), #krate::__solana_program_error::ProgramError> {
                 #validate

--- a/derive/src/account/traits.rs
+++ b/derive/src/account/traits.rs
@@ -70,47 +70,42 @@ pub(super) fn emit_dynamic_account_load(spec: AccountLoadSpec<'_>) -> proc_macro
         zc_mod,
     } = spec;
 
-    let body = emit_account_load_check_body(false, disc_len, disc_indices, disc_bytes, zc_mod);
-    let checked_body =
-        emit_account_load_check_body(true, disc_len, disc_indices, disc_bytes, zc_mod);
+    let validate = emit_account_load_validate(disc_len, disc_indices, disc_bytes, zc_mod);
 
     quote! {
+        impl #name {
+            /// The discriminator and compact-layout checks, over data borrowed
+            /// by whichever of the two entry points below the caller reached.
+            #[inline(always)]
+            fn __quasar_check_data(__data: &[u8]) -> Result<(), #krate::__solana_program_error::ProgramError> {
+                #validate
+            }
+        }
+
         impl #krate::account_load::AccountLoad for #name {
             #[inline(always)]
             fn check(view: &#krate::__internal::AccountView) -> Result<(), #krate::__solana_program_error::ProgramError> {
-                #body
+                // SAFETY: generated account parsing calls unchecked validation
+                // only when no checked borrow is live.
+                Self::__quasar_check_data(unsafe { view.borrow_unchecked() })
             }
 
             #[inline(always)]
             fn check_checked(view: &#krate::__internal::AccountView) -> Result<(), #krate::__solana_program_error::ProgramError> {
-                #checked_body
+                Self::__quasar_check_data(&view.try_borrow()?)
             }
         }
     }
 }
 
-fn emit_account_load_check_body(
-    checked: bool,
+fn emit_account_load_validate(
     disc_len: usize,
     disc_indices: &[usize],
     disc_bytes: &[syn::LitInt],
     zc_mod: &syn::Ident,
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
-    let borrow = if checked {
-        quote! {
-            let __data_ref = view.try_borrow()?;
-            let __data: &[u8] = &__data_ref;
-        }
-    } else {
-        quote! {
-            // SAFETY: generated account parsing calls unchecked validation only
-            // when no checked borrow is live.
-            let __data = unsafe { view.borrow_unchecked() };
-        }
-    };
-
-    let validate = quote! {
+    quote! {
         let __min = #disc_len
             + <#zc_mod::__Schema as #krate::ZeroPodCompact>::HEADER_SIZE;
         if __data.len() < __min {
@@ -129,10 +124,5 @@ fn emit_account_load_check_body(
             unsafe { __data.get_unchecked(#disc_len..) }
         ).map_err(|_| #krate::__solana_program_error::ProgramError::InvalidAccountData)?;
         Ok(())
-    };
-
-    quote! {
-        #borrow
-        #validate
     }
 }

--- a/derive/src/account/traits.rs
+++ b/derive/src/account/traits.rs
@@ -39,11 +39,11 @@ pub(super) fn emit_space_impl(
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     if has_dynamic {
-        // Space = discriminator + compact header size (includes length prefixes).
+        // Space = discriminator + compact header size (includes length prefixes),
+        // which is exactly the `MIN_SPACE` the dynamic impl block defines.
         quote! {
             impl #krate::traits::Space for #name {
-                const SPACE: usize = #disc_len
-                    + <#zc_mod::__Schema as #krate::ZeroPodCompact>::HEADER_SIZE;
+                const SPACE: usize = Self::MIN_SPACE;
             }
         }
     } else {
@@ -104,20 +104,18 @@ fn emit_account_load_validate(
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     quote! {
-        let __min = #disc_len
-            + <#zc_mod::__Schema as #krate::ZeroPodCompact>::HEADER_SIZE;
-        if __data.len() < __min {
+        if __data.len() < Self::MIN_SPACE {
             return Err(#krate::__solana_program_error::ProgramError::AccountDataTooSmall);
         }
         #(
-            // SAFETY: `__data.len() >= __min` and every discriminator index is
-            // strictly less than `disc_len`.
+            // SAFETY: `__data.len() >= MIN_SPACE` and every discriminator index
+            // is strictly less than `disc_len`.
             if unsafe { *__data.get_unchecked(#disc_indices) } != #disc_bytes {
                 return Err(#krate::__solana_program_error::ProgramError::InvalidAccountData);
             }
         )*
         <#zc_mod::__Schema as #krate::ZeroPodCompact>::validate(
-            // SAFETY: `__data.len() >= __min`, so the compact payload range
+            // SAFETY: `__data.len() >= MIN_SPACE`, so the compact payload range
             // starting at `disc_len` is in bounds.
             unsafe { __data.get_unchecked(#disc_len..) }
         ).map_err(|_| #krate::__solana_program_error::ProgramError::InvalidAccountData)?;

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -39,12 +39,19 @@ impl SlotOffset {
     /// index into the whole transaction's account list, against `base`.
     fn to_tokens(&self) -> proc_macro2::TokenStream {
         let krate = crate::krate::lang_path();
-        let fixed = self.fixed;
         let terms = self.composites.iter().map(|ty| {
             let inner = composite_parse_ty(ty);
             quote! { <#inner as #krate::traits::AccountCount>::COUNT }
         });
-        quote! { __offset + #fixed #(+ #terms)* }
+        // The first account of a struct sits at `__offset` itself; emitting the
+        // `+ 0usize` it would otherwise carry adds a term that reads as if the
+        // slot were computed when it is not.
+        if self.fixed == 0 {
+            quote! { __offset #(+ #terms)* }
+        } else {
+            let fixed = self.fixed;
+            quote! { __offset + #fixed #(+ #terms)* }
+        }
     }
 
     /// The offset rendered for the debug log. Stringifying `to_tokens()` would
@@ -145,18 +152,16 @@ fn emit_parse_field_step(field: &ParseFieldPlan) -> proc_macro2::TokenStream {
         ParseFieldKind::Composite { inner_ty } => {
             let cur_offset = field.offset.to_tokens();
             quote! {
-                {
-                    input = unsafe {
-                        // SAFETY: the generated caller passes an input slice with
-                        // enough accounts for the statically computed COUNT.
-                        <#inner_ty as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
-                            input,
-                            base,
-                            #cur_offset,
-                            __program_id,
-                        )?
-                    };
-                }
+                input = unsafe {
+                    // SAFETY: the generated caller passes an input slice with
+                    // enough accounts for the statically computed COUNT.
+                    <#inner_ty as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
+                        input,
+                        base,
+                        #cur_offset,
+                        __program_id,
+                    )?
+                };
             }
         }
         ParseFieldKind::Single(header) => {
@@ -267,11 +272,21 @@ fn emit_parse_body_from_inner(
         .any(|field| matches!(field.kind, ParseFieldKind::Composite { .. }))
     {
         let mut field_lets: Vec<proc_macro2::TokenStream> = Vec::new();
+        // Only a struct that hands out more than one chunk ever rebinds the
+        // cursor, and the final chunk never needs the tail it leaves behind.
+        let rebinds = fields.len() > 1;
+        let cursor_mut = if rebinds { quote! { mut } } else { quote! {} };
         field_lets.push(quote! {
-            let mut __accounts_rest: &mut [#krate::__internal::AccountView] = accounts;
+            let #cursor_mut __accounts_rest: &mut [#krate::__internal::AccountView] = accounts;
         });
 
-        for field in fields {
+        let last = fields.len() - 1;
+        for (idx, field) in fields.iter().enumerate() {
+            let (rest_pat, advance) = if idx == last {
+                (quote! { _ }, quote! {})
+            } else {
+                (quote! { __rest }, quote! { __accounts_rest = __rest; })
+            };
             match &field.kind {
                 ParseFieldKind::Composite { inner_ty, .. } => {
                     let field_name = &field.field_name;
@@ -279,10 +294,10 @@ fn emit_parse_body_from_inner(
                     field_lets.push(quote! {
                         // SAFETY: `parse_accounts_raw` already proved this
                         // composite's COUNT accounts are present.
-                        let (__chunk, __rest) = unsafe {
+                        let (__chunk, #rest_pat) = unsafe {
                             __accounts_rest.split_at_mut_unchecked(<#inner_ty as #krate::traits::AccountCount>::COUNT)
                         };
-                        __accounts_rest = __rest;
+                        #advance
                         // SAFETY: the raw parser above validated this composite
                         // account chunk.
                         let (#field_name, #bumps_var) = unsafe { <#inner_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
@@ -297,15 +312,14 @@ fn emit_parse_body_from_inner(
                     field_lets.push(quote! {
                         // SAFETY: `parse_accounts_raw` already proved at least
                         // one account remains for this field.
-                        let (__chunk, __rest) = unsafe { __accounts_rest.split_at_mut_unchecked(1) };
-                        __accounts_rest = __rest;
+                        let (__chunk, #rest_pat) = unsafe { __accounts_rest.split_at_mut_unchecked(1) };
+                        #advance
                         // SAFETY: the one-element split above guarantees index 0.
                         let #field_name = unsafe { __chunk.get_unchecked_mut(0) };
                     });
                 }
             }
         }
-        field_lets.push(quote! { let _ = __accounts_rest; });
 
         quote! {
             #(#field_lets)*

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -34,6 +34,10 @@ struct SlotOffset {
 }
 
 impl SlotOffset {
+    /// The slot index relative to `__offset`, the caller-supplied base of this
+    /// struct's region in the flattened account array. Absolute indices are
+    /// required: `parse_account_dup` resolves the SVM dup byte, which is an
+    /// index into the whole transaction's account list, against `base`.
     fn to_tokens(&self) -> proc_macro2::TokenStream {
         let krate = crate::krate::lang_path();
         let fixed = self.fixed;
@@ -41,7 +45,7 @@ impl SlotOffset {
             let inner = composite_parse_ty(ty);
             quote! { <#inner as #krate::traits::AccountCount>::COUNT }
         });
-        quote! { #fixed #(+ #terms)* }
+        quote! { __offset + #fixed #(+ #terms)* }
     }
 
     /// The offset rendered for the debug log. Stringifying `to_tokens()` would

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -131,7 +131,7 @@ pub(crate) fn build_accounts_plan(
         parse_steps: emit_parse_account_steps(&fields),
         count_expr: emit_count_expr(&fields),
         parse_body: emit_full_parse_body(typed_plan, &fields, cx),
-        direct_parse_body: emit_direct_parse_body(typed_plan, &fields, cx),
+        direct_parse_body: emit_direct_parse_body(&fields),
     }
 }
 
@@ -375,14 +375,9 @@ fn emit_parse_body_from_inner(
     }
 }
 
-fn emit_direct_parse_body(
-    typed_plan: &resolve::specs::AccountsPlanTyped,
-    fields: &[ParseFieldPlan],
-    cx: &EmitCx,
-) -> proc_macro2::TokenStream {
+fn emit_direct_parse_body(fields: &[ParseFieldPlan]) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     let count_expr = emit_count_expr(fields);
-    let fallback_body = emit_parse_body_without_behavior_assertions(typed_plan, fields, cx);
     quote! {
         let mut __buf = core::mem::MaybeUninit::<
             [#krate::__internal::AccountView; #count_expr]
@@ -391,23 +386,14 @@ fn emit_direct_parse_body(
         // SAFETY: parse_accounts initializes the whole fixed-size buffer before
         // returning Ok.
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as #krate::traits::ParseAccounts>::Bumps),
-            #krate::__solana_program_error::ProgramError,
-        > = {
-            #fallback_body
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        // SAFETY: the buffer holds exactly COUNT validated views, which is what
+        // the unchecked parser is generated for.
+        unsafe {
+            <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
-}
-
-fn emit_parse_body_without_behavior_assertions(
-    typed_plan: &resolve::specs::AccountsPlanTyped,
-    fields: &[ParseFieldPlan],
-    cx: &EmitCx,
-) -> proc_macro2::TokenStream {
-    let inner_body = super::parse::emit_parse_body_without_behavior_assertions(typed_plan, cx);
-    emit_parse_body_from_inner(fields, inner_body)
 }

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -44,9 +44,14 @@ impl SlotOffset {
         quote! { #fixed #(+ #terms)* }
     }
 
-    /// The offset rendered as a string literal for the debug log.
+    /// The offset rendered for the debug log. Stringifying `to_tokens()` would
+    /// bake a whole `<Ty as AccountCount>::COUNT` path into the binary.
     fn debug_string(&self) -> String {
-        self.to_tokens().to_string()
+        if self.composites.is_empty() {
+            self.fixed.to_string()
+        } else {
+            format!("{}+{}composite", self.fixed, self.composites.len())
+        }
     }
 }
 

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -77,16 +77,6 @@ impl HeaderPlan {
             allow_dup: fp.dup,
         }
     }
-
-    /// The field's header words. `HeaderSpec::of` is the single owner of the
-    /// bit layout, so the derive names the wrapper type once per account
-    /// instead of once per header expression.
-    fn spec_expr(&self) -> proc_macro2::TokenStream {
-        let krate = crate::krate::lang_path();
-        let ty = &self.ty;
-        let writable = self.writable;
-        quote! { #krate::__internal::HeaderSpec::of::<#ty>(#writable) }
-    }
 }
 
 pub(crate) fn build_accounts_plan(
@@ -182,57 +172,58 @@ fn emit_single_parse_step(
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     let cur_offset = offset.to_tokens();
-    let account_index = offset.debug_string();
-    let spec_expr = header.spec_expr();
+    let ty = &header.ty;
+    let writable = header.writable;
 
+    // The wrapper type and the required-writable bit are the whole header: the
+    // parse helpers read `IS_SIGNER`/`IS_EXECUTABLE` off `T` through an
+    // associated const, so no header constants reach the expansion.
     if header.optional || header.allow_dup {
+        let log = debug_log_line(field_name, offset, "parsed (dup-aware)");
         let is_optional = header.optional;
-        let is_ref_mut = header.writable;
         let allow_dup = header.allow_dup;
 
         return quote! {
-            {
-                const __HEADER: #krate::__internal::HeaderSpec = #spec_expr;
-                input = unsafe {
-                    // SAFETY: parse_account_dup validates the current account
-                    // and advances within the pre-counted input slice.
-                    #krate::__internal::parse_account_dup(
-                        input,
-                        base,
-                        #cur_offset,
-                        __program_id,
-                        #krate::__internal::ParseFlags {
-                            header: __HEADER,
-                            is_optional: #is_optional,
-                            is_ref_mut: #is_ref_mut,
-                            allow_dup: #allow_dup,
-                        },
-                    )?
-                };
-                #krate::debug_log!(concat!(
-                    "Account '", stringify!(#field_name),
-                    "' (index ", #account_index, "): parsed (dup-aware)"
-                ));
-            }
+            // SAFETY: parse_account_dup validates the current account and
+            // advances within the pre-counted input slice.
+            input = unsafe {
+                #krate::__internal::parse_account_dup::<#ty, #writable>(
+                    input,
+                    base,
+                    #cur_offset,
+                    __program_id,
+                    #krate::__internal::ParseFlags {
+                        is_optional: #is_optional,
+                        is_ref_mut: #writable,
+                        allow_dup: #allow_dup,
+                    },
+                )?
+            };
+            #log
         };
     }
 
+    let log = debug_log_line(field_name, offset, "validation passed");
     quote! {
-        {
-            const __HEADER: #krate::__internal::HeaderSpec = #spec_expr;
-            input = unsafe {
-                // SAFETY: parse_account validates the current account and
-                // advances within the pre-counted input slice.
-                #krate::__internal::parse_account(
-                    input, base, #cur_offset, __HEADER.expected, __HEADER.mask,
-                )?
-            };
-            #krate::debug_log!(concat!(
-                "Account '", stringify!(#field_name),
-                "' (index ", #account_index, "): validation passed"
-            ));
-        }
+        // SAFETY: parse_account validates the current account and advances
+        // within the pre-counted input slice.
+        input = unsafe {
+            #krate::__internal::parse_account::<#ty, #writable>(input, base, #cur_offset)?
+        };
+        #log
     }
+}
+
+/// The per-account trace line, built at macro time so the expansion carries one
+/// string literal instead of a `concat!`/`stringify!` tree.
+fn debug_log_line(
+    field_name: &syn::Ident,
+    offset: &SlotOffset,
+    outcome: &str,
+) -> proc_macro2::TokenStream {
+    let krate = crate::krate::lang_path();
+    let message = format!("account {field_name} @{}: {outcome}", offset.debug_string());
+    quote! { #krate::debug_log!(#message); }
 }
 
 fn emit_count_expr(fields: &[ParseFieldPlan]) -> proc_macro2::TokenStream {

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -267,6 +267,12 @@ fn emit_parse_body_from_inner(
     inner_body: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
+    // The chunk cursor and its splits are read only by the statements emitted
+    // just below, never by a user expression, so they take definition-site
+    // hygiene and stop being shadowable by a field of the same name.
+    let accounts_rest = crate::helpers::internal_ident("__accounts_rest");
+    let chunk = crate::helpers::internal_ident("__chunk");
+    let rest = crate::helpers::internal_ident("__rest");
     if fields
         .iter()
         .any(|field| matches!(field.kind, ParseFieldKind::Composite { .. }))
@@ -275,9 +281,13 @@ fn emit_parse_body_from_inner(
         // Only a struct that hands out more than one chunk ever rebinds the
         // cursor, and the final chunk never needs the tail it leaves behind.
         let rebinds = fields.len() > 1;
-        let cursor_mut = if rebinds { quote! { mut } } else { quote! {} };
+        let cursor_mut = if rebinds {
+            quote! { mut }
+        } else {
+            quote! {}
+        };
         field_lets.push(quote! {
-            let #cursor_mut __accounts_rest: &mut [#krate::__internal::AccountView] = accounts;
+            let #cursor_mut #accounts_rest: &mut [#krate::__internal::AccountView] = accounts;
         });
 
         let last = fields.len() - 1;
@@ -285,7 +295,7 @@ fn emit_parse_body_from_inner(
             let (rest_pat, advance) = if idx == last {
                 (quote! { _ }, quote! {})
             } else {
-                (quote! { __rest }, quote! { __accounts_rest = __rest; })
+                (quote! { #rest }, quote! { #accounts_rest = #rest; })
             };
             match &field.kind {
                 ParseFieldKind::Composite { inner_ty, .. } => {
@@ -294,14 +304,14 @@ fn emit_parse_body_from_inner(
                     field_lets.push(quote! {
                         // SAFETY: `parse_accounts_raw` already proved this
                         // composite's COUNT accounts are present.
-                        let (__chunk, #rest_pat) = unsafe {
-                            __accounts_rest.split_at_mut_unchecked(<#inner_ty as #krate::traits::AccountCount>::COUNT)
+                        let (#chunk, #rest_pat) = unsafe {
+                            #accounts_rest.split_at_mut_unchecked(<#inner_ty as #krate::traits::AccountCount>::COUNT)
                         };
                         #advance
                         // SAFETY: the raw parser above validated this composite
                         // account chunk.
                         let (#field_name, #bumps_var) = unsafe { <#inner_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                            __chunk,
+                            #chunk,
                             __ix_data,
                             __program_id
                         ) }?;
@@ -312,10 +322,10 @@ fn emit_parse_body_from_inner(
                     field_lets.push(quote! {
                         // SAFETY: `parse_accounts_raw` already proved at least
                         // one account remains for this field.
-                        let (__chunk, #rest_pat) = unsafe { __accounts_rest.split_at_mut_unchecked(1) };
+                        let (#chunk, #rest_pat) = unsafe { #accounts_rest.split_at_mut_unchecked(1) };
                         #advance
                         // SAFETY: the one-element split above guarantees index 0.
-                        let #field_name = unsafe { __chunk.get_unchecked_mut(0) };
+                        let #field_name = unsafe { #chunk.get_unchecked_mut(0) };
                     });
                 }
             }

--- a/derive/src/accounts/emit/entry.rs
+++ b/derive/src/accounts/emit/entry.rs
@@ -11,7 +11,6 @@ pub(crate) struct AccountsPlan {
     pub parse_steps: Vec<proc_macro2::TokenStream>,
     pub count_expr: proc_macro2::TokenStream,
     pub parse_body: proc_macro2::TokenStream,
-    pub direct_parse_body: proc_macro2::TokenStream,
 }
 
 struct ParseFieldPlan {
@@ -79,46 +78,14 @@ impl HeaderPlan {
         }
     }
 
-    // The three header expressions reference the single-source const fns in
-    // `quasar_lang::__internal`; the derive supplies the required-writable bit
-    // and the type's `AccountLoad` signer/executable consts.
-    fn expected_expr(&self) -> proc_macro2::TokenStream {
+    /// The field's header words. `HeaderSpec::of` is the single owner of the
+    /// bit layout, so the derive names the wrapper type once per account
+    /// instead of once per header expression.
+    fn spec_expr(&self) -> proc_macro2::TokenStream {
         let krate = crate::krate::lang_path();
         let ty = &self.ty;
         let writable = self.writable;
-        quote! {
-            #krate::__internal::header_expected(
-                <#ty as #krate::account_load::AccountLoad>::IS_SIGNER,
-                #writable,
-                <#ty as #krate::account_load::AccountLoad>::IS_EXECUTABLE,
-            )
-        }
-    }
-
-    fn mask_expr(&self) -> proc_macro2::TokenStream {
-        let krate = crate::krate::lang_path();
-        let ty = &self.ty;
-        let writable = self.writable;
-        quote! {
-            #krate::__internal::header_mask(
-                <#ty as #krate::account_load::AccountLoad>::IS_SIGNER,
-                #writable,
-                <#ty as #krate::account_load::AccountLoad>::IS_EXECUTABLE,
-            )
-        }
-    }
-
-    fn flag_mask_expr(&self) -> proc_macro2::TokenStream {
-        let krate = crate::krate::lang_path();
-        let ty = &self.ty;
-        let writable = self.writable;
-        quote! {
-            #krate::__internal::header_flag_mask(
-                <#ty as #krate::account_load::AccountLoad>::IS_SIGNER,
-                #writable,
-                <#ty as #krate::account_load::AccountLoad>::IS_EXECUTABLE,
-            )
-        }
+        quote! { #krate::__internal::HeaderSpec::of::<#ty>(#writable) }
     }
 }
 
@@ -131,7 +98,6 @@ pub(crate) fn build_accounts_plan(
         parse_steps: emit_parse_account_steps(&fields),
         count_expr: emit_count_expr(&fields),
         parse_body: emit_full_parse_body(typed_plan, &fields, cx),
-        direct_parse_body: emit_direct_parse_body(&fields),
     }
 }
 
@@ -217,20 +183,16 @@ fn emit_single_parse_step(
     let krate = crate::krate::lang_path();
     let cur_offset = offset.to_tokens();
     let account_index = offset.debug_string();
-    let expected_expr = header.expected_expr();
-    let mask_expr = header.mask_expr();
+    let spec_expr = header.spec_expr();
 
     if header.optional || header.allow_dup {
-        let flag_mask_expr = header.flag_mask_expr();
         let is_optional = header.optional;
         let is_ref_mut = header.writable;
         let allow_dup = header.allow_dup;
 
-        quote! {
+        return quote! {
             {
-                const __EXPECTED: u32 = #expected_expr;
-                const __MASK: u32 = #mask_expr;
-                const __FLAG_MASK: u32 = #flag_mask_expr;
+                const __HEADER: #krate::__internal::HeaderSpec = #spec_expr;
                 input = unsafe {
                     // SAFETY: parse_account_dup validates the current account
                     // and advances within the pre-counted input slice.
@@ -240,9 +202,7 @@ fn emit_single_parse_step(
                         #cur_offset,
                         __program_id,
                         #krate::__internal::ParseFlags {
-                            expected: __EXPECTED,
-                            mask: __MASK,
-                            flag_mask: __FLAG_MASK,
+                            header: __HEADER,
                             is_optional: #is_optional,
                             is_ref_mut: #is_ref_mut,
                             allow_dup: #allow_dup,
@@ -254,24 +214,23 @@ fn emit_single_parse_step(
                     "' (index ", #account_index, "): parsed (dup-aware)"
                 ));
             }
-        }
-    } else {
-        quote! {
-            {
-                const __EXPECTED: u32 = #expected_expr;
-                const __MASK: u32 = #mask_expr;
-                input = unsafe {
-                    // SAFETY: parse_account validates the current account and
-                    // advances within the pre-counted input slice.
-                    #krate::__internal::parse_account(
-                        input, base, #cur_offset, __EXPECTED, __MASK,
-                    )?
-                };
-                #krate::debug_log!(concat!(
-                    "Account '", stringify!(#field_name),
-                    "' (index ", #account_index, "): validation passed"
-                ));
-            }
+        };
+    }
+
+    quote! {
+        {
+            const __HEADER: #krate::__internal::HeaderSpec = #spec_expr;
+            input = unsafe {
+                // SAFETY: parse_account validates the current account and
+                // advances within the pre-counted input slice.
+                #krate::__internal::parse_account(
+                    input, base, #cur_offset, __HEADER.expected, __HEADER.mask,
+                )?
+            };
+            #krate::debug_log!(concat!(
+                "Account '", stringify!(#field_name),
+                "' (index ", #account_index, "): validation passed"
+            ));
         }
     }
 }
@@ -371,29 +330,6 @@ fn emit_parse_body_from_inner(
                 unsafe { core::hint::unreachable_unchecked() }
             };
             #inner_body
-        }
-    }
-}
-
-fn emit_direct_parse_body(fields: &[ParseFieldPlan]) -> proc_macro2::TokenStream {
-    let krate = crate::krate::lang_path();
-    let count_expr = emit_count_expr(fields);
-    quote! {
-        let mut __buf = core::mem::MaybeUninit::<
-            [#krate::__internal::AccountView; #count_expr]
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        // SAFETY: parse_accounts initializes the whole fixed-size buffer before
-        // returning Ok.
-        let mut __accounts = unsafe { __buf.assume_init() };
-        // SAFETY: the buffer holds exactly COUNT validated views, which is what
-        // the unchecked parser is generated for.
-        unsafe {
-            <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
         }
     }
 }

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -153,12 +153,34 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
             #[inline(always)]
             #[doc(hidden)]
             pub unsafe fn parse_accounts(
-                mut input: *mut u8,
+                input: *mut u8,
                 buf: &mut core::mem::MaybeUninit<[#krate::__internal::AccountView; #count_expr]>,
                 __program_id: &#krate::prelude::Address,
             ) -> Result<*mut u8, #krate::__solana_program_error::ProgramError> {
-                let base = buf.as_mut_ptr() as *mut #krate::__internal::AccountView;
+                Self::parse_accounts_into(
+                    input,
+                    buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
+                    0usize,
+                    __program_id,
+                )
+            }
 
+            /// Parse this struct's accounts directly into `base[__offset..]`.
+            ///
+            /// # Safety
+            ///
+            /// `base[__offset .. __offset + COUNT]` must be writable
+            /// `AccountView` slots, `base[..__offset]` must already be
+            /// initialized, and `input` must point at this struct's first
+            /// account entry.
+            #[inline(always)]
+            #[doc(hidden)]
+            pub unsafe fn parse_accounts_into(
+                mut input: *mut u8,
+                base: *mut #krate::__internal::AccountView,
+                __offset: usize,
+                __program_id: &#krate::prelude::Address,
+            ) -> Result<*mut u8, #krate::__solana_program_error::ProgramError> {
                 #(#parse_steps)*
 
                 Ok(input)
@@ -184,26 +206,8 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
                 offset: usize,
                 __program_id: &#krate::prelude::Address,
             ) -> Result<*mut u8, #krate::__solana_program_error::ProgramError> {
-                let mut __inner_buf = core::mem::MaybeUninit::<
-                    [#krate::__internal::AccountView; #count_expr]
-                >::uninit();
-                let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-                // SAFETY: parse_accounts initializes every element before
-                // returning Ok.
-                let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-                let mut __j = 0usize;
-                while __j < #count_expr {
-                    // SAFETY: `__j < count_expr`; the caller's `base + offset`
-                    // points into the preallocated outer account buffer.
-                    core::ptr::write(
-                        base.add(offset + __j),
-                        // SAFETY: `__inner` owns `count_expr` initialized
-                        // AccountView values.
-                        core::ptr::read(__inner.as_ptr().add(__j)),
-                    );
-                    __j += 1;
-                }
-                Ok(input)
+                // SAFETY: forwards the caller's `ParseAccountsRaw` contract.
+                unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
             }
         }
 

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -136,14 +136,8 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
                 program_id: Option<&#krate::prelude::Address>,
                 data: &[u8],
             ) -> Result<Self, #krate::__solana_program_error::ProgramError> {
-                let program_id = program_id.ok_or(#krate::__solana_program_error::ProgramError::InvalidInstructionData)?;
-                let (item, _bumps) =
-                    <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                        accounts,
-                        data,
-                        program_id,
-                    )?;
-                Ok(item)
+                // SAFETY: forwards the caller's exact-count contract.
+                unsafe { #krate::remaining::parse_group_chunk::<Self>(accounts, program_id, data) }
             }
         }
 

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -189,11 +189,10 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
             #[inline(always)]
             #[doc(hidden)]
             pub unsafe fn parse_direct_with_instruction_data_unchecked(
-                mut input: *mut u8,
+                input: *mut u8,
                 __ix_data: &[u8],
                 __program_id: &#krate::prelude::Address,
             ) -> Result<(Self, #bumps_name), #krate::__solana_program_error::ProgramError> {
-                #ix_arg_extraction
                 #direct_parse_body
             }
         }

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -5,6 +5,14 @@
 
 use quote::quote;
 
+/// Longest raw account walk still emitted as `#[inline(always)]`.
+///
+/// Measured across the test programs: below the crossover, forcing the walk
+/// inline is smaller (a one-account walk costs less than the call that would
+/// replace it); above it, letting the inliner outline and share the walk cuts
+/// 8-10% from programs that repeat it across many instructions.
+const INLINE_ALWAYS_MAX_STEPS: usize = 3;
+
 pub(crate) struct AccountsOutput<'a> {
     pub name: &'a syn::Ident,
     pub bumps_name: &'a syn::Ident,
@@ -63,6 +71,24 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         }
     };
 
+    // Whether the raw account walk is worth duplicating at every call site.
+    //
+    // A short walk is a handful of instructions, so forcing it inline costs
+    // less than the call it would replace and lets the surrounding parse
+    // specialize it. A long one is worth outlining: a program that repeats it
+    // across many instructions otherwise pays for a full copy at each, which is
+    // where the bulk of a token-heavy program's `.text` goes.
+    //
+    // `parse_steps` measures this body specifically, which is the thing being
+    // duplicated. A composite field contributes one step here — a call to the
+    // inner group's own `parse_accounts_raw` — however many accounts it stands
+    // for, and that inner group is sized by this same rule when it is emitted.
+    let raw_inline = if parse_steps.len() > INLINE_ALWAYS_MAX_STEPS {
+        quote! { #[inline] }
+    } else {
+        quote! { #[inline(always)] }
+    };
+
     let inherent_impl = if extract_ix_args_fn.is_empty() {
         quote! {}
     } else {
@@ -111,7 +137,7 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         #inherent_impl
 
         unsafe impl #impl_generics #krate::traits::ParseAccountsRaw for #name #ty_generics #where_clause {
-            #[inline(always)]
+            #raw_inline
             unsafe fn parse_accounts_raw(
                 mut input: *mut u8,
                 base: *mut #krate::__internal::AccountView,

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -28,9 +28,6 @@ pub(crate) struct AccountsOutput<'a> {
     /// The single `#[inline(always)] fn __extract_ix_args` definition, placed
     /// on the inherent impl (empty when there are no ix args).
     pub extract_ix_args_fn: proc_macro2::TokenStream,
-    /// The single `__assert_builder` helper, placed on the inherent impl (empty
-    /// when the struct has no behavior groups).
-    pub assert_builder_fn: proc_macro2::TokenStream,
 }
 
 pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::TokenStream {
@@ -54,21 +51,18 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         client_macro,
         ix_arg_extraction,
         extract_ix_args_fn,
-        assert_builder_fn,
     } = output;
 
     let has_epilogue_const = quote! {
         const HAS_EPILOGUE: bool = #has_epilogue_expr;
     };
 
-    // Both helpers are empty for a struct with no ix args and no behaviors.
-    let inherent_impl = if extract_ix_args_fn.is_empty() && assert_builder_fn.is_empty() {
+    let inherent_impl = if extract_ix_args_fn.is_empty() {
         quote! {}
     } else {
         quote! {
             impl #impl_generics #name #ty_generics #where_clause {
                 #extract_ix_args_fn
-                #assert_builder_fn
             }
         }
     };

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -53,8 +53,14 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         extract_ix_args_fn,
     } = output;
 
-    let has_epilogue_const = quote! {
-        const HAS_EPILOGUE: bool = #has_epilogue_expr;
+    // `ParseAccounts::HAS_EPILOGUE` already defaults to false, which is exactly
+    // what the expression folds to for a struct with no lifecycle steps.
+    let has_epilogue_const = if has_epilogue_expr.to_string() == "false" {
+        quote! {}
+    } else {
+        quote! {
+            const HAS_EPILOGUE: bool = #has_epilogue_expr;
+        }
     };
 
     let inherent_impl = if extract_ix_args_fn.is_empty() {

--- a/derive/src/accounts/emit/output.rs
+++ b/derive/src/accounts/emit/output.rs
@@ -17,7 +17,6 @@ pub(crate) struct AccountsOutput<'a> {
     pub needs_event_cpi_expr: proc_macro2::TokenStream,
     pub parse_steps: Vec<proc_macro2::TokenStream>,
     pub parse_body: proc_macro2::TokenStream,
-    pub direct_parse_body: proc_macro2::TokenStream,
     pub bumps_struct: proc_macro2::TokenStream,
     pub signer_helpers_impl: proc_macro2::TokenStream,
     pub epilogue_method: proc_macro2::TokenStream,
@@ -48,7 +47,6 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         needs_event_cpi_expr,
         parse_steps,
         parse_body,
-        direct_parse_body,
         bumps_struct,
         signer_helpers_impl,
         epilogue_method,
@@ -59,50 +57,26 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
         assert_builder_fn,
     } = output;
 
-    let exact_len_guard = quote! {
-        #krate::traits::check_account_count(accounts.len(), Self::COUNT)?;
-    };
-
     let has_epilogue_const = quote! {
         const HAS_EPILOGUE: bool = #has_epilogue_expr;
+    };
+
+    // Both helpers are empty for a struct with no ix args and no behaviors.
+    let inherent_impl = if extract_ix_args_fn.is_empty() && assert_builder_fn.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            impl #impl_generics #name #ty_generics #where_clause {
+                #extract_ix_args_fn
+                #assert_builder_fn
+            }
+        }
     };
 
     let parse_accounts_impl = quote! {
         impl #parse_impl_generics #krate::traits::ParseAccounts<'input> for #name #ty_generics #parse_where_clause {
             type Bumps = #bumps_name;
             #has_epilogue_const
-
-            #[inline(always)]
-            fn parse(accounts: &'input mut [#krate::__internal::AccountView], program_id: &#krate::prelude::Address) -> Result<(Self, Self::Bumps), #krate::__solana_program_error::ProgramError> {
-                #exact_len_guard
-                // SAFETY: the exact-count guard above proves the unchecked parser
-                // receives the account count it was generated for.
-                unsafe {
-                    <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                        accounts,
-                        &[],
-                        program_id,
-                    )
-                }
-            }
-
-            #[inline(always)]
-            fn parse_with_instruction_data(
-                accounts: &'input mut [#krate::__internal::AccountView],
-                __ix_data: &[u8],
-                __program_id: &#krate::prelude::Address,
-            ) -> Result<(Self, Self::Bumps), #krate::__solana_program_error::ProgramError> {
-                #exact_len_guard
-                // SAFETY: the exact-count guard above proves the unchecked parser
-                // receives the account count it was generated for.
-                unsafe {
-                    <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                        accounts,
-                        __ix_data,
-                        __program_id,
-                    )
-                }
-            }
 
             #epilogue_method
         }
@@ -111,18 +85,6 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
             for #name #ty_generics
             #parse_where_clause
         {
-            #[inline(always)]
-            unsafe fn parse_unchecked(
-                accounts: &'input mut [#krate::__internal::AccountView],
-                program_id: &#krate::prelude::Address,
-            ) -> Result<(Self, Self::Bumps), #krate::__solana_program_error::ProgramError> {
-                <Self as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                    accounts,
-                    &[],
-                    program_id,
-                )
-            }
-
             #[inline(always)]
             unsafe fn parse_with_instruction_data_unchecked(
                 accounts: &'input mut [#krate::__internal::AccountView],
@@ -146,36 +108,11 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
             const NEEDS_EVENT_CPI: bool = #needs_event_cpi_expr;
         }
 
-        impl #impl_generics #name #ty_generics #where_clause {
-            #extract_ix_args_fn
-            #assert_builder_fn
+        #inherent_impl
 
+        unsafe impl #impl_generics #krate::traits::ParseAccountsRaw for #name #ty_generics #where_clause {
             #[inline(always)]
-            #[doc(hidden)]
-            pub unsafe fn parse_accounts(
-                input: *mut u8,
-                buf: &mut core::mem::MaybeUninit<[#krate::__internal::AccountView; #count_expr]>,
-                __program_id: &#krate::prelude::Address,
-            ) -> Result<*mut u8, #krate::__solana_program_error::ProgramError> {
-                Self::parse_accounts_into(
-                    input,
-                    buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
-                    0usize,
-                    __program_id,
-                )
-            }
-
-            /// Parse this struct's accounts directly into `base[__offset..]`.
-            ///
-            /// # Safety
-            ///
-            /// `base[__offset .. __offset + COUNT]` must be writable
-            /// `AccountView` slots, `base[..__offset]` must already be
-            /// initialized, and `input` must point at this struct's first
-            /// account entry.
-            #[inline(always)]
-            #[doc(hidden)]
-            pub unsafe fn parse_accounts_into(
+            unsafe fn parse_accounts_raw(
                 mut input: *mut u8,
                 base: *mut #krate::__internal::AccountView,
                 __offset: usize,
@@ -184,29 +121,6 @@ pub(crate) fn emit_accounts_output(output: AccountsOutput<'_>) -> proc_macro2::T
                 #(#parse_steps)*
 
                 Ok(input)
-            }
-
-            #[inline(always)]
-            #[doc(hidden)]
-            pub unsafe fn parse_direct_with_instruction_data_unchecked(
-                input: *mut u8,
-                __ix_data: &[u8],
-                __program_id: &#krate::prelude::Address,
-            ) -> Result<(Self, #bumps_name), #krate::__solana_program_error::ProgramError> {
-                #direct_parse_body
-            }
-        }
-
-        unsafe impl #impl_generics #krate::traits::ParseAccountsRaw for #name #ty_generics #where_clause {
-            #[inline(always)]
-            unsafe fn parse_accounts_raw(
-                input: *mut u8,
-                base: *mut #krate::__internal::AccountView,
-                offset: usize,
-                __program_id: &#krate::prelude::Address,
-            ) -> Result<*mut u8, #krate::__solana_program_error::ProgramError> {
-                // SAFETY: forwards the caller's `ParseAccountsRaw` contract.
-                unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
             }
         }
 

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -415,10 +415,35 @@ pub(crate) fn emit_epilogue(
         return quote! {};
     }
 
+    let plain = quote! { #(#exit_stmts)* };
+    let contextual = quote! { #(#contextual_exit_stmts)* };
+
+    // The two bodies diverge only where a behavior exit signs with a PDA, which
+    // is the only thing that reads `__bumps`/`__ix_data`. Otherwise they are
+    // token-identical, so emit one and forward.
+    if plain.to_string() == contextual.to_string() {
+        return quote! {
+            #[inline(always)]
+            fn epilogue(&mut self) -> Result<(), #krate::__solana_program_error::ProgramError> {
+                #plain
+                Ok(())
+            }
+
+            #[inline(always)]
+            fn epilogue_with_context(
+                &mut self,
+                _bumps: &Self::Bumps,
+                _ix_data: &[u8],
+            ) -> Result<(), #krate::__solana_program_error::ProgramError> {
+                self.epilogue()
+            }
+        };
+    }
+
     quote! {
         #[inline(always)]
         fn epilogue(&mut self) -> Result<(), #krate::__solana_program_error::ProgramError> {
-            #(#exit_stmts)*
+            #plain
             Ok(())
         }
 
@@ -429,7 +454,7 @@ pub(crate) fn emit_epilogue(
             __bumps: &Self::Bumps,
             __ix_data: &[u8],
         ) -> Result<(), #krate::__solana_program_error::ProgramError> {
-            #(#contextual_exit_stmts)*
+            #contextual
             Ok(())
         }
     }

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -457,7 +457,7 @@ pub(crate) fn emit_epilogue(
 pub(crate) fn emit_has_epilogue_typed(plan: &AccountsPlanTyped) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
     // Collect const-evaluable terms for HAS_EPILOGUE.
-    let mut terms: Vec<proc_macro2::TokenStream> = vec![quote! { false }];
+    let mut terms: Vec<proc_macro2::TokenStream> = Vec::new();
 
     for fp in &plan.fields {
         let ty = &fp.effective_ty;
@@ -474,7 +474,7 @@ pub(crate) fn emit_has_epilogue_typed(plan: &AccountsPlanTyped) -> proc_macro2::
         }
     }
 
-    quote! { #(#terms)||* }
+    crate::helpers::or_bool_terms(terms)
 }
 
 // Load phase.

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -628,7 +628,7 @@ fn behavior_validates_account_data_expr(
         }
     });
 
-    Some(quote! { false #(|| #terms)* })
+    Some(crate::helpers::or_bool_terms(terms))
 }
 
 // User checks, structural rather than behavior-group based.

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -30,7 +30,7 @@ use {
         typed_emit,
     },
     crate::helpers::strip_generics,
-    quote::{format_ident, quote},
+    quote::{format_ident, quote, quote_spanned},
 };
 
 pub(crate) fn emit_parse_body(
@@ -674,6 +674,10 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
     for fp in field_plans {
         let ty = &fp.effective_ty;
         let field_name = fp.ident.to_string();
+        // Anchor each assertion to the field it is about, so a failure
+        // underlines that field rather than the whole derive. The message still
+        // names the field for the cases rustc reports without a snippet.
+        let at_field = fp.ident.span();
 
         for group in &fp.behaviors {
             let path = &group.path;
@@ -685,11 +689,11 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
                     "behavior `{}` requires `#[account(mut)]` on field `{}`",
                     group.name, field_name,
                 );
-                asserts.push(quote! {
-                    const _: () = assert!(
-                        !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::REQUIRES_MUT,
-                        #msg,
-                    );
+                let cond = quote! {
+                    !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::REQUIRES_MUT
+                };
+                asserts.push(quote_spanned! { at_field =>
+                    const _: () = assert!(#cond, #msg,);
                 });
             }
 
@@ -697,12 +701,12 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
                 "behavior `{}` sets VALIDATES_ACCOUNT_DATA and must keep RUN_CHECK = true",
                 group.name,
             );
-            asserts.push(quote! {
-                const _: () = assert!(
-                    !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::VALIDATES_ACCOUNT_DATA
-                        || <#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::RUN_CHECK,
-                    #validates_data_msg,
-                );
+            let cond = quote! {
+                !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::VALIDATES_ACCOUNT_DATA
+                    || <#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::RUN_CHECK
+            };
+            asserts.push(quote_spanned! { at_field =>
+                const _: () = assert!(#cond, #validates_data_msg,);
             });
 
             // RUN_AFTER_INIT assertion: `after_init` only runs on account
@@ -714,11 +718,11 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
                      `{}`",
                     group.name, field_name,
                 );
-                asserts.push(quote! {
-                    const _: () = assert!(
-                        !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::RUN_AFTER_INIT,
-                        #after_init_msg,
-                    );
+                let cond = quote! {
+                    !<#path::Behavior as #krate::account_behavior::AccountBehavior<#ty>>::RUN_AFTER_INIT
+                };
+                asserts.push(quote_spanned! { at_field =>
+                    const _: () = assert!(#cond, #after_init_msg,);
                 });
             }
         }
@@ -742,11 +746,9 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
                     "at most one behavior group on field `{}` may set `SETS_INIT_PARAMS = true`",
                     field_name,
                 );
-                asserts.push(quote! {
-                    const _: () = assert!(
-                        #(#init_contributor_count)+* <= 1,
-                        #at_most_one_msg,
-                    );
+                let cond = quote! { #(#init_contributor_count)+* <= 1 };
+                asserts.push(quote_spanned! { at_field =>
+                    const _: () = assert!(#cond, #at_most_one_msg,);
                 });
             }
 
@@ -766,7 +768,7 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
                         || #(#init_contributor_count)+* >= 1
                 }
             };
-            asserts.push(quote! {
+            asserts.push(quote_spanned! { at_field =>
                 const _: () = assert!(#condition, #required_msg,);
             });
         }

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -420,22 +420,15 @@ pub(crate) fn emit_epilogue(
 
     // The two bodies diverge only where a behavior exit signs with a PDA, which
     // is the only thing that reads `__bumps`/`__ix_data`. Otherwise they are
-    // token-identical, so emit one and forward.
+    // token-identical, and `ParseAccounts::epilogue_with_context` already
+    // defaults to `self.epilogue()`, so emitting an override would restate the
+    // default verbatim.
     if plain.to_string() == contextual.to_string() {
         return quote! {
             #[inline(always)]
             fn epilogue(&mut self) -> Result<(), #krate::__solana_program_error::ProgramError> {
                 #plain
                 Ok(())
-            }
-
-            #[inline(always)]
-            fn epilogue_with_context(
-                &mut self,
-                _bumps: &Self::Bumps,
-                _ix_data: &[u8],
-            ) -> Result<(), #krate::__solana_program_error::ProgramError> {
-                self.epilogue()
             }
         };
     }
@@ -758,23 +751,23 @@ fn emit_behavior_assertions(field_plans: &[FieldPlan]) -> proc_macro2::TokenStre
             }
 
             // If the account type requires init params (DEFAULT_INIT_PARAMS_VALID
-            // = false), at least one behavior must provide them.
-            // This fires even with zero behavior groups (count_expr = 0usize).
-            let count_expr = if init_contributor_count.is_empty() {
-                quote! { 0usize }
-            } else {
-                quote! { #(#init_contributor_count)+* }
-            };
+            // = false), at least one behavior must provide them. With no
+            // behavior groups there is nothing to count, so the type's own
+            // default is the whole condition.
             let required_msg = format!(
                 "field `{}` requires an init-param behavior (e.g., token(...) or mint(...))",
                 field_name,
             );
-            asserts.push(quote! {
-                const _: () = assert!(
+            let condition = if init_contributor_count.is_empty() {
+                quote! { <#ty as #krate::account_init::AccountInit>::DEFAULT_INIT_PARAMS_VALID }
+            } else {
+                quote! {
                     <#ty as #krate::account_init::AccountInit>::DEFAULT_INIT_PARAMS_VALID
-                        || #count_expr >= 1,
-                    #required_msg,
-                );
+                        || #(#init_contributor_count)+* >= 1
+                }
+            };
+            asserts.push(quote! {
+                const _: () = assert!(#condition, #required_msg,);
             });
         }
     }

--- a/derive/src/accounts/emit/parse.rs
+++ b/derive/src/accounts/emit/parse.rs
@@ -37,21 +37,6 @@ pub(crate) fn emit_parse_body(
     plan: &AccountsPlanTyped,
     cx: &super::EmitCx,
 ) -> proc_macro2::TokenStream {
-    emit_parse_body_inner(plan, cx, true)
-}
-
-pub(crate) fn emit_parse_body_without_behavior_assertions(
-    plan: &AccountsPlanTyped,
-    cx: &super::EmitCx,
-) -> proc_macro2::TokenStream {
-    emit_parse_body_inner(plan, cx, false)
-}
-
-fn emit_parse_body_inner(
-    plan: &AccountsPlanTyped,
-    cx: &super::EmitCx,
-    include_behavior_assertions: bool,
-) -> proc_macro2::TokenStream {
     let parse_sequence = emit_parse_sequence(plan);
     let bump_vars = emit_bump_vars(&plan.fields);
     let init_state_vars = emit_init_state_vars(&plan.fields);
@@ -59,11 +44,7 @@ fn emit_parse_body_inner(
     let bump_init = emit_bump_init(&plan.fields, &cx.bumps_name);
 
     // Behavior const assertions: REQUIRES_MUT and SETS_INIT_PARAMS.
-    let behavior_asserts = if include_behavior_assertions {
-        emit_behavior_assertions(&plan.fields)
-    } else {
-        quote! {}
-    };
+    let behavior_asserts = emit_behavior_assertions(&plan.fields);
 
     let construct_fields: Vec<proc_macro2::TokenStream> = plan
         .fields

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -25,6 +25,7 @@ pub(crate) fn emit_post_load_behavior(
     did_init_var: Option<&syn::Ident>,
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
+    let bhv_args = crate::helpers::internal_ident("__bhv_args");
     let path = &call.path;
     let bhv = quote! { <#path::Behavior as #krate::account_behavior::AccountBehavior<#field_ty>> };
     let args_block = emit_behavior_args_builder(call, field_ty, phase.as_behavior_phase(), &[]);
@@ -34,7 +35,7 @@ pub(crate) fn emit_post_load_behavior(
         PostLoadPhase::AfterInit => quote! {
             if #bhv::RUN_AFTER_INIT {
                 #args_block
-                #bhv::after_init(&mut #field_ident, &__bhv_args)?;
+                #bhv::after_init(&mut #field_ident, &#bhv_args)?;
             }
         },
         PostLoadPhase::Check => {
@@ -45,14 +46,14 @@ pub(crate) fn emit_post_load_behavior(
             quote! {
                 if #bhv::RUN_CHECK #fresh_init_guard {
                     #args_block
-                    #bhv::check(&#field_ident, &__bhv_args)?;
+                    #bhv::check(&#field_ident, &#bhv_args)?;
                 }
             }
         }
         PostLoadPhase::Update => quote! {
             if #bhv::RUN_UPDATE {
                 #args_block
-                #bhv::update(&mut #field_ident, &__bhv_args)?;
+                #bhv::update(&mut #field_ident, &#bhv_args)?;
             }
         },
     }
@@ -69,6 +70,7 @@ pub(crate) fn emit_epilogue_behavior(
     ix_arg_extraction: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
+    let bhv_args = crate::helpers::internal_ident("__bhv_args");
     let path = &call.path;
     let bhv = quote! { <#path::Behavior as #krate::account_behavior::AccountBehavior<#field_ty>> };
     let args_block = emit_behavior_args_builder(call, field_ty, BehaviorPhase::Exit, &[]);
@@ -76,7 +78,7 @@ pub(crate) fn emit_epilogue_behavior(
     let unsigned_exit = quote! {
         if #bhv::RUN_EXIT {
             #args_block
-            #bhv::exit(&mut self.#field_ident, &__bhv_args)?;
+            #bhv::exit(&mut self.#field_ident, &#bhv_args)?;
         }
     };
 
@@ -86,7 +88,7 @@ pub(crate) fn emit_epilogue_behavior(
 
     let mut exit_call = quote! {
         #args_block
-        #bhv::exit(&mut self.#field_ident, &__bhv_args)?;
+        #bhv::exit(&mut self.#field_ident, &#bhv_args)?;
     };
 
     for candidate in signer_candidates.iter().rev() {
@@ -110,7 +112,7 @@ pub(crate) fn emit_epilogue_behavior(
                 #args_block
                 #bhv::exit_signed(
                     &mut self.#field_ident,
-                    &__bhv_args,
+                    &#bhv_args,
                     &__bhv_signer,
                 )?;
             } else {
@@ -137,6 +139,7 @@ pub(crate) fn emit_behavior_init(
     inferable_accounts: &[&syn::Ident],
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
+    let bhv_args = crate::helpers::internal_ident("__bhv_args");
     let payer_ident = &spec.payer.ident;
     let idempotent = spec.idempotent;
     let has_address = spec.verified_address.is_some();
@@ -157,7 +160,7 @@ pub(crate) fn emit_behavior_init(
                     #args_block
                     <#path::Behavior as #krate::account_behavior::AccountBehavior<#field_ty>>::set_init_param(
                         &mut __init_params,
-                        &__bhv_args,
+                        &#bhv_args,
                     )?;
                 }
             }
@@ -292,6 +295,8 @@ fn emit_behavior_args_builder(
     inferable_accounts: &[&syn::Ident],
 ) -> proc_macro2::TokenStream {
     let krate = crate::krate::lang_path();
+    let bhv_args = crate::helpers::internal_ident("__bhv_args");
+    let bhv_builder = crate::helpers::internal_ident("__bhv_builder");
     // Exit args reference `self.field`; every other phase uses local bindings.
     let exit_context = matches!(phase, BehaviorPhase::Exit);
     let path = &call.path;
@@ -303,7 +308,7 @@ fn emit_behavior_args_builder(
             #bhv::infer_init_account::<{
                 #krate::account_behavior::behavior_arg_key_hash(#key)
             }>(
-                &mut __bhv_args,
+                &mut #bhv_args,
                 #krate::traits::AsAccountView::to_account_view(&#account),
             );
         }
@@ -316,12 +321,12 @@ fn emit_behavior_args_builder(
             let key_lit = key.to_string();
             let val = emit_lowered_value(&arg.lowered, exit_context);
             quote! {
-                let __bhv_builder = if #krate::account_behavior::#phase_guard::<
+                let #bhv_builder = if #krate::account_behavior::#phase_guard::<
                     __QuasarBhv, __QuasarBhvAcct, { #krate::account_behavior::key(#key_lit) },
                 >() {
-                    __bhv_builder.#key(#val)
+                    #bhv_builder.#key(#val)
                 } else {
-                    __bhv_builder
+                    #bhv_builder
                 };
             }
         })
@@ -335,13 +340,13 @@ fn emit_behavior_args_builder(
 
     let args_binding = if inferable_accounts.is_empty() {
         quote! {
-            let __bhv_args =
-                #krate::account_behavior::BehaviorArgsBuilder::#build_method(__bhv_builder)?;
+            let #bhv_args =
+                #krate::account_behavior::BehaviorArgsBuilder::#build_method(#bhv_builder)?;
         }
     } else {
         quote! {
-            let mut __bhv_args =
-                #krate::account_behavior::BehaviorArgsBuilder::#build_method(__bhv_builder)?;
+            let mut #bhv_args =
+                #krate::account_behavior::BehaviorArgsBuilder::#build_method(#bhv_builder)?;
             #(#inferred_accounts)*
         }
     };
@@ -362,12 +367,12 @@ fn emit_behavior_args_builder(
 
     quote! {
         #aliases
-        let __bhv_builder = #path::Args::builder();
+        let #bhv_builder = #path::Args::builder();
         #(#setters)*
         // Bound check: the builder must implement the stable BehaviorArgsBuilder
         // contract. A plugin whose builder is missing a phase fails here with a
         // clear diagnostic instead of a "no method" error.
-        #krate::account_behavior::assert_builder(&__bhv_builder);
+        #krate::account_behavior::assert_builder(&#bhv_builder);
         #args_binding
     }
 }

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -38,13 +38,12 @@ pub(crate) fn emit_post_load_behavior(
             }
         },
         PostLoadPhase::Check => {
-            let fresh_init_guard = if let Some(did_init_var) = did_init_var {
-                quote! { !(#did_init_var && #bhv::INIT_SATISFIES_CHECK) }
-            } else {
-                quote! { true }
+            let fresh_init_guard = match did_init_var {
+                Some(did_init_var) => quote! { && !(#did_init_var && #bhv::INIT_SATISFIES_CHECK) },
+                None => quote! {},
             };
             quote! {
-                if #bhv::RUN_CHECK && #fresh_init_guard {
+                if #bhv::RUN_CHECK #fresh_init_guard {
                     #args_block
                     #bhv::check(&#field_ident, &__bhv_args)?;
                 }

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -354,25 +354,9 @@ fn emit_behavior_args_builder(
         #(#setters)*
         // Bound check: the builder must implement the stable BehaviorArgsBuilder
         // contract. A plugin whose builder is missing a phase fails here with a
-        // clear diagnostic instead of a "no method" error. The assertion helper
-        // is defined once per derive (see `emit_assert_builder_fn`).
-        Self::__assert_builder(&__bhv_builder);
+        // clear diagnostic instead of a "no method" error.
+        #krate::account_behavior::assert_builder(&__bhv_builder);
         #args_binding
-    }
-}
-
-/// Emit the single `__assert_builder` helper on the accounts struct's inherent
-/// impl, used by every behavior-args block to prove the builder implements the
-/// stable `BehaviorArgsBuilder` contract. Empty when the struct has no
-/// behavior groups.
-pub(crate) fn emit_assert_builder_fn(has_behaviors: bool) -> proc_macro2::TokenStream {
-    let krate = crate::krate::lang_path();
-    if !has_behaviors {
-        return quote! {};
-    }
-    quote! {
-        #[inline(always)]
-        fn __assert_builder<__B: #krate::account_behavior::BehaviorArgsBuilder>(_: &__B) {}
     }
 }
 

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -316,7 +316,9 @@ fn emit_behavior_args_builder(
             let key_lit = key.to_string();
             let val = emit_lowered_value(&arg.lowered, exit_context);
             quote! {
-                let __bhv_builder = if #bhv::uses_arg::<
+                let __bhv_builder = if #krate::account_behavior::uses_arg::<
+                    #path::Behavior,
+                    #field_ty,
                     { #phase_const },
                     { #krate::account_behavior::behavior_arg_key_hash(#key_lit) },
                 >() {

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -84,9 +84,6 @@ pub(crate) fn emit_epilogue_behavior(
         return unsigned_exit;
     }
 
-    let field_refs = account_fields
-        .iter()
-        .map(|ident| quote! { let #ident = &self.#ident; });
     let mut exit_call = quote! {
         #args_block
         #bhv::exit(&mut self.#field_ident, &__bhv_args)?;
@@ -96,7 +93,12 @@ pub(crate) fn emit_epilogue_behavior(
         let key = candidate.key.to_string();
         let signer_field = candidate.field_ident;
         let addr_expr = candidate.addr_expr;
-        let refs = field_refs.clone();
+        // Bind only the fields this signer's address expression reads.
+        let addr_tokens = quote! { #addr_expr };
+        let refs = account_fields
+            .iter()
+            .filter(|ident| crate::helpers::mentions_ident(&addr_tokens, ident))
+            .map(|ident| quote! { let #ident = &self.#ident; });
         let fallback = exit_call;
         exit_call = quote! {
             if #bhv::uses_exit_signer_arg::<{

--- a/derive/src/accounts/emit/typed_emit.rs
+++ b/derive/src/accounts/emit/typed_emit.rs
@@ -296,7 +296,7 @@ fn emit_behavior_args_builder(
     let exit_context = matches!(phase, BehaviorPhase::Exit);
     let path = &call.path;
     let bhv = quote! { <#path::Behavior as #krate::account_behavior::AccountBehavior<#field_ty>> };
-    let phase_const = emit_arg_phase_const(phase);
+    let phase_guard = emit_arg_phase_guard(phase);
     let inferred_accounts = inferable_accounts.iter().map(|account| {
         let key = account.to_string();
         quote! {
@@ -316,11 +316,8 @@ fn emit_behavior_args_builder(
             let key_lit = key.to_string();
             let val = emit_lowered_value(&arg.lowered, exit_context);
             quote! {
-                let __bhv_builder = if #krate::account_behavior::uses_arg::<
-                    #path::Behavior,
-                    #field_ty,
-                    { #phase_const },
-                    { #krate::account_behavior::behavior_arg_key_hash(#key_lit) },
+                let __bhv_builder = if #krate::account_behavior::#phase_guard::<
+                    __QuasarBhv, __QuasarBhvAcct, { #krate::account_behavior::key(#key_lit) },
                 >() {
                     __bhv_builder.#key(#val)
                 } else {
@@ -349,7 +346,22 @@ fn emit_behavior_args_builder(
         }
     };
 
+    // Every argument site in this block guards on the same behavior and the
+    // same account type. Naming the pair once keeps each site to one line and
+    // reports an unresolved behavior module here rather than once per argument.
+    // These stay concrete types, so the guard keeps the inference behaviour its
+    // `if` position exists to preserve.
+    let aliases = if call.args.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            type __QuasarBhv = #path::Behavior;
+            type __QuasarBhvAcct = #field_ty;
+        }
+    };
+
     quote! {
+        #aliases
         let __bhv_builder = #path::Args::builder();
         #(#setters)*
         // Bound check: the builder must implement the stable BehaviorArgsBuilder
@@ -360,19 +372,19 @@ fn emit_behavior_args_builder(
     }
 }
 
-fn emit_arg_phase_const(phase: BehaviorPhase) -> proc_macro2::TokenStream {
-    let krate = crate::krate::lang_path();
-    match phase {
-        BehaviorPhase::SetInitParam => {
-            quote! { #krate::account_behavior::ARG_PHASE_SET_INIT_PARAM }
-        }
-        BehaviorPhase::AfterInit => {
-            quote! { #krate::account_behavior::ARG_PHASE_AFTER_INIT }
-        }
-        BehaviorPhase::Check => quote! { #krate::account_behavior::ARG_PHASE_CHECK },
-        BehaviorPhase::Update => quote! { #krate::account_behavior::ARG_PHASE_UPDATE },
-        BehaviorPhase::Exit => quote! { #krate::account_behavior::ARG_PHASE_EXIT },
-    }
+/// The per-phase `uses_*_arg` guard for an argument site.
+///
+/// The phase is fixed when the site is emitted, so it rides in the function
+/// name instead of a `{ ARG_PHASE_* }` const-generic argument.
+fn emit_arg_phase_guard(phase: BehaviorPhase) -> syn::Ident {
+    let name = match phase {
+        BehaviorPhase::SetInitParam => "uses_set_init_param_arg",
+        BehaviorPhase::AfterInit => "uses_after_init_arg",
+        BehaviorPhase::Check => "uses_check_arg",
+        BehaviorPhase::Update => "uses_update_arg",
+        BehaviorPhase::Exit => "uses_exit_arg",
+    };
+    format_ident!("{}", name)
 }
 
 /// Emit a lowered behavior-arg value. `on_self` selects the receiver:

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -817,14 +817,19 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
         has_instruction_args,
     } = ctx;
 
-    let field_refs: Vec<proc_macro2::TokenStream> = plan
-        .fields
-        .iter()
-        .map(|fp| {
-            let field_name = &fp.ident;
-            quote! { let #field_name = &self.#field_name; }
-        })
-        .collect();
+    // Bind only the fields the address expression reads; binding all of them is
+    // what forced the `allow(unused_variables)` on these helpers.
+    let field_refs = |addr_expr: &syn::Expr| -> Vec<proc_macro2::TokenStream> {
+        let addr_tokens = quote! { #addr_expr };
+        plan.fields
+            .iter()
+            .filter(|fp| crate::helpers::mentions_ident(&addr_tokens, &fp.ident))
+            .map(|fp| {
+                let field_name = &fp.ident;
+                quote! { let #field_name = &self.#field_name; }
+            })
+            .collect()
+    };
 
     let signer_methods: Vec<proc_macro2::TokenStream> = plan
         .fields
@@ -835,6 +840,7 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
             let addr_expr = &signer_helper.addr_expr;
             let set_ty = &signer_helper.set_ty;
             let method_name = format_ident!("{}_signer", field_name);
+            let field_refs = field_refs(addr_expr);
             if has_instruction_args {
                 Some(quote! {
                     #[inline(always)]
@@ -856,7 +862,6 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
             } else {
                 Some(quote! {
                     #[inline(always)]
-                    #[allow(unused_variables)]
                     pub fn #method_name<'__quasar_seed>(
                         &'__quasar_seed self,
                         bumps: &'__quasar_seed #bumps_name,

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -131,7 +131,6 @@ pub(crate) fn derive_accounts_inner(input: proc_macro2::TokenStream) -> proc_mac
         parse_steps,
         count_expr,
         parse_body,
-        direct_parse_body,
     } = accounts_plan;
 
     // Instruction arg extraction: emitted ONCE as `Self::__extract_ix_args` and
@@ -207,7 +206,6 @@ pub(crate) fn derive_accounts_inner(input: proc_macro2::TokenStream) -> proc_mac
         needs_event_cpi_expr: emit_needs_event_cpi_expr(&typed_plan),
         parse_steps,
         parse_body,
-        direct_parse_body,
         bumps_struct,
         signer_helpers_impl,
         epilogue_method,
@@ -888,7 +886,6 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
             type Bumps = #bumps_name;
         }
 
-        impl #impl_generics #krate::traits::AccountGroup for #name #ty_generics #where_clause {}
     }
 }
 

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -760,7 +760,7 @@ fn emit_needs_event_cpi_expr(plan: &resolve::specs::AccountsPlanTyped) -> proc_m
         })
         .collect();
 
-    quote! { false #(|| #terms)* }
+    crate::helpers::or_bool_terms(terms)
 }
 
 struct SignerHelpersCtx<'a> {
@@ -839,10 +839,18 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
         })
         .collect();
 
-    quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
-            #(#signer_methods)*
+    let signer_methods_impl = if signer_methods.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            impl #impl_generics #name #ty_generics #where_clause {
+                #(#signer_methods)*
+            }
         }
+    };
+
+    quote! {
+        #signer_methods_impl
 
         impl #impl_generics #krate::traits::AccountBumps for #name #ty_generics #where_clause {
             type Bumps = #bumps_name;

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -213,9 +213,6 @@ pub(crate) fn derive_accounts_inner(input: proc_macro2::TokenStream) -> proc_mac
         client_macro,
         ix_arg_extraction: ix_arg_extraction_call,
         extract_ix_args_fn: ix_arg_extraction_fn,
-        assert_builder_fn: emit::typed_emit::emit_assert_builder_fn(
-            typed_plan.fields.iter().any(|fp| !fp.behaviors.is_empty()),
-        ),
     });
 
     quote::quote! {

--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -580,6 +580,9 @@ fn emit_idl_accounts_meta(
         .iter()
         .map(|fp| {
             let field_name = crate::helpers::snake_to_camel(&fp.ident.to_string());
+            if fp.kind == resolve::FieldKind::Composite {
+                return emit_idl_composite_entry(&field_name, &fp.effective_ty);
+            }
             let optional = fp.optional;
             let writable = fp.writable;
             let signer = emit_account_signer(fp);
@@ -622,14 +625,16 @@ fn emit_idl_accounts_meta(
             let node_docs = crate::helpers::docs_tokens_from_lines(&fp.docs);
 
             quote! {
-                #krate::idl_build::__reexport::IdlAccountNode {
-                    name: #krate::idl_build::s(#field_name),
-                    optional: #optional,
-                    writable: #krate::idl_build::__reexport::AccountFlag::Fixed(#writable),
-                    signer: #krate::idl_build::__reexport::AccountFlag::Fixed(#signer),
-                    resolver: #resolver_tokens,
-                    docs: #node_docs,
-                }
+                #krate::idl_build::AccountsMetaEntry::Node(
+                    #krate::idl_build::__reexport::IdlAccountNode {
+                        name: #krate::idl_build::s(#field_name),
+                        optional: #optional,
+                        writable: #krate::idl_build::__reexport::AccountFlag::Fixed(#writable),
+                        signer: #krate::idl_build::__reexport::AccountFlag::Fixed(#signer),
+                        resolver: #resolver_tokens,
+                        docs: #node_docs,
+                    }
+                )
             }
         })
         .collect();
@@ -643,6 +648,33 @@ fn emit_idl_accounts_meta(
                     #krate::idl_build::vec![#(#account_nodes),*],
                 )
             })
+        }
+    }
+}
+
+/// A composite field's IDL entry: a reference to the inner accounts struct's
+/// own fragment, which `build_idl` splices in. The derive cannot resolve the
+/// inner struct's fields itself, so the repeat count is left as a const
+/// expression over `AccountCount` and evaluated when the fragment runs.
+fn emit_idl_composite_entry(field_name: &str, ty: &Type) -> proc_macro2::TokenStream {
+    let krate = crate::krate::lang_path();
+    let inner_ty = crate::helpers::extract_generic_inner_type(ty, "AccountsArray").unwrap_or(ty);
+    let inner_name = crate::helpers::last_type_segment_name(inner_ty);
+    let inner = strip_generics(inner_ty).unwrap_or_else(|_| quote! { #inner_ty });
+    let outer = composite_event_ty(ty);
+
+    quote! {
+        #krate::idl_build::AccountsMetaEntry::Group {
+            field: #field_name,
+            accounts_struct: #inner_name,
+            repeat: {
+                let __inner = <#inner as #krate::traits::AccountCount>::COUNT;
+                if __inner == 0 {
+                    0
+                } else {
+                    <#outer as #krate::traits::AccountCount>::COUNT / __inner
+                }
+            },
         }
     }
 }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -30,7 +30,6 @@ pub fn generate_accounts_macro(
     generics: &syn::Generics,
     plan: &crate::accounts::resolve::specs::AccountsPlanTyped,
 ) -> TokenStream {
-    let krate = crate::krate::lang_path();
     let descriptors = describe_accounts(name, generics, plan);
     let macro_name = format_ident!("__{}_instruction", pascal_to_snake(&name.to_string()));
     let module_name = format_ident!("__{}_client_macro", pascal_to_snake(&name.to_string()));
@@ -67,6 +66,11 @@ pub fn generate_accounts_macro(
         })
         .collect();
 
+    let arms =
+        [(false, false), (true, false), (false, true), (true, true)].map(|(compact, remaining)| {
+            emit_macro_arm(compact, remaining, &account_fields, &accounts_build)
+        });
+
     quote! {
         #(#seed_input_aliases)*
 
@@ -76,130 +80,95 @@ pub fn generate_accounts_macro(
             #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
             #[macro_export]
             macro_rules! #macro_name {
-            ($struct_name:ident, [$($disc:expr),*], {$($arg_name:ident : $arg_ty:ty),*}) => {
-                pub struct $struct_name {
-                    #(#account_fields)*
-                    $(pub $arg_name: $arg_ty,)*
-                }
-
-                impl From<$struct_name> for #krate::client::Instruction {
-                    #[allow(unused_variables)]
-                    fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let accounts = #accounts_build;
-                        let data = {
-                            let mut _data = ::alloc::vec![$($disc),*];
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::SerializeArg>::serialize_arg(&ix.$arg_name)
-                                );
-                            )*
-                            _data
-                        };
-                        #krate::client::Instruction {
-                            program_id: $crate::ID,
-                            accounts,
-                            data,
-                        }
-                    }
-                }
-            };
-            ($struct_name:ident, [$($disc:expr),*], {$($arg_name:ident : $arg_ty:ty),*}, compact) => {
-                pub struct $struct_name {
-                    #(#account_fields)*
-                    $(pub $arg_name: $arg_ty,)*
-                }
-
-                impl From<$struct_name> for #krate::client::Instruction {
-                    #[allow(unused_variables)]
-                    fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let accounts = #accounts_build;
-                        let data = {
-                            let mut _data = ::alloc::vec![$($disc),*];
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_header(&ix.$arg_name)
-                                );
-                            )*
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_tail(&ix.$arg_name)
-                                );
-                            )*
-                            _data
-                        };
-                        #krate::client::Instruction {
-                            program_id: $crate::ID,
-                            accounts,
-                            data,
-                        }
-                    }
-                }
-            };
-            ($struct_name:ident, [$($disc:expr),*], {$($arg_name:ident : $arg_ty:ty),*}, remaining) => {
-                pub struct $struct_name {
-                    #(#account_fields)*
-                    $(pub $arg_name: $arg_ty,)*
-                    pub remaining_accounts: ::alloc::vec::Vec<#krate::client::AccountMeta>,
-                }
-
-                impl From<$struct_name> for #krate::client::Instruction {
-                    #[allow(unused_variables)]
-                    fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let mut accounts = #accounts_build;
-                        accounts.extend(ix.remaining_accounts);
-                        let data = {
-                            let mut _data = ::alloc::vec![$($disc),*];
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::SerializeArg>::serialize_arg(&ix.$arg_name)
-                                );
-                            )*
-                            _data
-                        };
-                        #krate::client::Instruction {
-                            program_id: $crate::ID,
-                            accounts,
-                            data,
-                        }
-                    }
-                }
-            };
-            ($struct_name:ident, [$($disc:expr),*], {$($arg_name:ident : $arg_ty:ty),*}, compact, remaining) => {
-                pub struct $struct_name {
-                    #(#account_fields)*
-                    $(pub $arg_name: $arg_ty,)*
-                    pub remaining_accounts: ::alloc::vec::Vec<#krate::client::AccountMeta>,
-                }
-
-                impl From<$struct_name> for #krate::client::Instruction {
-                    #[allow(unused_variables)]
-                    fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let mut accounts = #accounts_build;
-                        accounts.extend(ix.remaining_accounts);
-                        let data = {
-                            let mut _data = ::alloc::vec![$($disc),*];
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_header(&ix.$arg_name)
-                                );
-                            )*
-                            $(
-                                _data.extend_from_slice(
-                                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_tail(&ix.$arg_name)
-                                );
-                            )*
-                            _data
-                        };
-                        #krate::client::Instruction {
-                            program_id: $crate::ID,
-                            accounts,
-                            data,
-                        }
-                    }
-                }
-            };
+                #(#arms)*
             }
         }
+    }
+}
+
+/// One `macro_rules!` arm of a client instruction macro.
+///
+/// The four public arms differ only in whether trailing accounts join the
+/// struct and which serializer the args go through, so they are generated from
+/// the same body rather than written out four times.
+fn emit_macro_arm(
+    compact: bool,
+    remaining: bool,
+    account_fields: &[TokenStream],
+    accounts_build: &TokenStream,
+) -> TokenStream {
+    let krate = crate::krate::lang_path();
+
+    let mut selectors = TokenStream::new();
+    if compact {
+        selectors.extend(quote! { , compact });
+    }
+    if remaining {
+        selectors.extend(quote! { , remaining });
+    }
+
+    let (remaining_field, accounts_binding) = if remaining {
+        (
+            quote! {
+                pub remaining_accounts: ::alloc::vec::Vec<#krate::client::AccountMeta>,
+            },
+            quote! {
+                let mut accounts = #accounts_build;
+                accounts.extend(ix.remaining_accounts);
+            },
+        )
+    } else {
+        (quote! {}, quote! { let accounts = #accounts_build; })
+    };
+
+    let data = if compact {
+        quote! {
+            let mut _data = ::alloc::vec![$($disc),*];
+            $(
+                _data.extend_from_slice(
+                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_header(&ix.$arg_name)
+                );
+            )*
+            $(
+                _data.extend_from_slice(
+                    &<$arg_ty as #krate::client::CompactSerializeArg>::compact_tail(&ix.$arg_name)
+                );
+            )*
+            _data
+        }
+    } else {
+        quote! {
+            let mut _data = ::alloc::vec![$($disc),*];
+            $(
+                _data.extend_from_slice(
+                    &<$arg_ty as #krate::client::SerializeArg>::serialize_arg(&ix.$arg_name)
+                );
+            )*
+            _data
+        }
+    };
+
+    quote! {
+        ($struct_name:ident, [$($disc:expr),*], {$($arg_name:ident : $arg_ty:ty),*} #selectors) => {
+            pub struct $struct_name {
+                #(#account_fields)*
+                $(pub $arg_name: $arg_ty,)*
+                #remaining_field
+            }
+
+            impl From<$struct_name> for #krate::client::Instruction {
+                #[allow(unused_variables)]
+                fn from(ix: $struct_name) -> #krate::client::Instruction {
+                    #accounts_binding
+                    let data = { #data };
+                    #krate::client::Instruction {
+                        program_id: $crate::ID,
+                        accounts,
+                        data,
+                    }
+                }
+            }
+        };
     }
 }
 

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -32,7 +32,6 @@ pub fn generate_accounts_macro(
 ) -> TokenStream {
     let descriptors = describe_accounts(name, generics, plan);
     let macro_name = format_ident!("__{}_instruction", pascal_to_snake(&name.to_string()));
-    let module_name = format_ident!("__{}_client_macro", pascal_to_snake(&name.to_string()));
     // Two derived fields may share a stored-data seed root (a chained field
     // inherits its base's inputs); the input appears once, at first use.
     let mut seen_inputs: Vec<syn::Ident> = Vec::new();
@@ -76,12 +75,10 @@ pub fn generate_accounts_macro(
 
         #[doc(hidden)]
         #[allow(unexpected_cfgs)]
-        mod #module_name {
-            #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-            #[macro_export]
-            macro_rules! #macro_name {
-                #(#arms)*
-            }
+        #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+        #[macro_export]
+        macro_rules! #macro_name {
+            #(#arms)*
         }
     }
 }

--- a/derive/src/client_macro.rs
+++ b/derive/src/client_macro.rs
@@ -18,6 +18,11 @@ struct AccountDescriptor {
     /// Synthetic typed inputs replacing a derived field whose seeds read
     /// stored account data: `(input ident, definition-site type tokens)`.
     seed_inputs: Vec<(syn::Ident, TokenStream)>,
+    /// A composite field (`AccountsArray<..>` or a nested `#[account(group)]`
+    /// struct) flattens to `Inner::COUNT` accounts, not one. The derive only
+    /// sees the field's type, not the inner struct's plan, so the caller
+    /// supplies that account's metas and the client splices them in place.
+    composite: bool,
 }
 
 pub fn generate_accounts_macro(
@@ -46,7 +51,7 @@ pub fn generate_accounts_macro(
         .iter()
         .map(|descriptor| emit_account_field(name, descriptor))
         .collect();
-    let account_metas: Vec<_> = descriptors.iter().map(emit_account_meta).collect();
+    let accounts_build = emit_accounts_build(&descriptors);
     let seed_input_aliases: Vec<_> = descriptors
         .iter()
         .flat_map(|descriptor| {
@@ -80,9 +85,7 @@ pub fn generate_accounts_macro(
                 impl From<$struct_name> for #krate::client::Instruction {
                     #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let accounts = ::alloc::vec![
-                            #(#account_metas)*
-                        ];
+                        let accounts = #accounts_build;
                         let data = {
                             let mut _data = ::alloc::vec![$($disc),*];
                             $(
@@ -109,9 +112,7 @@ pub fn generate_accounts_macro(
                 impl From<$struct_name> for #krate::client::Instruction {
                     #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let accounts = ::alloc::vec![
-                            #(#account_metas)*
-                        ];
+                        let accounts = #accounts_build;
                         let data = {
                             let mut _data = ::alloc::vec![$($disc),*];
                             $(
@@ -144,9 +145,7 @@ pub fn generate_accounts_macro(
                 impl From<$struct_name> for #krate::client::Instruction {
                     #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let mut accounts = ::alloc::vec![
-                            #(#account_metas)*
-                        ];
+                        let mut accounts = #accounts_build;
                         accounts.extend(ix.remaining_accounts);
                         let data = {
                             let mut _data = ::alloc::vec![$($disc),*];
@@ -175,9 +174,7 @@ pub fn generate_accounts_macro(
                 impl From<$struct_name> for #krate::client::Instruction {
                     #[allow(unused_variables)]
                     fn from(ix: $struct_name) -> #krate::client::Instruction {
-                        let mut accounts = ::alloc::vec![
-                            #(#account_metas)*
-                        ];
+                        let mut accounts = #accounts_build;
                         accounts.extend(ix.remaining_accounts);
                         let data = {
                             let mut _data = ::alloc::vec![$($disc),*];
@@ -207,6 +204,13 @@ pub fn generate_accounts_macro(
 }
 
 fn emit_account_field(name: &syn::Ident, descriptor: &AccountDescriptor) -> TokenStream {
+    if descriptor.composite {
+        let krate = crate::krate::lang_path();
+        let ident = &descriptor.name;
+        return quote! {
+            pub #ident: ::alloc::vec::Vec<#krate::client::AccountMeta>,
+        };
+    }
     if descriptor.fixed_address.is_some() {
         // A derived field whose seeds read stored account data is replaced by
         // typed inputs carrying those values (via definition-site re-aliases,
@@ -243,11 +247,41 @@ fn emit_account_meta(descriptor: &AccountDescriptor) -> TokenStream {
     };
     if descriptor.writable {
         quote! {
-            #krate::client::AccountMeta::new(#address, #signer),
+            #krate::client::AccountMeta::new(#address, #signer)
         }
     } else {
         quote! {
-            #krate::client::AccountMeta::new_readonly(#address, #signer),
+            #krate::client::AccountMeta::new_readonly(#address, #signer)
+        }
+    }
+}
+
+/// The `accounts` vector for one instruction.
+///
+/// Without composites this stays the original `vec![..]` literal. With one, the
+/// list is built incrementally so a composite can splice in its own metas.
+fn emit_accounts_build(descriptors: &[AccountDescriptor]) -> TokenStream {
+    let krate = crate::krate::lang_path();
+    if !descriptors.iter().any(|d| d.composite) {
+        let metas = descriptors.iter().map(emit_account_meta);
+        return quote! { ::alloc::vec![ #(#metas,)* ] };
+    }
+
+    let steps = descriptors.iter().map(|descriptor| {
+        let ident = &descriptor.name;
+        if descriptor.composite {
+            quote! { __accounts.extend(ix.#ident); }
+        } else {
+            let meta = emit_account_meta(descriptor);
+            quote! { __accounts.push(#meta); }
+        }
+    });
+    quote! {
+        {
+            let mut __accounts: ::alloc::vec::Vec<#krate::client::AccountMeta> =
+                ::alloc::vec::Vec::new();
+            #(#steps)*
+            __accounts
         }
     }
 }
@@ -307,6 +341,7 @@ fn describe_accounts(
                 },
                 fixed_address,
                 seed_inputs,
+                composite: fp.kind == crate::accounts::resolve::FieldKind::Composite,
             }
         })
         .collect()

--- a/derive/src/declare_program.rs
+++ b/derive/src/declare_program.rs
@@ -246,6 +246,18 @@ fn map_idl_type(ty: &IdlType, type_sizes: &HashMap<String, usize>) -> Result<Typ
     }
 }
 
+/// The destination pointer for a write at `offset` into the CPI data buffer.
+///
+/// Offset zero is the buffer base, so naming `__ptr` directly keeps the
+/// generated write from reading as though it were displaced.
+fn data_ptr_at(offset: usize) -> TokenStream2 {
+    if offset == 0 {
+        quote! { __ptr }
+    } else {
+        quote! { __ptr.add(#offset) }
+    }
+}
+
 /// Generate the data write block for instruction args, flattening struct fields
 /// recursively into a packed byte buffer.
 fn generate_data_write(
@@ -259,8 +271,9 @@ fn generate_data_write(
 
     for (i, &byte) in disc.iter().enumerate() {
         let byte_lit = proc_macro2::Literal::u8_suffixed(byte);
+        let dst = data_ptr_at(i);
         write_stmts.push(quote! {
-            core::ptr::write(__ptr.add(#i), #byte_lit);
+            core::ptr::write(#dst, #byte_lit);
         });
     }
 
@@ -308,23 +321,24 @@ fn emit_field_write(
             let next_offset = field_offset
                 .checked_add(size)
                 .ok_or_else(|| "CPI instruction data size overflows usize".to_string())?;
+            let dst = data_ptr_at(field_offset);
             if p == "pubkey" {
                 stmts.push(quote! {
                     core::ptr::copy_nonoverlapping(
                         #access.as_ref().as_ptr(),
-                        __ptr.add(#field_offset),
+                        #dst,
                         #size,
                     );
                 });
             } else if size == 1 {
                 stmts.push(quote! {
-                    core::ptr::write(__ptr.add(#field_offset), #access as u8);
+                    core::ptr::write(#dst, #access as u8);
                 });
             } else {
                 stmts.push(quote! {
                     core::ptr::copy_nonoverlapping(
                         #access.to_le_bytes().as_ptr(),
-                        __ptr.add(#field_offset),
+                        #dst,
                         #size,
                     );
                 });

--- a/derive/src/event.rs
+++ b/derive/src/event.rs
@@ -83,9 +83,12 @@ pub(crate) fn event_inner(attr: TokenStream2, item: TokenStream2) -> TokenStream
                 // SAFETY: `write_log_disc` initialized the discriminator bytes
                 // and returned the payload offset. The remaining `#data_size`
                 // bytes fit exactly in the buffer.
-                <Self as #krate::traits::Event>::write_data(self, unsafe {
-                    core::slice::from_raw_parts_mut(ptr.add(data_offset), #data_size)
-                });
+                unsafe {
+                    <Self as #krate::traits::Event>::write_data(
+                        self,
+                        core::slice::from_raw_parts_mut(ptr.add(data_offset), #data_size),
+                    );
+                }
                 // SAFETY: Discriminator and payload bytes were initialized
                 // above before exposing the full buffer as a slice.
                 #krate::log::log_data(&[unsafe { buf.assume_init_ref() }]);
@@ -173,10 +176,10 @@ pub(crate) fn event_inner(attr: TokenStream2, item: TokenStream2) -> TokenStream
             const DATA_SIZE: usize = #data_size;
 
             #[inline(always)]
-            fn write_data(&self, buf: &mut [u8]) {
+            unsafe fn write_data(&self, buf: &mut [u8]) {
                 // SAFETY: The compile-time size assertion above proves `Self`
-                // has exactly `DATA_SIZE` bytes with no padding, and callers
-                // pass a buffer of that length.
+                // has exactly `DATA_SIZE` bytes with no padding, and the
+                // caller guarantees `buf` holds at least that many.
                 unsafe {
                     core::ptr::copy_nonoverlapping(
                         self as *const Self as *const u8,
@@ -203,12 +206,12 @@ pub(crate) fn event_inner(attr: TokenStream2, item: TokenStream2) -> TokenStream
                 // SAFETY: `write_cpi_disc` initialized the prefix bytes and
                 // returned the payload offset. The remaining `__DATA_SIZE`
                 // bytes fit exactly in the buffer.
-                self.write_data(unsafe {
-                    core::slice::from_raw_parts_mut(
+                unsafe {
+                    self.write_data(core::slice::from_raw_parts_mut(
                         ptr.add(data_offset),
                         __DATA_SIZE,
-                    )
-                });
+                    ));
+                }
 
                 // SAFETY: Prefix and payload bytes were initialized above.
                 f(unsafe { buf.assume_init_ref() })

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -23,6 +23,25 @@ fn duplicate_arg_error(ident: &Ident) -> syn::Error {
     syn::Error::new(ident.span(), format!("duplicate `{ident}`"))
 }
 
+/// Join const-evaluable `bool` terms into one `||` chain, folding literals away
+/// so the emitted const reads `true` rather than `false || true`.
+pub(crate) fn or_bool_terms(
+    terms: impl IntoIterator<Item = proc_macro2::TokenStream>,
+) -> proc_macro2::TokenStream {
+    let mut kept = Vec::new();
+    for term in terms {
+        match term.to_string().as_str() {
+            "true" => return quote! { true },
+            "false" => {}
+            _ => kept.push(term),
+        }
+    }
+    if kept.is_empty() {
+        return quote! { false };
+    }
+    quote! { #(#kept)||* }
+}
+
 /// Parse `#[max(N)]` or `#[max(N, pfx = P)]` from an attribute list.
 pub(crate) fn parse_max_attr(attrs: &[syn::Attribute]) -> Option<syn::Result<(usize, usize)>> {
     for attr in attrs {

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -23,6 +23,18 @@ fn duplicate_arg_error(ident: &Ident) -> syn::Error {
     syn::Error::new(ident.span(), format!("duplicate `{ident}`"))
 }
 
+/// Whether `tokens` mention `ident` anywhere, including inside groups.
+///
+/// Used to bind only the account fields an emitted expression actually reads,
+/// instead of every field in the struct.
+pub(crate) fn mentions_ident(tokens: &proc_macro2::TokenStream, ident: &Ident) -> bool {
+    tokens.clone().into_iter().any(|tree| match tree {
+        proc_macro2::TokenTree::Ident(found) => found == *ident,
+        proc_macro2::TokenTree::Group(group) => mentions_ident(&group.stream(), ident),
+        _ => false,
+    })
+}
+
 /// Join const-evaluable `bool` terms into one `||` chain, folding literals away
 /// so the emitted const reads `true` rather than `false || true`.
 pub(crate) fn or_bool_terms(

--- a/derive/src/helpers.rs
+++ b/derive/src/helpers.rs
@@ -1,5 +1,21 @@
 use heck::{ToLowerCamelCase, ToSnakeCase, ToUpperCamelCase};
 
+/// An identifier for a binding that only generated code may see.
+///
+/// `Span::mixed_site()` gives the binding definition-site hygiene, so it is
+/// visible to the rest of this expansion and to nothing else. A field or local
+/// in the user's crate that happens to share the name can no longer capture it
+/// or be captured by it — the compiler enforces what the `__` prefix could only
+/// suggest.
+///
+/// Only for names the user never writes. Anything that deliberately crosses the
+/// macro boundary — a field name the user's own expressions refer to, the
+/// `__quasar_pda_*` helpers, the client macro's parameters — must keep
+/// call-site hygiene or the reference stops resolving.
+pub(crate) fn internal_ident(name: &str) -> syn::Ident {
+    syn::Ident::new(name, proc_macro2::Span::mixed_site())
+}
+
 pub(crate) fn pascal_to_snake(value: &str) -> String {
     value.to_snake_case()
 }

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -512,29 +512,34 @@ pub(crate) fn instruction_inner(attr: TokenStream2, item: TokenStream2) -> Token
                 let __program_id_addr = unsafe {
                     &*(__program_id as *const [u8; 32] as *const #krate::prelude::Address)
                 };
-                let mut __buf = core::mem::MaybeUninit::<
-                    [#krate::__internal::AccountView;
-                        <#accounts_ty as #krate::traits::AccountCount>::COUNT]
-                >::uninit();
-                // SAFETY: dispatch checked the runtime account count against
-                // COUNT before reaching this arm.
-                let _ = unsafe {
-                    <#accounts_ty as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
-                        __accounts_start,
-                        __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
-                        0usize,
-                        __program_id_addr,
-                    )?
-                };
-                // SAFETY: `parse_accounts_raw` initialized every slot before
-                // returning `Ok`.
-                let mut __accounts_buf = unsafe { __buf.assume_init() };
-                let (__accounts, __bumps) = unsafe {
-                    <#accounts_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                        &mut __accounts_buf,
-                        __ix_data,
-                        __program_id_addr,
-                    )?
+                // The view buffer is scoped to the parse: the account wrappers
+                // hold raw views rather than borrowing it, so keeping it alive
+                // across the handler call would only pin stack.
+                let (__accounts, __bumps) = {
+                    let mut __buf = core::mem::MaybeUninit::<
+                        [#krate::__internal::AccountView;
+                            <#accounts_ty as #krate::traits::AccountCount>::COUNT]
+                    >::uninit();
+                    // SAFETY: dispatch checked the runtime account count against
+                    // COUNT before reaching this arm.
+                    let _ = unsafe {
+                        <#accounts_ty as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
+                            __accounts_start,
+                            __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
+                            0usize,
+                            __program_id_addr,
+                        )?
+                    };
+                    // SAFETY: `parse_accounts_raw` initialized every slot before
+                    // returning `Ok`.
+                    let mut __accounts_buf = unsafe { __buf.assume_init() };
+                    unsafe {
+                        <#accounts_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                            &mut __accounts_buf,
+                            __ix_data,
+                            __program_id_addr,
+                        )?
+                    }
                 };
                 #body_fn_name(#krate::context::Ctx {
                     accounts: __accounts,

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -503,7 +503,10 @@ pub(crate) fn instruction_inner(attr: TokenStream2, item: TokenStream2) -> Token
     } else {
         let direct_name = format_ident!("__quasar_direct_{}", fn_name);
         quote! {
-            #[inline(always)]
+            // `inline`, not `inline(always)`: forcing the parse into `__dispatch`
+            // spills registers. Letting the inliner pick per call site measured
+            // cheaper on every escrow instruction and 808 bytes smaller.
+            #[inline]
             fn #direct_name(
                 __program_id: &[u8; 32],
                 __accounts_start: *mut u8,
@@ -531,11 +534,14 @@ pub(crate) fn instruction_inner(attr: TokenStream2, item: TokenStream2) -> Token
                         )?
                     };
                     // SAFETY: `parse_accounts_raw` initialized every slot before
-                    // returning `Ok`.
-                    let mut __accounts_buf = unsafe { __buf.assume_init() };
+                    // returning `Ok`. Referencing the array in place keeps
+                    // its length static and avoids moving it out.
+                    let __accounts_buf = unsafe {
+                        &mut *__buf.as_mut_ptr()
+                    };
                     unsafe {
                         <#accounts_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                            &mut __accounts_buf,
+                            __accounts_buf,
                             __ix_data,
                             __program_id_addr,
                         )?

--- a/derive/src/instruction.rs
+++ b/derive/src/instruction.rs
@@ -512,9 +512,26 @@ pub(crate) fn instruction_inner(attr: TokenStream2, item: TokenStream2) -> Token
                 let __program_id_addr = unsafe {
                     &*(__program_id as *const [u8; 32] as *const #krate::prelude::Address)
                 };
-                let (__accounts, __bumps) = unsafe {
-                    <#accounts_ty>::parse_direct_with_instruction_data_unchecked(
+                let mut __buf = core::mem::MaybeUninit::<
+                    [#krate::__internal::AccountView;
+                        <#accounts_ty as #krate::traits::AccountCount>::COUNT]
+                >::uninit();
+                // SAFETY: dispatch checked the runtime account count against
+                // COUNT before reaching this arm.
+                let _ = unsafe {
+                    <#accounts_ty as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
                         __accounts_start,
+                        __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
+                        0usize,
+                        __program_id_addr,
+                    )?
+                };
+                // SAFETY: `parse_accounts_raw` initialized every slot before
+                // returning `Ok`.
+                let mut __accounts_buf = unsafe { __buf.assume_init() };
+                let (__accounts, __bumps) = unsafe {
+                    <#accounts_ty as #krate::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                        &mut __accounts_buf,
                         __ix_data,
                         __program_id_addr,
                     )?

--- a/derive/src/program/dispatch.rs
+++ b/derive/src/program/dispatch.rs
@@ -184,9 +184,10 @@ fn guarded_match_arm(spec: &InstructionSpec, any_heap: bool, disc_len: usize) ->
             let __remaining_ptr = unsafe {
                 // SAFETY: the account count check above guarantees the
                 // fixed account parser has enough records to read.
-                <#accounts_type>::parse_accounts(
+                <#accounts_type as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
                     __accounts_start,
-                    &mut __buf,
+                    __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
+                    0usize,
                     unsafe {
                         // SAFETY: Address is represented by the same 32-byte
                         // value as the ABI program id.
@@ -195,12 +196,12 @@ fn guarded_match_arm(spec: &InstructionSpec, any_heap: bool, disc_len: usize) ->
                 )?
             };
             let mut __accounts = unsafe {
-                // SAFETY: `parse_accounts` initialized exactly COUNT slots
+                // SAFETY: `parse_accounts_raw` initialized exactly COUNT slots
                 // before returning `Ok`.
                 __buf.assume_init()
             };
             let __data_after_disc = #data_after_disc;
-            // SAFETY: `parse_accounts` returned the remaining-region
+            // SAFETY: `parse_accounts_raw` returned the remaining-region
             // pointer for this SVM buffer, and the ABI places the
             // instruction-data length prefix directly before
             // `instruction_data`, giving the accounts boundary.

--- a/derive/src/program/dispatch.rs
+++ b/derive/src/program/dispatch.rs
@@ -370,13 +370,15 @@ fn emit_event_dispatch_block(model: &ProgramModel) -> TokenStream2 {
             .iter()
             .map(|spec| &spec.accounts_type)
             .collect();
+        let needs_event_cpi = crate::helpers::or_bool_terms(accounts_types.iter().map(|ty| {
+            quote! { <#ty as #krate::traits::AccountCount>::NEEDS_EVENT_CPI }
+        }));
         // Small dispatch tables compile smaller with the explicit 0xFF
         // invalid-instruction fast path. Larger tables benefit from
         // erasing it unless an account set can actually service event CPI.
         if instruction_specs.len() >= EVENT_FASTPATH_MIN_IX {
             quote! {
-                const __QUASAR_NEEDS_EVENT_CPI: bool =
-                    false #(|| <#accounts_types as #krate::traits::AccountCount>::NEEDS_EVENT_CPI)*;
+                const __QUASAR_NEEDS_EVENT_CPI: bool = #needs_event_cpi;
                 if __QUASAR_NEEDS_EVENT_CPI {
                     if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
                         return __handle_event(ptr, instruction_data);
@@ -385,8 +387,7 @@ fn emit_event_dispatch_block(model: &ProgramModel) -> TokenStream2 {
             }
         } else {
             quote! {
-                const __QUASAR_NEEDS_EVENT_CPI: bool =
-                    false #(|| <#accounts_types as #krate::traits::AccountCount>::NEEDS_EVENT_CPI)*;
+                const __QUASAR_NEEDS_EVENT_CPI: bool = #needs_event_cpi;
                 if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
                     if __QUASAR_NEEDS_EVENT_CPI {
                         return __handle_event(ptr, instruction_data);

--- a/derive/src/program/dispatch.rs
+++ b/derive/src/program/dispatch.rs
@@ -176,45 +176,41 @@ fn guarded_match_arm(spec: &InstructionSpec, any_heap: bool, disc_len: usize) ->
         }
     };
 
+    // Statements only: every use site already supplies a block, so wrapping
+    // these in braces here would nest one inside another.
     let buffered_body = quote! {
-        {
-            let mut __buf = core::mem::MaybeUninit::<
-                [#krate::__internal::AccountView; <#accounts_type as #krate::traits::AccountCount>::COUNT]
-            >::uninit();
-            let __remaining_ptr = unsafe {
-                // SAFETY: the account count check above guarantees the
-                // fixed account parser has enough records to read.
-                <#accounts_type as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
-                    __accounts_start,
-                    __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
-                    0usize,
-                    unsafe {
-                        // SAFETY: Address is represented by the same 32-byte
-                        // value as the ABI program id.
-                        &*(__program_id as *const [u8; 32] as *const #krate::prelude::Address)
-                    },
-                )?
-            };
-            let mut __accounts = unsafe {
-                // SAFETY: `parse_accounts_raw` initialized exactly COUNT slots
-                // before returning `Ok`.
-                __buf.assume_init()
-            };
-            let __data_after_disc = #data_after_disc;
-            // SAFETY: `parse_accounts_raw` returned the remaining-region
-            // pointer for this SVM buffer, and the ABI places the
-            // instruction-data length prefix directly before
-            // `instruction_data`, giving the accounts boundary.
-            #fn_name(unsafe {
-                #krate::context::Context::from_raw_parts(
-                    __program_id,
-                    &mut __accounts,
-                    __data_after_disc,
-                    __remaining_ptr,
-                    instruction_data.as_ptr().sub(__U64_SIZE),
-                )
-            })
-        }
+        let mut __buf = core::mem::MaybeUninit::<
+            [#krate::__internal::AccountView; <#accounts_type as #krate::traits::AccountCount>::COUNT]
+        >::uninit();
+        let __remaining_ptr = unsafe {
+            // SAFETY: the account count check above guarantees the
+            // fixed account parser has enough records to read.
+            <#accounts_type as #krate::traits::ParseAccountsRaw>::parse_accounts_raw(
+                __accounts_start,
+                __buf.as_mut_ptr() as *mut #krate::__internal::AccountView,
+                0usize,
+                __program_id_addr,
+            )?
+        };
+        let mut __accounts = unsafe {
+            // SAFETY: `parse_accounts_raw` initialized exactly COUNT slots
+            // before returning `Ok`.
+            __buf.assume_init()
+        };
+        let __data_after_disc = #data_after_disc;
+        // SAFETY: `parse_accounts_raw` returned the remaining-region
+        // pointer for this SVM buffer, and the ABI places the
+        // instruction-data length prefix directly before
+        // `instruction_data`, giving the accounts boundary.
+        #fn_name(unsafe {
+            #krate::context::Context::from_raw_parts(
+                __program_id,
+                &mut __accounts,
+                __data_after_disc,
+                __remaining_ptr,
+                instruction_data.as_ptr().sub(__U64_SIZE),
+            )
+        })
     };
 
     let body = if spec.has_remaining {
@@ -428,6 +424,13 @@ fn emit_normal_dispatch_tail(model: &ProgramModel) -> TokenStream2 {
                 // SAFETY: the Solana entrypoint ABI stores the program
                 // id immediately after the instruction data slice.
                 &*(instruction_data.as_ptr().add(instruction_data.len()) as *const [u8; 32])
+            };
+            // Named once here rather than per arm: every buffered arm needs the
+            // same view, and the cast is a no-op on the same 32 bytes.
+            let __program_id_addr: &#krate::prelude::Address = unsafe {
+                // SAFETY: Address is represented by the same 32-byte value as
+                // the ABI program id.
+                &*(__program_id as *const [u8; 32] as *const #krate::prelude::Address)
             };
             const __U64_SIZE: usize = core::mem::size_of::<u64>();
             let __num_accounts = unsafe {

--- a/derive/src/program/mod.rs
+++ b/derive/src/program/mod.rs
@@ -75,10 +75,13 @@ pub(crate) fn program_inner(attr: TokenStream2, item: TokenStream2) -> TokenStre
 
     let program_type = event_authority::emit_program_type(&program_type_name);
 
-    // Suppress dead_code warnings on the user's #[program] module.
-    // Instruction handlers and account structs inside it are only referenced
-    // from macro-generated dispatch code, which the compiler can't see.
-    module.attrs.push(syn::parse_quote!(#[allow(dead_code)]));
+    // On host builds the entrypoint is cfg'd out, so `__dispatch` is unreachable
+    // and every handler under it reads as dead. Suppress there only: an SBF
+    // build has a live entrypoint, so dead code in the user's module is real
+    // and worth reporting.
+    module.attrs.push(syn::parse_quote!(
+        #[cfg_attr(not(any(target_arch = "bpf", target_os = "solana")), allow(dead_code))]
+    ));
 
     let idl = idl::emit_idl(&model, &mod_name);
 
@@ -88,11 +91,10 @@ pub(crate) fn program_inner(attr: TokenStream2, item: TokenStream2) -> TokenStre
         #module
 
         #[allow(unexpected_cfgs)]
-        #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-        extern crate alloc;
-
-        #[allow(unexpected_cfgs)]
-        #[cfg(all(any(target_os = "solana", target_arch = "bpf"), feature = "alloc"))]
+        #[cfg(any(
+            not(any(target_arch = "bpf", target_os = "solana")),
+            feature = "alloc"
+        ))]
         extern crate alloc;
 
         #[allow(unexpected_cfgs)]

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -235,9 +235,17 @@ pub(crate) fn generate_seeds_impl(
         quote! { _lt: core::marker::PhantomData, }
     };
 
+    // `HasSeeds::HAS_SEED_PREFIX` already defaults to true, so only a prefixless
+    // PDA has anything to say here.
+    let has_prefix_const = if has_prefix {
+        quote! {}
+    } else {
+        quote! { const HAS_SEED_PREFIX: bool = false; }
+    };
+
     quote! {
         impl #impl_generics #krate::traits::HasSeeds for #name #ty_generics #where_clause {
-            const HAS_SEED_PREFIX: bool = #has_prefix;
+            #has_prefix_const
             const SEED_PREFIX: &'static [u8] = &[#(#prefix_bytes),*];
             const SEED_DYNAMIC_COUNT: usize = #dynamic_count;
             type WithBump<'__quasar_seed> = #seed_set_bump<'__quasar_seed>;

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -219,10 +219,6 @@ pub(crate) fn generate_seeds_impl(
         .iter()
         .map(|expr| quote! { #krate::cpi::Seed::from(#expr) })
         .collect();
-    let signer_seed_exprs_bump: Vec<_> = slice_exprs_bump
-        .iter()
-        .map(|expr| quote! { #krate::cpi::Seed::from(#expr) })
-        .collect();
 
     let has_address_param = seeds_attr
         .params
@@ -333,7 +329,7 @@ pub(crate) fn generate_seeds_impl(
             where
                 F: FnOnce(&[#krate::cpi::Signer<'_, '_>]) -> R,
             {
-                let seeds = [#(#signer_seed_exprs_bump),*];
+                let seeds = self.signer_seeds();
                 let signer = #krate::cpi::Signer::from(&seeds);
                 f(core::slice::from_ref(&signer))
             }
@@ -415,15 +411,15 @@ pub(crate) fn generate_seeds_impl(
                 Ok(self._bump[0])
             }
 
+            /// The set already carries its bump, so `_bump` is ignored and the
+            /// stored one is used.
             #[inline(always)]
             fn with_signer_seeds<R>(
                 &self,
                 _bump: &[u8],
                 f: impl FnOnce(&[#krate::cpi::Signer<'_, '_>]) -> R,
             ) -> R {
-                let seeds = [#(#signer_seed_exprs_bump),*];
-                let signer = #krate::cpi::Signer::from(&seeds);
-                f(core::slice::from_ref(&signer))
+                #krate::cpi::CpiSignerSeeds::with_signers(self, f)
             }
         }
     }

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -319,7 +319,7 @@ pub(crate) fn generate_seeds_impl(
             /// construction cost once.
             #[inline(always)]
             pub fn signer_seeds(&self) -> [#krate::cpi::Seed<'_>; #n_slices_with_bump] {
-                [ #( #krate::cpi::Seed::from(#slice_exprs_bump) ),* ]
+                self.as_slices().map(#krate::cpi::Seed::from)
             }
         }
 

--- a/derive/src/seeds.rs
+++ b/derive/src/seeds.rs
@@ -411,8 +411,7 @@ pub(crate) fn generate_seeds_impl(
                 Ok(self._bump[0])
             }
 
-            /// The set already carries its bump, so `_bump` is ignored and the
-            /// stored one is used.
+            // The set carries its own bump; `_bump` is ignored.
             #[inline(always)]
             fn with_signer_seeds<R>(
                 &self,

--- a/derive/src/serialize.rs
+++ b/derive/src/serialize.rs
@@ -117,7 +117,7 @@ fn derive_fixed(input: DeriveInput, fields: Vec<Field>) -> TokenStream2 {
         .zip(canonical_field_types.iter())
         .map(|(name, ty)| {
             quote! {
-                #name: <#ty as #krate::instruction_arg::InstructionArg>::from_zc(&pod.#name)
+                #name: <#ty as #krate::instruction_arg::InstructionArg>::from_zc(&zc.#name)
             }
         })
         .collect();
@@ -253,7 +253,6 @@ fn derive_fixed(input: DeriveInput, fields: Vec<Field>) -> TokenStream2 {
 
             #[inline(always)]
             fn from_zc(zc: &Self::Zc) -> Self {
-                let pod = zc;
                 Self {
                     #(#from_zc_fields,)*
                 }

--- a/derive/src/snapshot_tests.rs
+++ b/derive/src/snapshot_tests.rs
@@ -308,6 +308,64 @@ fn program_dispatch_two_ix() {
         .assert_eq(&expand_pretty(program_inner(attr, item)));
 }
 
+/// Raw instructions on contiguous 1-byte discriminators: the `callx`
+/// function-pointer table, the shared raw account walk, and the normal
+/// discriminator match living alongside it.
+#[test]
+fn program_dispatch_raw_table() {
+    let attr = quote! {};
+    let item = quote! {
+        mod quasar_raw_demo {
+            use super::*;
+
+            #[instruction(discriminator = 0)]
+            pub fn normal(ctx: Ctx<NormalInit>) -> Result<(), ProgramError> {
+                ctx.accounts.handler()
+            }
+
+            #[instruction(discriminator = 1, raw)]
+            pub fn raw_one(ctx: Context) -> Result<(), ProgramError> {
+                let _ = ctx.data;
+                Ok(())
+            }
+
+            #[instruction(discriminator = 2, raw)]
+            pub fn raw_two(ctx: Context) -> Result<(), ProgramError> {
+                let _ = ctx.data;
+                Ok(())
+            }
+        }
+    };
+    expect_test::expect_file!["expansions/program_dispatch_raw_table.rs"]
+        .assert_eq(&expand_pretty(program_inner(attr, item)));
+}
+
+/// Raw instructions on non-contiguous discriminators, which cannot use the
+/// jump table and fall back to the guarded match chain.
+#[test]
+fn program_dispatch_raw_match_fallback() {
+    let attr = quote! {};
+    let item = quote! {
+        mod quasar_raw_gap_demo {
+            use super::*;
+
+            #[instruction(discriminator = 1, raw)]
+            pub fn raw_one(ctx: Context) -> Result<(), ProgramError> {
+                let _ = ctx.data;
+                Ok(())
+            }
+
+            #[instruction(discriminator = 7, raw)]
+            pub fn raw_seven(ctx: Context) -> Result<(), ProgramError> {
+                let _ = ctx.data;
+                Ok(())
+            }
+        }
+    };
+    expect_test::expect_file!["expansions/program_dispatch_raw_match_fallback.rs"]
+        .assert_eq(&expand_pretty(program_inner(attr, item)));
+}
+
 // ---------------------------------------------------------------------------
 // #[account] type macro.
 // ---------------------------------------------------------------------------

--- a/derive/tests/account_meta_signers.rs
+++ b/derive/tests/account_meta_signers.rs
@@ -55,7 +55,8 @@ struct InitTokenAccount {
 // the `#[program]` module); this mirror gives its `super::` paths the same
 // shape.
 mod cpi {
-    use super::*;
+    // No `use super::*`: these fixtures have no stored-data seed inputs, which
+    // are the only thing the generated struct names unqualified.
 
     __init_associated_token_instruction!(InitAssociatedTokenInstruction, [0], {});
     __init_token_account_instruction!(InitTokenAccountInstruction, [1], {});

--- a/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
@@ -63,17 +63,14 @@ impl ::quasar_lang::traits::Owner for DynamicAccount {
     const OWNER: ::quasar_lang::prelude::Address = crate::ID;
 }
 impl ::quasar_lang::traits::Space for DynamicAccount {
-    const SPACE: usize = 1usize
-        + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
+    const SPACE: usize = Self::MIN_SPACE;
 }
 impl DynamicAccount {
     #[inline(always)]
     fn __quasar_check_data(
         __data: &[u8],
     ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        let __min = 1usize
-            + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
-        if __data.len() < __min {
+        if __data.len() < Self::MIN_SPACE {
             return Err(
                 ::quasar_lang::__solana_program_error::ProgramError::AccountDataTooSmall,
             );
@@ -186,9 +183,7 @@ impl<'a> DynamicAccountCompactMut<'a> {
                 * core::mem::size_of::<
                     <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,
                 >();
-        let __new_total = 1usize
-            + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE
-            + __tail_size;
+        let __new_total = DynamicAccount::MIN_SPACE + __tail_size;
         let __old_total = self.__view.data_len();
         if __new_total != __old_total {
             ::quasar_lang::accounts::account::realloc_account(
@@ -350,9 +345,7 @@ impl<'a> DynamicAccountCompactWriter<'a> {
         let tags = self
             .__tags
             .ok_or(::quasar_lang::error::QuasarError::CompactWriterFieldNotSet)?;
-        let __new_total = 1usize
-            + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE
-            + name.len()
+        let __new_total = DynamicAccount::MIN_SPACE + name.len()
             + tags.len()
                 * core::mem::size_of::<
                     <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,

--- a/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
@@ -225,27 +225,7 @@ impl<'a> DynamicAccountCompactMut<'a> {
         Ok(())
     }
     pub fn reload(&mut self) {
-        let (name, tags) = {
-            let __data = unsafe { self.__view.borrow_unchecked() };
-            let __r = unsafe {
-                __dynamic_account_zc::__SchemaRef::new_unchecked(
-                    __data.get_unchecked(1usize..),
-                )
-            };
-            let mut name = ::quasar_lang::pod::PodString::<8, 1usize>::default();
-            if !name.set(__r.name()) {
-                ::quasar_lang::abort_program();
-            }
-            let mut tags = ::quasar_lang::pod::PodVec::<
-                <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,
-                2,
-                2usize,
-            >::default();
-            if !tags.set_from_slice(__r.tags()) {
-                ::quasar_lang::abort_program();
-            }
-            (name, tags)
-        };
+        let (name, tags) = DynamicAccount::__snapshot_dynamic(self.__view);
         self.name = name;
         self.tags = tags;
     }
@@ -258,32 +238,46 @@ impl<'a> Drop for DynamicAccountCompactMut<'a> {
     }
 }
 impl DynamicAccount {
+    /// Read every dynamic field out of the compact tail into owned
+    /// caches. Shared by `as_mut` and the guard's `reload`, which each
+    /// need the identical read.
+    #[inline(always)]
+    fn __snapshot_dynamic(
+        __view: &::quasar_lang::__internal::AccountView,
+    ) -> (
+        ::quasar_lang::pod::PodString<8, 1usize>,
+        ::quasar_lang::pod::PodVec<
+            <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,
+            2,
+            2usize,
+        >,
+    ) {
+        let __data = unsafe { __view.borrow_unchecked() };
+        let __r = unsafe {
+            __dynamic_account_zc::__SchemaRef::new_unchecked(
+                __data.get_unchecked(1usize..),
+            )
+        };
+        let mut name = ::quasar_lang::pod::PodString::<8, 1usize>::default();
+        if !name.set(__r.name()) {
+            ::quasar_lang::abort_program();
+        }
+        let mut tags = ::quasar_lang::pod::PodVec::<
+            <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,
+            2,
+            2usize,
+        >::default();
+        if !tags.set_from_slice(__r.tags()) {
+            ::quasar_lang::abort_program();
+        }
+        (name, tags)
+    }
     #[inline(always)]
     pub fn as_mut<'a>(
         &'a mut self,
         payer: &'a ::quasar_lang::__internal::AccountView,
     ) -> DynamicAccountCompactMut<'a> {
-        let (name, tags) = {
-            let __data = unsafe { self.__view.borrow_unchecked() };
-            let __r = unsafe {
-                __dynamic_account_zc::__SchemaRef::new_unchecked(
-                    __data.get_unchecked(1usize..),
-                )
-            };
-            let mut name = ::quasar_lang::pod::PodString::<8, 1usize>::default();
-            if !name.set(__r.name()) {
-                ::quasar_lang::abort_program();
-            }
-            let mut tags = ::quasar_lang::pod::PodVec::<
-                <Address as ::quasar_lang::instruction_arg::InstructionArg>::Zc,
-                2,
-                2usize,
-            >::default();
-            if !tags.set_from_slice(__r.tags()) {
-                ::quasar_lang::abort_program();
-            }
-            (name, tags)
-        };
+        let (name, tags) = Self::__snapshot_dynamic(&self.__view);
         let __view = unsafe {
             &mut *(&mut self.__view as *mut ::quasar_lang::__internal::AccountView)
         };

--- a/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
@@ -67,8 +67,6 @@ impl ::quasar_lang::traits::Space for DynamicAccount {
         + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
 }
 impl DynamicAccount {
-    /// The discriminator and compact-layout checks, over data borrowed
-    /// by whichever of the two entry points below the caller reached.
     #[inline(always)]
     fn __quasar_check_data(
         __data: &[u8],

--- a/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
@@ -460,9 +460,6 @@ impl DynamicAccount {
             )?;
         }
         let __ptr = __view.data_mut_ptr();
-        let __zc = unsafe {
-            &mut *(__ptr.add(1usize) as *mut __dynamic_account_zc::DynamicAccountZc)
-        };
         let __compact_data = unsafe {
             core::slice::from_raw_parts_mut(
                 __ptr.add(1usize),

--- a/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/account_dynamic.rs
@@ -66,12 +66,13 @@ impl ::quasar_lang::traits::Space for DynamicAccount {
     const SPACE: usize = 1usize
         + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
 }
-impl ::quasar_lang::account_load::AccountLoad for DynamicAccount {
+impl DynamicAccount {
+    /// The discriminator and compact-layout checks, over data borrowed
+    /// by whichever of the two entry points below the caller reached.
     #[inline(always)]
-    fn check(
-        view: &::quasar_lang::__internal::AccountView,
+    fn __quasar_check_data(
+        __data: &[u8],
     ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        let __data = unsafe { view.borrow_unchecked() };
         let __min = 1usize
             + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
         if __data.len() < __min {
@@ -92,31 +93,19 @@ impl ::quasar_lang::account_load::AccountLoad for DynamicAccount {
             })?;
         Ok(())
     }
+}
+impl ::quasar_lang::account_load::AccountLoad for DynamicAccount {
+    #[inline(always)]
+    fn check(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        Self::__quasar_check_data(unsafe { view.borrow_unchecked() })
+    }
     #[inline(always)]
     fn check_checked(
         view: &::quasar_lang::__internal::AccountView,
     ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        let __data_ref = view.try_borrow()?;
-        let __data: &[u8] = &__data_ref;
-        let __min = 1usize
-            + <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::HEADER_SIZE;
-        if __data.len() < __min {
-            return Err(
-                ::quasar_lang::__solana_program_error::ProgramError::AccountDataTooSmall,
-            );
-        }
-        if unsafe { *__data.get_unchecked(0usize) } != 5 {
-            return Err(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidAccountData,
-            );
-        }
-        <__dynamic_account_zc::__Schema as ::quasar_lang::ZeroPodCompact>::validate(unsafe {
-                __data.get_unchecked(1usize..)
-            })
-            .map_err(|_| {
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidAccountData
-            })?;
-        Ok(())
+        Self::__quasar_check_data(&view.try_borrow()?)
     }
 }
 impl ::quasar_lang::account_init::AccountInit for DynamicAccount {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -48,7 +48,7 @@ impl ::quasar_lang::traits::AccountCount for BasicAccounts {
     const NEEDS_EVENT_CPI: bool = false;
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
-    #[inline(always)]
+    #[inline]
     unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -102,13 +102,35 @@ impl BasicAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 4usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -124,7 +146,7 @@ impl BasicAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -157,7 +179,7 @@ impl BasicAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -190,7 +212,7 @@ impl BasicAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    2usize,
+                    __offset + 2usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -215,7 +237,7 @@ impl BasicAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    3usize,
+                    __offset + 3usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -284,20 +306,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 4usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 4usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for BasicAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -252,7 +252,7 @@ impl BasicAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -264,38 +264,13 @@ impl BasicAccounts {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [payer, config, system_program, rent] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let mut payer = <Signer as ::quasar_lang::account_load::AccountLoad>::load_mut(
-                payer,
-            )?;
-            let config = <Account<
-                TestConfig,
-            > as ::quasar_lang::account_load::AccountLoad>::load(config)?;
-            let system_program = <Program<
-                SystemProgram,
-            > as ::quasar_lang::account_load::AccountLoad>::load(system_program)?;
-            let rent = <Sysvar<
-                Rent,
-            > as ::quasar_lang::account_load::AccountLoad>::load(rent)?;
-            Ok((
-                Self {
-                    payer,
-                    config,
-                    system_program,
-                    rent,
-                },
-                BasicAccountsBumps,
-            ))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -3,62 +3,12 @@ pub struct BasicAccountsBumps;
 impl ::quasar_lang::traits::AccountBumps for BasicAccounts {
     type Bumps = BasicAccountsBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for BasicAccounts {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for BasicAccounts {
     type Bumps = BasicAccountsBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for BasicAccounts {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -98,57 +48,25 @@ impl ::quasar_lang::traits::AccountCount for BasicAccounts {
     const COUNT: usize = 4usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl BasicAccounts {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 4usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -157,31 +75,16 @@ impl BasicAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<
-                    TestConfig,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    TestConfig,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<
-                    TestConfig,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    TestConfig,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<TestConfig>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 1usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -190,31 +93,16 @@ impl BasicAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Program<SystemProgram>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 2usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -223,23 +111,16 @@ impl BasicAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Sysvar<Rent> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Sysvar<Rent> as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Sysvar<Rent> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Sysvar<Rent> as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Sysvar<Rent>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 3usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -248,40 +129,6 @@ impl BasicAccounts {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, BasicAccountsBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 4usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for BasicAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for BasicAccounts {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for BasicAccounts {
     type Bumps = BasicAccountsBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for BasicAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -306,95 +306,90 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for BasicAccounts {
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __basic_accounts_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __basic_accounts_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __basic_accounts_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub config
+        : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
+        $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub config
+        : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
+        $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg >
+        ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub config
+        : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub config
+        : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::BasicAccounts::__QUASAR_FIXED_ADDRESS_rent,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[allow(non_upper_case_globals)]
 impl BasicAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -95,16 +95,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for BasicAccounts {
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -407,33 +407,34 @@ impl BasicAccounts {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("BasicAccounts"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("config"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("config"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Const { address :
     ::quasar_lang::idl_build::address_to_base58(& < SystemProgram as
-    ::quasar_lang::traits::Id > ::ID), }, docs : ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("rent"), optional : false, writable :
+    ::quasar_lang::traits::Id > ::ID), }, docs : ::quasar_lang::idl_build::Vec::new(),
+    }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("rent"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Const { address :
     ::quasar_lang::idl_build::address_to_base58(& < Rent as
     ::quasar_lang::sysvars::Sysvar > ::ID), }, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -56,78 +56,34 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account payer @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<TestConfig>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(config), "' (index ", "1",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                false,
+            >(input, base, __offset + 1usize)?
+        };
+        ::quasar_lang::debug_log!("account config @1: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Program<SystemProgram>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 2usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                false,
+            >(input, base, __offset + 2usize)?
+        };
+        ::quasar_lang::debug_log!("account system_program @2: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Sysvar<Rent>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 3usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(rent), "' (index ", "3",
-                "): validation passed")
-            );
-        }
+                false,
+            >(input, base, __offset + 3usize)?
+        };
+        ::quasar_lang::debug_log!("account rent @3: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct BasicAccountsBumps;
-impl BasicAccounts {}
 impl ::quasar_lang::traits::AccountBumps for BasicAccounts {
     type Bumps = BasicAccountsBumps;
 }
@@ -131,7 +130,7 @@ impl BasicAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0usize",
+                concat!("Account '", stringify!(payer), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -164,7 +163,7 @@ impl BasicAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(config), "' (index ", "1usize",
+                concat!("Account '", stringify!(config), "' (index ", "1",
                 "): validation passed")
             );
         }
@@ -197,7 +196,7 @@ impl BasicAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2usize",
+                concat!("Account '", stringify!(system_program), "' (index ", "2",
                 "): validation passed")
             );
         }
@@ -222,7 +221,7 @@ impl BasicAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(rent), "' (index ", "3usize",
+                concat!("Account '", stringify!(rent), "' (index ", "3",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_basic_mut_signer.rs
@@ -60,7 +60,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for BasicAccounts {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account payer @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -61,7 +61,7 @@ for UseCustomBehavior {
             } else {
                 __bhv_builder
             };
-            Self::__assert_builder(&__bhv_builder);
+            ::quasar_lang::account_behavior::assert_builder(&__bhv_builder);
             let __bhv_args = ::quasar_lang::account_behavior::BehaviorArgsBuilder::build_check(
                 __bhv_builder,
             )?;
@@ -76,12 +76,6 @@ impl ::quasar_lang::traits::AccountCount for UseCustomBehavior {
     const COUNT: usize = 1usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl UseCustomBehavior {
-    #[inline(always)]
-    fn __assert_builder<__B: ::quasar_lang::account_behavior::BehaviorArgsBuilder>(
-        _: &__B,
-    ) {}
-}
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
     #[inline(always)]
     unsafe fn parse_accounts_raw(
@@ -94,7 +88,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
             ::quasar_lang::__internal::parse_account::<
                 Account<MyData>,
                 false,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account data @0: validation passed");
         Ok(input)

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -49,12 +49,13 @@ for UseCustomBehavior {
         if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
             Account<MyData>,
         >>::RUN_CHECK {
+            type __QuasarBhv = min_value::Behavior;
+            type __QuasarBhvAcct = Account<MyData>;
             let __bhv_builder = min_value::Args::builder();
-            let __bhv_builder = if ::quasar_lang::account_behavior::uses_arg::<
-                min_value::Behavior,
-                Account<MyData>,
-                { ::quasar_lang::account_behavior::ARG_PHASE_CHECK },
-                { ::quasar_lang::account_behavior::behavior_arg_key_hash("min") },
+            let __bhv_builder = if ::quasar_lang::account_behavior::uses_check_arg::<
+                __QuasarBhv,
+                __QuasarBhvAcct,
+                { ::quasar_lang::account_behavior::key("min") },
             >() {
                 __bhv_builder.min(10u64)
             } else {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -90,24 +90,13 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<MyData>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(data), "' (index ", "0",
-                "): validation passed")
-            );
-        }
+                false,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account data @0: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -328,8 +328,8 @@ mod __use_custom_behavior_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("UseCustomBehavior"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("data"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("data"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::one_behavior_resolver("data",
@@ -337,7 +337,7 @@ mod __use_custom_behavior_client_macro {
     ::quasar_lang::account_behavior::AccountBehavior < Account < MyData > >>
     ::IDL_RESOLVER, & [], & ["data"],)],).unwrap_or_else(|| {
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {} }), docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -137,13 +137,35 @@ impl UseCustomBehavior {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 1usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Account<MyData> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -163,7 +185,7 @@ impl UseCustomBehavior {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -250,20 +272,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 1usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UseCustomBehavior {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -200,7 +200,7 @@ impl UseCustomBehavior {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -212,56 +212,13 @@ impl UseCustomBehavior {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [data] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let data = if false
-                || <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
-                    Account<MyData>,
-                >>::VALIDATES_ACCOUNT_DATA
-            {
-                unsafe {
-                    <Account<
-                        MyData,
-                    > as ::quasar_lang::account_load::AccountLoad>::load_intrinsic(data)?
-                }
-            } else {
-                <Account<
-                    MyData,
-                > as ::quasar_lang::account_load::AccountLoad>::load(data)?
-            };
-            if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
-                Account<MyData>,
-            >>::RUN_CHECK && true
-            {
-                let __bhv_builder = min_value::Args::builder();
-                let __bhv_builder = if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
-                    Account<MyData>,
-                >>::uses_arg::<
-                    { ::quasar_lang::account_behavior::ARG_PHASE_CHECK },
-                    { ::quasar_lang::account_behavior::behavior_arg_key_hash("min") },
-                >() {
-                    __bhv_builder.min(10u64)
-                } else {
-                    __bhv_builder
-                };
-                Self::__assert_builder(&__bhv_builder);
-                let __bhv_args = ::quasar_lang::account_behavior::BehaviorArgsBuilder::build_check(
-                    __bhv_builder,
-                )?;
-                <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
-                    Account<MyData>,
-                >>::check(&data, &__bhv_args)?;
-            }
-            Ok((Self { data }, UseCustomBehaviorBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -51,9 +51,9 @@ for UseCustomBehavior {
             Account<MyData>,
         >>::RUN_CHECK {
             let __bhv_builder = min_value::Args::builder();
-            let __bhv_builder = if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
+            let __bhv_builder = if ::quasar_lang::account_behavior::uses_arg::<
+                min_value::Behavior,
                 Account<MyData>,
-            >>::uses_arg::<
                 { ::quasar_lang::account_behavior::ARG_PHASE_CHECK },
                 { ::quasar_lang::account_behavior::behavior_arg_key_hash("min") },
             >() {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct UseCustomBehaviorBumps;
-impl UseCustomBehavior {}
 impl ::quasar_lang::traits::AccountBumps for UseCustomBehavior {
     type Bumps = UseCustomBehaviorBumps;
 }
@@ -170,7 +169,7 @@ impl UseCustomBehavior {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(data), "' (index ", "0usize",
+                concat!("Account '", stringify!(data), "' (index ", "0",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -3,62 +3,12 @@ pub struct UseCustomBehaviorBumps;
 impl ::quasar_lang::traits::AccountBumps for UseCustomBehavior {
     type Bumps = UseCustomBehaviorBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for UseCustomBehavior {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for UseCustomBehavior {
     type Bumps = UseCustomBehaviorBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for UseCustomBehavior {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -131,60 +81,26 @@ impl UseCustomBehavior {
     fn __assert_builder<__B: ::quasar_lang::account_behavior::BehaviorArgsBuilder>(
         _: &__B,
     ) {}
+}
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<MyData> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    MyData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<MyData> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    MyData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<MyData>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -193,40 +109,6 @@ impl UseCustomBehavior {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, UseCustomBehaviorBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UseCustomBehavior {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UseCustomBehavior {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for UseCustomBehavior {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for UseCustomBehavior {
     type Bumps = UseCustomBehaviorBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for UseCustomBehavior {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -108,16 +108,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UseCustomBehavi
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_behavior_group.rs
@@ -86,11 +86,9 @@ for UseCustomBehavior {
             Account < MyData > >> ::RUN_AFTER_INIT,
             "behavior `min_value` runs after_init and requires `#[account(init, ...)]` on field `data`",
         );
-        let data = if false
-            || <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
-                Account<MyData>,
-            >>::VALIDATES_ACCOUNT_DATA
-        {
+        let data = if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
+            Account<MyData>,
+        >>::VALIDATES_ACCOUNT_DATA {
             unsafe {
                 <Account<
                     MyData,
@@ -101,8 +99,7 @@ for UseCustomBehavior {
         };
         if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
             Account<MyData>,
-        >>::RUN_CHECK && true
-        {
+        >>::RUN_CHECK {
             let __bhv_builder = min_value::Args::builder();
             let __bhv_builder = if <min_value::Behavior as ::quasar_lang::account_behavior::AccountBehavior<
                 Account<MyData>,
@@ -254,75 +251,70 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UseCustomBehavi
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __use_custom_behavior_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __use_custom_behavior_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __use_custom_behavior_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data, false),];
+        let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data, false),];
+        let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg >
+        ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub data : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.data, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -262,82 +262,77 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for CloseAccounts {
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __close_accounts_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __close_accounts_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
-            ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = {
-            let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
-            $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
-            ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = {
-            let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
-            $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix
-            . $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
-            ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts
-            .extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
-            ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts
-            .extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __close_accounts_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+        From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+        ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = { let
+        mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+        From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+        ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; let data = { let
+        mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+        ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts.extend(ix
+        .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+        $(_data.extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        old_data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.authority, true),
+        ::quasar_lang::client::AccountMeta::new(ix.old_data, false),]; accounts.extend(ix
+        .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+        $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -70,42 +70,20 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(authority), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account authority @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<OldData>,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(old_data), "' (index ", "1",
-                "): validation passed")
-            );
-        }
+                true,
+            >(input, base, __offset + 1usize)?
+        };
+        ::quasar_lang::debug_log!("account old_data @1: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -1,13 +1,12 @@
 #[derive(Copy, Clone)]
 pub struct CloseAccountsBumps;
-impl CloseAccounts {}
 impl ::quasar_lang::traits::AccountBumps for CloseAccounts {
     type Bumps = CloseAccountsBumps;
 }
 impl ::quasar_lang::traits::AccountGroup for CloseAccounts {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for CloseAccounts {
     type Bumps = CloseAccountsBumps;
-    const HAS_EPILOGUE: bool = false || true;
+    const HAS_EPILOGUE: bool = true;
     #[inline(always)]
     fn parse(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -160,7 +159,7 @@ impl CloseAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(authority), "' (index ", "0usize",
+                concat!("Account '", stringify!(authority), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -193,7 +192,7 @@ impl CloseAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(old_data), "' (index ", "1usize",
+                concat!("Account '", stringify!(old_data), "' (index ", "1",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -3,45 +3,9 @@ pub struct CloseAccountsBumps;
 impl ::quasar_lang::traits::AccountBumps for CloseAccounts {
     type Bumps = CloseAccountsBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for CloseAccounts {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for CloseAccounts {
     type Bumps = CloseAccountsBumps;
     const HAS_EPILOGUE: bool = true;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
     #[inline(always)]
     fn epilogue(
         &mut self,
@@ -74,20 +38,6 @@ impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for CloseAccounts {
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for CloseAccounts {
     #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
-    #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
         __ix_data: &[u8],
@@ -112,57 +62,25 @@ impl ::quasar_lang::traits::AccountCount for CloseAccounts {
     const COUNT: usize = 2usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl CloseAccounts {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -171,31 +89,16 @@ impl CloseAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<
-                    OldData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    OldData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<
-                    OldData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    OldData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<OldData>,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 1usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -204,40 +107,6 @@ impl CloseAccounts {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, CloseAccountsBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for CloseAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -131,13 +131,35 @@ impl CloseAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 2usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -153,7 +175,7 @@ impl CloseAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -186,7 +208,7 @@ impl CloseAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -241,20 +263,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 2usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for CloseAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -223,7 +223,7 @@ impl CloseAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -235,24 +235,13 @@ impl CloseAccounts {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [authority, old_data] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let mut authority = <Signer as ::quasar_lang::account_load::AccountLoad>::load_mut(
-                authority,
-            )?;
-            let mut old_data = <Account<
-                OldData,
-            > as ::quasar_lang::account_load::AccountLoad>::load_mut(old_data)?;
-            Ok((Self { authority, old_data }, CloseAccountsBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -95,16 +95,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for CloseAccounts {
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -26,14 +26,6 @@ impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for CloseAccounts {
         }
         Ok(())
     }
-    #[inline(always)]
-    fn epilogue_with_context(
-        &mut self,
-        _bumps: &Self::Bumps,
-        _ix_data: &[u8],
-    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        self.epilogue()
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for CloseAccounts {
@@ -74,7 +66,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for CloseAccounts {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account authority @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -343,18 +343,18 @@ mod __close_accounts_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("CloseAccounts"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("authority"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("authority"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("oldData"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("oldData"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_close.rs
@@ -63,27 +63,12 @@ impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for CloseAccounts {
         Ok(())
     }
     #[inline(always)]
-    #[allow(unused_variables)]
     fn epilogue_with_context(
         &mut self,
-        __bumps: &Self::Bumps,
-        __ix_data: &[u8],
+        _bumps: &Self::Bumps,
+        _ix_data: &[u8],
     ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            let __view = unsafe {
-                <Account<
-                    OldData,
-                > as ::quasar_lang::account_load::AccountLoad>::to_account_view_mut(
-                    &mut self.old_data,
-                )
-            };
-            ::quasar_lang::ops::close::Op {
-                disc_len: <OldData as ::quasar_lang::traits::Discriminator>::DISCRIMINATOR
-                    .len(),
-            }
-                .apply(__view, self.authority.to_account_view())?;
-        }
-        Ok(())
+        self.epilogue()
     }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -119,7 +119,7 @@ impl UsesAccountArray {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 1usize
                 + <AccountsArray<
@@ -129,7 +129,29 @@ impl UsesAccountArray {
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -145,7 +167,7 @@ impl UsesAccountArray {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -163,7 +185,7 @@ impl UsesAccountArray {
                 > as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __program_id,
                 )?
             };
@@ -241,30 +263,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize
-                + <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::AccountCount>::COUNT],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j
-            < 1usize
-                + <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::AccountCount>::COUNT
-        {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UsesAccountArray {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -27,7 +27,7 @@ for UsesAccountArray {
         let (__chunk, __rest) = unsafe { __accounts_rest.split_at_mut_unchecked(1) };
         __accounts_rest = __rest;
         let payer = unsafe { __chunk.get_unchecked_mut(0) };
-        let (__chunk, __rest) = unsafe {
+        let (__chunk, _) = unsafe {
             __accounts_rest
                 .split_at_mut_unchecked(
                     <AccountsArray<
@@ -36,7 +36,6 @@ for UsesAccountArray {
                     > as ::quasar_lang::traits::AccountCount>::COUNT,
                 )
         };
-        __accounts_rest = __rest;
         let (pairs, __composite_bumps_pairs) = unsafe {
             <AccountsArray<
                 SignerPair,
@@ -47,7 +46,6 @@ for UsesAccountArray {
                 __program_id,
             )
         }?;
-        let _ = __accounts_rest;
         let payer = <Signer as ::quasar_lang::account_load::AccountLoad>::load(payer)?;
         Ok((
             Self { payer, pairs },
@@ -77,22 +75,20 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 false,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account payer @0: validation passed");
-        {
-            input = unsafe {
-                <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __program_id,
-                )?
-            };
-        }
+        input = unsafe {
+            <AccountsArray<
+                SignerPair,
+                2,
+            > as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
+                input,
+                base,
+                __offset + 1usize,
+                __program_id,
+            )?
+        };
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -5,7 +5,6 @@ pub struct UsesAccountArrayBumps {
         2,
     > as ::quasar_lang::traits::AccountBumps>::Bumps,
 }
-impl UsesAccountArray {}
 impl ::quasar_lang::traits::AccountBumps for UsesAccountArray {
     type Bumps = UsesAccountArrayBumps;
 }
@@ -111,11 +110,10 @@ for UsesAccountArray {
 impl ::quasar_lang::traits::AccountCount for UsesAccountArray {
     const COUNT: usize = 1usize
         + <AccountsArray<SignerPair, 2> as ::quasar_lang::traits::AccountCount>::COUNT;
-    const NEEDS_EVENT_CPI: bool = false
-        || <AccountsArray<
-            SignerPair,
-            2,
-        > as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI;
+    const NEEDS_EVENT_CPI: bool = <AccountsArray<
+        SignerPair,
+        2,
+    > as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI;
 }
 impl UsesAccountArray {
     #[inline(always)]
@@ -153,7 +151,7 @@ impl UsesAccountArray {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0usize",
+                concat!("Account '", stringify!(payer), "' (index ", "0",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -195,7 +195,7 @@ impl UsesAccountArray {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -211,48 +211,13 @@ impl UsesAccountArray {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let mut __accounts_rest: &mut [::quasar_lang::__internal::AccountView] = accounts;
-            let (__chunk, __rest) = unsafe { __accounts_rest.split_at_mut_unchecked(1) };
-            __accounts_rest = __rest;
-            let payer = unsafe { __chunk.get_unchecked_mut(0) };
-            let (__chunk, __rest) = unsafe {
-                __accounts_rest
-                    .split_at_mut_unchecked(
-                        <AccountsArray<
-                            SignerPair,
-                            2,
-                        > as ::quasar_lang::traits::AccountCount>::COUNT,
-                    )
-            };
-            __accounts_rest = __rest;
-            let (pairs, __composite_bumps_pairs) = unsafe {
-                <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                    __chunk,
-                    __ix_data,
-                    __program_id,
-                )
-            }?;
-            let _ = __accounts_rest;
-            let payer = <Signer as ::quasar_lang::account_load::AccountLoad>::load(
-                payer,
-            )?;
-            Ok((
-                Self { payer, pairs },
-                UsesAccountArrayBumps {
-                    pairs: __composite_bumps_pairs,
-                },
-            ))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -104,16 +104,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UsesAccountArra
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -73,24 +73,13 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0",
-                "): validation passed")
-            );
-        }
+                false,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account payer @0: validation passed");
         {
             input = unsafe {
                 <AccountsArray<

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -8,62 +8,12 @@ pub struct UsesAccountArrayBumps {
 impl ::quasar_lang::traits::AccountBumps for UsesAccountArray {
     type Bumps = UsesAccountArrayBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for UsesAccountArray {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for UsesAccountArray {
     type Bumps = UsesAccountArrayBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for UsesAccountArray {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -115,61 +65,25 @@ impl ::quasar_lang::traits::AccountCount for UsesAccountArray {
         2,
     > as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI;
 }
-impl UsesAccountArray {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 1usize
-                + <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::AccountCount>::COUNT],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -191,44 +105,6 @@ impl UsesAccountArray {
             };
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, UsesAccountArrayBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize
-                + <AccountsArray<
-                    SignerPair,
-                    2,
-                > as ::quasar_lang::traits::AccountCount>::COUNT],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for UsesAccountArray {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UsesAccountArray {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -253,90 +253,85 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for UsesAccountArra
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __uses_account_array_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __uses_account_array_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts = { let
-            mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
-            ::alloc::vec::Vec::new(); __accounts
-            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
-            __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts = { let
-            mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
-            ::alloc::vec::Vec::new(); __accounts
-            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
-            __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = {
-            let mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >
-            = ::alloc::vec::Vec::new(); __accounts
-            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
-            __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
-            .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
-            $(_data.extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg
-            > ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = {
-            let mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >
-            = ::alloc::vec::Vec::new(); __accounts
-            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
-            __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
-            .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
-            $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __uses_account_array_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub pairs
+        : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub $arg_name :
+        $arg_ty,)* } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts = { let mut __accounts :
+        ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+        ::alloc::vec::Vec::new(); __accounts
+        .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+        __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub pairs
+        : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub $arg_name :
+        $arg_ty,)* } impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts = { let mut __accounts :
+        ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+        ::alloc::vec::Vec::new(); __accounts
+        .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+        __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub pairs
+        : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub $arg_name :
+        $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = { let
+        mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+        ::alloc::vec::Vec::new(); __accounts
+        .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+        __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
+        .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+        $(_data.extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub pairs
+        : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub $arg_name :
+        $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = { let
+        mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+        ::alloc::vec::Vec::new(); __accounts
+        .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+        __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
+        .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+        $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -10,7 +10,6 @@ impl ::quasar_lang::traits::AccountBumps for UsesAccountArray {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for UsesAccountArray {
     type Bumps = UsesAccountArrayBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for UsesAccountArray {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -296,33 +296,36 @@ mod __uses_account_array_client_macro {
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
+            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
+            $arg_name : $arg_ty,)* } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts = { let
+            mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+            ::alloc::vec::Vec::new(); __accounts
+            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+            __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
+            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
+            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
+            accounts, data, } } }
         };
         (
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             compact
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
+            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
+            $arg_name : $arg_ty,)* } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let accounts = { let
+            mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta > =
+            ::alloc::vec::Vec::new(); __accounts
+            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+            __accounts.extend(ix.pairs); __accounts }; let data = { let mut _data =
+            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
             $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
             $crate::ID, accounts, data, } } }
         };
@@ -331,33 +334,37 @@ mod __uses_account_array_client_macro {
             remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
+            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
+            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = {
+            let mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >
+            = ::alloc::vec::Vec::new(); __accounts
+            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+            __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
+            .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+            $(_data.extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg
+            > ::serialize_arg(& ix. $arg_name));)* _data };
+            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+            } } }
         };
         (
             $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
             compact, remaining
         ) => {
             pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            pairs : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.payer,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.pairs, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+            pairs : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, $(pub
+            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts = {
+            let mut __accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >
+            = ::alloc::vec::Vec::new(); __accounts
+            .push(::quasar_lang::client::AccountMeta::new_readonly(ix.payer, true));
+            __accounts.extend(ix.pairs); __accounts }; accounts.extend(ix
+            .remaining_accounts); let data = { let mut _data = ::alloc::vec![$($disc),*];
+            $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
             $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
             ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_composite.rs
@@ -342,18 +342,17 @@ mod __uses_account_array_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("UsesAccountArray"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("pairs"), optional : false, writable :
-    ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
-    ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
-    ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Group { field : "pairs", accounts_struct
+    : "SignerPair", repeat : { let __inner = < SignerPair as
+    ::quasar_lang::traits::AccountCount > ::COUNT; if __inner == 0 { 0 } else { <
+    AccountsArray < SignerPair, 2 > as ::quasar_lang::traits::AccountCount > ::COUNT /
+    __inner } }, }],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -3,62 +3,12 @@ pub struct HeaderDupReadonlyBumps;
 impl ::quasar_lang::traits::AccountBumps for HeaderDupReadonly {
     type Bumps = HeaderDupReadonlyBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for HeaderDupReadonly {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for HeaderDupReadonly {
     type Bumps = HeaderDupReadonlyBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for HeaderDupReadonly {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -82,57 +32,25 @@ impl ::quasar_lang::traits::AccountCount for HeaderDupReadonly {
     const COUNT: usize = 2usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl HeaderDupReadonly {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -141,21 +59,9 @@ impl HeaderDupReadonly {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __FLAG_MASK: u32 = ::quasar_lang::__internal::header_flag_mask(
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                UncheckedAccount,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account_dup(
                     input,
@@ -163,9 +69,7 @@ impl HeaderDupReadonly {
                     __offset + 1usize,
                     __program_id,
                     ::quasar_lang::__internal::ParseFlags {
-                        expected: __EXPECTED,
-                        mask: __MASK,
-                        flag_mask: __FLAG_MASK,
+                        header: __HEADER,
                         is_optional: false,
                         is_ref_mut: false,
                         allow_dup: true,
@@ -178,40 +82,6 @@ impl HeaderDupReadonly {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, HeaderDupReadonlyBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for HeaderDupReadonly {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -40,47 +40,30 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(source), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                false,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account source @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account_dup::<
                 UncheckedAccount,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account_dup(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __program_id,
-                    ::quasar_lang::__internal::ParseFlags {
-                        header: __HEADER,
-                        is_optional: false,
-                        is_ref_mut: false,
-                        allow_dup: true,
-                    },
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(destination), "' (index ", "1",
-                "): parsed (dup-aware)")
-            );
-        }
+                false,
+            >(
+                input,
+                base,
+                __offset + 1usize,
+                __program_id,
+                ::quasar_lang::__internal::ParseFlags {
+                    is_optional: false,
+                    is_ref_mut: false,
+                    allow_dup: true,
+                },
+            )?
+        };
+        ::quasar_lang::debug_log!("account destination @1: parsed (dup-aware)");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -318,19 +318,19 @@ mod __header_dup_readonly_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("HeaderDupReadonly"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("source"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("source"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("destination"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("destination"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
     ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::s("CHECK: test-only unchecked account used to validate duplicate readonly aliases.")],
-    }],) })
+    })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -75,16 +75,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for HeaderDupReadon
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct HeaderDupReadonlyBumps;
-impl HeaderDupReadonly {}
 impl ::quasar_lang::traits::AccountBumps for HeaderDupReadonly {
     type Bumps = HeaderDupReadonlyBumps;
 }
@@ -115,7 +114,7 @@ impl HeaderDupReadonly {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(source), "' (index ", "0usize",
+                concat!("Account '", stringify!(source), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -152,7 +151,7 @@ impl HeaderDupReadonly {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(destination), "' (index ", "1usize",
+                concat!("Account '", stringify!(destination), "' (index ", "1",
                 "): parsed (dup-aware)")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -44,7 +44,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 false,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account source @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -236,83 +236,78 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for HeaderDupReadon
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __header_dup_readonly_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __header_dup_readonly_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
-            destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
-            destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
-            destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
-            destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.destination,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __header_dup_readonly_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
+        destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.destination, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
+        $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
+        $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
+        destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.destination, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
+        destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.destination, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub source : ::quasar_lang::prelude::Address, pub
+        destination : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.source, true),
+        ::quasar_lang::client::AccountMeta::new_readonly(ix.destination, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -182,7 +182,7 @@ impl HeaderDupReadonly {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -194,24 +194,13 @@ impl HeaderDupReadonly {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [source, destination] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let source = <Signer as ::quasar_lang::account_load::AccountLoad>::load(
-                source,
-            )?;
-            let destination = <UncheckedAccount as ::quasar_lang::account_load::AccountLoad>::load_checked(
-                destination,
-            )?;
-            Ok((Self { source, destination }, HeaderDupReadonlyBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for HeaderDupReadonly {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for HeaderDupReadonly {
     type Bumps = HeaderDupReadonlyBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for HeaderDupReadonly {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_dup.rs
@@ -86,13 +86,35 @@ impl HeaderDupReadonly {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 2usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -108,7 +130,7 @@ impl HeaderDupReadonly {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -138,7 +160,7 @@ impl HeaderDupReadonly {
                 ::quasar_lang::__internal::parse_account_dup(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __program_id,
                     ::quasar_lang::__internal::ParseFlags {
                         expected: __EXPECTED,
@@ -200,20 +222,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for HeaderDupReadonly {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 2usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for HeaderDupReadonly {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -18,62 +18,12 @@ impl InitEscrow {
 impl ::quasar_lang::traits::AccountBumps for InitEscrow {
     type Bumps = InitEscrowBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for InitEscrow {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for InitEscrow {
     type Bumps = InitEscrowBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for InitEscrow {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -147,57 +97,25 @@ impl ::quasar_lang::traits::AccountCount for InitEscrow {
     const COUNT: usize = 3usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl InitEscrow {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -206,27 +124,16 @@ impl InitEscrow {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<Escrow> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    Escrow,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<Escrow> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    Escrow,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<Escrow>,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 1usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -235,31 +142,16 @@ impl InitEscrow {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Program<SystemProgram>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 2usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -268,40 +160,6 @@ impl InitEscrow {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, InitEscrowBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for InitEscrow {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -428,14 +428,14 @@ impl InitEscrow {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("InitEscrow"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("escrow"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("escrow"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Pda { program :
@@ -447,15 +447,15 @@ impl InitEscrow {
     ::SEED_PREFIX), }); } seeds
     .push(::quasar_lang::idl_build::__reexport::IdlPdaSeed::Account { path :
     ::quasar_lang::idl_build::s("payer"), }); seeds }, }, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Const { address :
     ::quasar_lang::idl_build::address_to_base58(& < SystemProgram as
     ::quasar_lang::traits::Id > ::ID), }, docs : ::quasar_lang::idl_build::Vec::new(),
-    }],) })
+    })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -151,13 +151,35 @@ impl InitEscrow {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 3usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -173,7 +195,7 @@ impl InitEscrow {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -202,7 +224,7 @@ impl InitEscrow {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -235,7 +257,7 @@ impl InitEscrow {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    2usize,
+                    __offset + 2usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -334,20 +356,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 3usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for InitEscrow {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -179,7 +179,7 @@ impl InitEscrow {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0usize",
+                concat!("Account '", stringify!(payer), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -208,7 +208,7 @@ impl InitEscrow {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(escrow), "' (index ", "1usize",
+                concat!("Account '", stringify!(escrow), "' (index ", "1",
                 "): validation passed")
             );
         }
@@ -241,7 +241,7 @@ impl InitEscrow {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2usize",
+                concat!("Account '", stringify!(system_program), "' (index ", "2",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -4,14 +4,11 @@ pub struct InitEscrowBumps {
 }
 impl InitEscrow {
     #[inline(always)]
-    #[allow(unused_variables)]
     pub fn escrow_signer<'__quasar_seed>(
         &'__quasar_seed self,
         bumps: &'__quasar_seed InitEscrowBumps,
     ) -> <Escrow as ::quasar_lang::traits::HasSeeds>::WithBump<'__quasar_seed> {
         let payer = &self.payer;
-        let escrow = &self.escrow;
-        let system_program = &self.system_program;
         Escrow::seeds(payer.address()).with_bump(bumps.escrow)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -137,16 +137,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for InitEscrow {
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -105,60 +105,27 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account payer @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<Escrow>,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(escrow), "' (index ", "1",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 1usize)?
+        };
+        ::quasar_lang::debug_log!("account escrow @1: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Program<SystemProgram>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 2usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2",
-                "): validation passed")
-            );
-        }
+                false,
+            >(input, base, __offset + 2usize)?
+        };
+        ::quasar_lang::debug_log!("account system_program @2: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -35,7 +35,7 @@ for InitEscrow {
         };
         const _: () = assert!(
             < Account < Escrow > as ::quasar_lang::account_init::AccountInit >
-            ::DEFAULT_INIT_PARAMS_VALID || 0usize >= 1,
+            ::DEFAULT_INIT_PARAMS_VALID,
             "field `escrow` requires an init-param behavior (e.g., token(...) or mint(...))",
         );
         let __bumps_escrow: u8;
@@ -106,7 +106,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account payer @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -17,7 +17,6 @@ impl ::quasar_lang::traits::AccountBumps for InitEscrow {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for InitEscrow {
     type Bumps = InitEscrowBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for InitEscrow {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -272,7 +272,7 @@ impl InitEscrow {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -284,68 +284,13 @@ impl InitEscrow {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [payer, escrow, system_program] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let __bumps_escrow: u8;
-            let __rent_ctx = ::quasar_lang::ops::OpCtx::new(
-                unsafe { &*(__program_id as *const ::quasar_lang::prelude::Address) },
-                ::quasar_lang::ops::RentResolver::fetch_once(),
-            );
-            let mut payer = <Signer as ::quasar_lang::account_load::AccountLoad>::load_mut(
-                payer,
-            )?;
-            let system_program = <Program<
-                SystemProgram,
-            > as ::quasar_lang::account_load::AccountLoad>::load(system_program)?;
-            let __addr_escrow = Escrow::seeds(payer.address());
-            __bumps_escrow = ::quasar_lang::address::AddressVerify::verify(
-                &__addr_escrow,
-                escrow.address(),
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
                 __program_id,
-            )?;
-            {
-                let __bump_ref: &[u8] = &[__bumps_escrow];
-                ::quasar_lang::address::AddressVerify::with_signer_seeds(
-                    &__addr_escrow,
-                    __bump_ref,
-                    |__signers| -> Result<(), ::quasar_lang::prelude::ProgramError> {
-                        let __init_params = ();
-                        let __init_op = ::quasar_lang::ops::init::Op {
-                            payer: payer.to_account_view(),
-                            space: <Account<
-                                Escrow,
-                            > as ::quasar_lang::traits::Space>::SPACE as u64,
-                            signers: __signers,
-                            params: __init_params,
-                            idempotent: false,
-                        };
-                        __init_op.apply::<Account<Escrow>, _>(escrow, &__rent_ctx)?;
-                        Ok(())
-                    },
-                )?;
-            }
-            let mut escrow = <Account<
-                Escrow,
-            > as ::quasar_lang::account_load::AccountLoad>::load_mut(escrow)?;
-            Ok((
-                Self {
-                    payer,
-                    escrow,
-                    system_program,
-                },
-                InitEscrowBumps {
-                    escrow: __bumps_escrow,
-                },
-            ))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for InitEscrow {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_init_payer.rs
@@ -326,87 +326,82 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for InitEscrow {
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __init_escrow_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __init_escrow_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
-            ix.payer, & $crate::ID), false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
-            ix.payer, & $crate::ID), false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
-            ix.payer, & $crate::ID), false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
-            $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
-            ix.payer, & $crate::ID), false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __init_escrow_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+        ix.payer, & $crate::ID), false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+        ix.payer, & $crate::ID), false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg >
+        ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+        ix.payer, & $crate::ID), false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(super::InitEscrow::__quasar_pda_escrow(&
+        ix.payer, & $crate::ID), false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::InitEscrow::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[allow(non_upper_case_globals)]
 impl InitEscrow {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -93,16 +93,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for TwoDyn {
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -314,12 +314,12 @@ mod __two_dyn_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("TwoDyn"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("account"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("account"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -186,38 +186,25 @@ impl TwoDyn {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
         (Self, TwoDynBumps),
         ::quasar_lang::__solana_program_error::ProgramError,
     > {
-        let (tag, a, b) = Self::__extract_ix_args(__ix_data)?;
         let mut __buf = core::mem::MaybeUninit::<
             [::quasar_lang::__internal::AccountView; 1usize],
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [account] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let mut account = <Account<
-                TwoDynArgsAccount,
-            > as ::quasar_lang::account_load::AccountLoad>::load_mut(account)?;
-            ::quasar_lang::validation::check_constraint(
-                tag != 0 && a.len() == b.len(),
-                ::quasar_lang::error::QuasarError::ConstraintViolation.into(),
-            )?;
-            Ok((Self { account }, TwoDynBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -240,75 +240,70 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for TwoDyn {
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __two_dyn_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __two_dyn_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __two_dyn_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
+        $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
+        $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for TwoDyn {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for TwoDyn {
     type Bumps = TwoDynBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input> for TwoDyn {
     #[inline(always)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct TwoDynBumps;
-impl TwoDyn {}
 impl ::quasar_lang::traits::AccountBumps for TwoDyn {
     type Bumps = TwoDynBumps;
 }
@@ -156,7 +155,7 @@ impl TwoDyn {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(account), "' (index ", "0usize",
+                concat!("Account '", stringify!(account), "' (index ", "0",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -3,61 +3,11 @@ pub struct TwoDynBumps;
 impl ::quasar_lang::traits::AccountBumps for TwoDyn {
     type Bumps = TwoDynBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for TwoDyn {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for TwoDyn {
     type Bumps = TwoDynBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input> for TwoDyn {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -116,64 +66,26 @@ impl TwoDyn {
         let b = __ref.b();
         Ok((tag, a, b))
     }
+}
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<
-                    TwoDynArgsAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    TwoDynArgsAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<
-                    TwoDynArgsAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    TwoDynArgsAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<TwoDynArgsAccount>,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -182,40 +94,6 @@ impl TwoDyn {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, TwoDynBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for TwoDyn {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -75,24 +75,13 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<TwoDynArgsAccount>,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(account), "' (index ", "0",
-                "): validation passed")
-            );
-        }
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account account @0: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -119,13 +119,35 @@ impl TwoDyn {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 1usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Account<
@@ -149,7 +171,7 @@ impl TwoDyn {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -206,20 +228,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 1usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for TwoDyn {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_dynamic.rs
@@ -79,7 +79,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for TwoDyn {
             ::quasar_lang::__internal::parse_account::<
                 Account<TwoDynArgsAccount>,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account account @0: validation passed");
         Ok(input)

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -96,16 +96,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for IxArgsFixed {
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -243,75 +243,70 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for IxArgsFixed {
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __ix_args_fixed_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __ix_args_fixed_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub account : ::quasar_lang::prelude::Address,
-            $(pub $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __ix_args_fixed_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
+        $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
+        $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub account : ::quasar_lang::prelude::Address, $(pub
+        $arg_name : $arg_ty,)* pub remaining_accounts : ::alloc::vec::Vec <
+        ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
+        ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
+        $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.account, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -122,13 +122,35 @@ impl IxArgsFixed {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 1usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Account<
@@ -152,7 +174,7 @@ impl IxArgsFixed {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -209,20 +231,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 1usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for IxArgsFixed {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -78,24 +78,13 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<SimpleAccount>,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(account), "' (index ", "0",
-                "): validation passed")
-            );
-        }
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account account @0: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -82,7 +82,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {
             ::quasar_lang::__internal::parse_account::<
                 Account<SimpleAccount>,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account account @0: validation passed");
         Ok(input)

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct IxArgsFixedBumps;
-impl IxArgsFixed {}
 impl ::quasar_lang::traits::AccountBumps for IxArgsFixed {
     type Bumps = IxArgsFixedBumps;
 }
@@ -159,7 +158,7 @@ impl IxArgsFixed {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(account), "' (index ", "0usize",
+                concat!("Account '", stringify!(account), "' (index ", "0",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -3,62 +3,12 @@ pub struct IxArgsFixedBumps;
 impl ::quasar_lang::traits::AccountBumps for IxArgsFixed {
     type Bumps = IxArgsFixedBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for IxArgsFixed {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for IxArgsFixed {
     type Bumps = IxArgsFixedBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for IxArgsFixed {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -119,64 +69,26 @@ impl IxArgsFixed {
         );
         Ok((amount, flag))
     }
+}
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<
-                    SimpleAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    SimpleAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<
-                    SimpleAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    SimpleAccount,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<SimpleAccount>,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -185,40 +97,6 @@ impl IxArgsFixed {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, IxArgsFixedBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 1usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for IxArgsFixed {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for IxArgsFixed {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for IxArgsFixed {
     type Bumps = IxArgsFixedBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for IxArgsFixed {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -317,12 +317,12 @@ mod __ix_args_fixed_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("IxArgsFixed"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("account"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("account"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_ix_args_fixed.rs
@@ -189,38 +189,25 @@ impl IxArgsFixed {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
         (Self, IxArgsFixedBumps),
         ::quasar_lang::__solana_program_error::ProgramError,
     > {
-        let (amount, flag) = Self::__extract_ix_args(__ix_data)?;
         let mut __buf = core::mem::MaybeUninit::<
             [::quasar_lang::__internal::AccountView; 1usize],
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [account] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let mut account = <Account<
-                SimpleAccount,
-            > as ::quasar_lang::account_load::AccountLoad>::load_mut(account)?;
-            ::quasar_lang::validation::check_constraint(
-                amount > 0 && flag,
-                ::quasar_lang::error::QuasarError::ConstraintViolation.into(),
-            )?;
-            Ok((Self { account }, IxArgsFixedBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for IxArgsFixed {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -339,18 +339,18 @@ mod __optional_accounts_client_macro {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("OptionalAccounts"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("authority"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("authority"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("config"), optional : true, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("config"), optional : true, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), }],) })
+    ::quasar_lang::idl_build::Vec::new(), })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -257,83 +257,78 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for OptionalAccount
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __optional_accounts_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __optional_accounts_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* }
-            impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
-            let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address,
-            pub config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)*
-            pub remaining_accounts : ::alloc::vec::Vec <
-            ::quasar_lang::client::AccountMeta >, } impl From < $struct_name > for
-            ::quasar_lang::client::Instruction { #[allow(unused_variables)] fn from(ix :
-            $struct_name) -> ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
-            true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
-            accounts.extend(ix.remaining_accounts); let data = { let mut _data =
-            ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __optional_accounts_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+        From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+        true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix.
+        $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
+        $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
+        From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+        true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),]; let
+        data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& <
+        $arg_ty as ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+        true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub authority : ::quasar_lang::prelude::Address, pub
+        config : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new_readonly(ix.authority,
+        true), ::quasar_lang::client::AccountMeta::new_readonly(ix.config, false),];
+        accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -90,16 +90,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for OptionalAccount
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for OptionalAccounts {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for OptionalAccounts {
     type Bumps = OptionalAccountsBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for OptionalAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct OptionalAccountsBumps;
-impl OptionalAccounts {}
 impl ::quasar_lang::traits::AccountBumps for OptionalAccounts {
     type Bumps = OptionalAccountsBumps;
 }
@@ -130,7 +129,7 @@ impl OptionalAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(authority), "' (index ", "0usize",
+                concat!("Account '", stringify!(authority), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -173,7 +172,7 @@ impl OptionalAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(config), "' (index ", "1usize",
+                concat!("Account '", stringify!(config), "' (index ", "1",
                 "): parsed (dup-aware)")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -59,7 +59,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 false,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account authority @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -3,62 +3,12 @@ pub struct OptionalAccountsBumps;
 impl ::quasar_lang::traits::AccountBumps for OptionalAccounts {
     type Bumps = OptionalAccountsBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for OptionalAccounts {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for OptionalAccounts {
     type Bumps = OptionalAccountsBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for OptionalAccounts {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -97,57 +47,25 @@ impl ::quasar_lang::traits::AccountCount for OptionalAccounts {
     const COUNT: usize = 2usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl OptionalAccounts {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -156,27 +74,9 @@ impl OptionalAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<Config> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    Config,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<Config> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    Config,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __FLAG_MASK: u32 = ::quasar_lang::__internal::header_flag_mask(
-                <Account<Config> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Account<
-                    Config,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<Config>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account_dup(
                     input,
@@ -184,9 +84,7 @@ impl OptionalAccounts {
                     __offset + 1usize,
                     __program_id,
                     ::quasar_lang::__internal::ParseFlags {
-                        expected: __EXPECTED,
-                        mask: __MASK,
-                        flag_mask: __FLAG_MASK,
+                        header: __HEADER,
                         is_optional: true,
                         is_ref_mut: false,
                         allow_dup: false,
@@ -199,40 +97,6 @@ impl OptionalAccounts {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, OptionalAccountsBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for OptionalAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -101,13 +101,35 @@ impl OptionalAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 2usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -123,7 +145,7 @@ impl OptionalAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -159,7 +181,7 @@ impl OptionalAccounts {
                 ::quasar_lang::__internal::parse_account_dup(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __program_id,
                     ::quasar_lang::__internal::ParseFlags {
                         expected: __EXPECTED,
@@ -234,20 +256,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 2usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 2usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for OptionalAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -203,7 +203,7 @@ impl OptionalAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -215,37 +215,13 @@ impl OptionalAccounts {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [authority, config] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let authority = <Signer as ::quasar_lang::account_load::AccountLoad>::load(
-                authority,
-            )?;
-            let config = if ::quasar_lang::keys_eq(config.address(), __program_id) {
-                None
-            } else {
-                Some(
-                    <Account<
-                        Config,
-                    > as ::quasar_lang::account_load::AccountLoad>::load(config)?,
-                )
-            };
-            if let Some(ref config) = config {
-                ::quasar_lang::validation::check_address_match(
-                    &config.authority,
-                    authority.to_account_view().address(),
-                    ::quasar_lang::error::QuasarError::HasOneMismatch.into(),
-                )?;
-            }
-            Ok((Self { authority, config }, OptionalAccountsBumps))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_optional.rs
@@ -55,47 +55,30 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for OptionalAccounts {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(authority), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                false,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account authority @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account_dup::<
                 Account<Config>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account_dup(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __program_id,
-                    ::quasar_lang::__internal::ParseFlags {
-                        header: __HEADER,
-                        is_optional: true,
-                        is_ref_mut: false,
-                        allow_dup: false,
-                    },
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(config), "' (index ", "1",
-                "): parsed (dup-aware)")
-            );
-        }
+                false,
+            >(
+                input,
+                base,
+                __offset + 1usize,
+                __program_id,
+                ::quasar_lang::__internal::ParseFlags {
+                    is_optional: true,
+                    is_ref_mut: false,
+                    allow_dup: false,
+                },
+            )?
+        };
+        ::quasar_lang::debug_log!("account config @1: parsed (dup-aware)");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -3,62 +3,12 @@ pub struct ReallocAccountsBumps;
 impl ::quasar_lang::traits::AccountBumps for ReallocAccounts {
     type Bumps = ReallocAccountsBumps;
 }
-impl ::quasar_lang::traits::AccountGroup for ReallocAccounts {}
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for ReallocAccounts {
     type Bumps = ReallocAccountsBumps;
     const HAS_EPILOGUE: bool = false;
-    #[inline(always)]
-    fn parse(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                &[],
-                program_id,
-            )
-        }
-    }
-    #[inline(always)]
-    fn parse_with_instruction_data(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        ::quasar_lang::traits::check_account_count(accounts.len(), Self::COUNT)?;
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for ReallocAccounts {
-    #[inline(always)]
-    unsafe fn parse_unchecked(
-        accounts: &'input mut [::quasar_lang::__internal::AccountView],
-        program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, Self::Bumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            &[],
-            program_id,
-        )
-    }
     #[inline(always)]
     unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [::quasar_lang::__internal::AccountView],
@@ -105,57 +55,25 @@ impl ::quasar_lang::traits::AccountCount for ReallocAccounts {
     const COUNT: usize = 3usize;
     const NEEDS_EVENT_CPI: bool = false;
 }
-impl ReallocAccounts {
+unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {
     #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts(
-        input: *mut u8,
-        buf: &mut core::mem::MaybeUninit<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        Self::parse_accounts_into(
-            input,
-            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id,
-        )
-    }
-    /// Parse this struct's accounts directly into `base[__offset..]`.
-    ///
-    /// # Safety
-    ///
-    /// `base[__offset .. __offset + COUNT]` must be writable
-    /// `AccountView` slots, `base[..__offset]` must already be
-    /// initialized, and `input` must point at this struct's first
-    /// account entry.
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_accounts_into(
+    unsafe fn parse_accounts_raw(
         mut input: *mut u8,
         base: *mut ::quasar_lang::__internal::AccountView,
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Signer as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Signer,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 0usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -164,27 +82,16 @@ impl ReallocAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Account<MyData> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    MyData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Account<MyData> as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                true,
-                <Account<
-                    MyData,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Account<MyData>,
+            >(true);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 1usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -193,31 +100,16 @@ impl ReallocAccounts {
             );
         }
         {
-            const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
-            const __MASK: u32 = ::quasar_lang::__internal::header_mask(
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
-                false,
-                <Program<
-                    SystemProgram,
-                > as ::quasar_lang::account_load::AccountLoad>::IS_EXECUTABLE,
-            );
+            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                Program<SystemProgram>,
+            >(false);
             input = unsafe {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
                     __offset + 2usize,
-                    __EXPECTED,
-                    __MASK,
+                    __HEADER.expected,
+                    __HEADER.mask,
                 )?
             };
             ::quasar_lang::debug_log!(
@@ -226,40 +118,6 @@ impl ReallocAccounts {
             );
         }
         Ok(input)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        input: *mut u8,
-        __ix_data: &[u8],
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<
-        (Self, ReallocAccountsBumps),
-        ::quasar_lang::__solana_program_error::ProgramError,
-    > {
-        let mut __buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >::uninit();
-        let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
-        let mut __accounts = unsafe { __buf.assume_init() };
-        unsafe {
-            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts,
-                __ix_data,
-                __program_id,
-            )
-        }
-    }
-}
-unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {
-    #[inline(always)]
-    unsafe fn parse_accounts_raw(
-        input: *mut u8,
-        base: *mut ::quasar_lang::__internal::AccountView,
-        offset: usize,
-        __program_id: &::quasar_lang::prelude::Address,
-    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for ReallocAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -1,6 +1,5 @@
 #[derive(Copy, Clone)]
 pub struct ReallocAccountsBumps;
-impl ReallocAccounts {}
 impl ::quasar_lang::traits::AccountBumps for ReallocAccounts {
     type Bumps = ReallocAccountsBumps;
 }
@@ -138,7 +137,7 @@ impl ReallocAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0usize",
+                concat!("Account '", stringify!(payer), "' (index ", "0",
                 "): validation passed")
             );
         }
@@ -167,7 +166,7 @@ impl ReallocAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(data), "' (index ", "1usize",
+                concat!("Account '", stringify!(data), "' (index ", "1",
                 "): validation passed")
             );
         }
@@ -200,7 +199,7 @@ impl ReallocAccounts {
                 )?
             };
             ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2usize",
+                concat!("Account '", stringify!(system_program), "' (index ", "2",
                 "): validation passed")
             );
         }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -5,7 +5,6 @@ impl ::quasar_lang::traits::AccountBumps for ReallocAccounts {
 }
 impl<'input> ::quasar_lang::traits::ParseAccounts<'input> for ReallocAccounts {
     type Bumps = ReallocAccountsBumps;
-    const HAS_EPILOGUE: bool = false;
 }
 unsafe impl<'input> ::quasar_lang::traits::ParseAccountsUnchecked<'input>
 for ReallocAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -63,60 +63,27 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {
         __offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Signer,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 0usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(payer), "' (index ", "0",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 0usize)?
+        };
+        ::quasar_lang::debug_log!("account payer @0: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Account<MyData>,
-            >(true);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 1usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(data), "' (index ", "1",
-                "): validation passed")
-            );
-        }
-        {
-            const __HEADER: ::quasar_lang::__internal::HeaderSpec = ::quasar_lang::__internal::HeaderSpec::of::<
+                true,
+            >(input, base, __offset + 1usize)?
+        };
+        ::quasar_lang::debug_log!("account data @1: validation passed");
+        input = unsafe {
+            ::quasar_lang::__internal::parse_account::<
                 Program<SystemProgram>,
-            >(false);
-            input = unsafe {
-                ::quasar_lang::__internal::parse_account(
-                    input,
-                    base,
-                    __offset + 2usize,
-                    __HEADER.expected,
-                    __HEADER.mask,
-                )?
-            };
-            ::quasar_lang::debug_log!(
-                concat!("Account '", stringify!(system_program), "' (index ", "2",
-                "): validation passed")
-            );
-        }
+                false,
+            >(input, base, __offset + 2usize)?
+        };
+        ::quasar_lang::debug_log!("account system_program @2: validation passed");
         Ok(input)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -95,16 +95,11 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for ReallocAccounts
         program_id: Option<&::quasar_lang::prelude::Address>,
         data: &[u8],
     ) -> Result<Self, ::quasar_lang::__solana_program_error::ProgramError> {
-        let program_id = program_id
-            .ok_or(
-                ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
-            )?;
-        let (item, _bumps) = <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            accounts,
-            data,
-            program_id,
-        )?;
-        Ok(item)
+        unsafe {
+            ::quasar_lang::remaining::parse_group_chunk::<
+                Self,
+            >(accounts, program_id, data)
+        }
     }
 }
 #[doc(hidden)]

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -230,7 +230,7 @@ impl ReallocAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_direct_with_instruction_data_unchecked(
-        mut input: *mut u8,
+        input: *mut u8,
         __ix_data: &[u8],
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<
@@ -242,45 +242,13 @@ impl ReallocAccounts {
         >::uninit();
         let _ = Self::parse_accounts(input, &mut __buf, __program_id)?;
         let mut __accounts = unsafe { __buf.assume_init() };
-        let accounts = &mut __accounts;
-        let __parsed_result: Result<
-            (Self, <Self as ::quasar_lang::traits::ParseAccounts>::Bumps),
-            ::quasar_lang::__solana_program_error::ProgramError,
-        > = {
-            let [payer, data, system_program] = accounts else {
-                unsafe { core::hint::unreachable_unchecked() }
-            };
-            let __rent_ctx = ::quasar_lang::ops::OpCtx::new(
-                unsafe { &*(__program_id as *const ::quasar_lang::prelude::Address) },
-                ::quasar_lang::ops::RentResolver::fetch_once(),
-            );
-            let mut payer = <Signer as ::quasar_lang::account_load::AccountLoad>::load_mut(
-                payer,
-            )?;
-            let mut data = <Account<
-                MyData,
-            > as ::quasar_lang::account_load::AccountLoad>::load_mut(data)?;
-            let system_program = <Program<
-                SystemProgram,
-            > as ::quasar_lang::account_load::AccountLoad>::load(system_program)?;
-            {
-                let __realloc_op = ::quasar_lang::ops::realloc::Op {
-                    space: (200) as usize,
-                    payer: payer.to_account_view(),
-                };
-                __realloc_op.apply::<Account<MyData>, _>(&mut data, &__rent_ctx)?;
-            }
-            Ok((
-                Self {
-                    payer,
-                    data,
-                    system_program,
-                },
-                ReallocAccountsBumps,
-            ))
-        };
-        let (__parsed_accounts, __parsed_bumps) = __parsed_result?;
-        Ok((__parsed_accounts, __parsed_bumps))
+        unsafe {
+            <Self as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts,
+                __ix_data,
+                __program_id,
+            )
+        }
     }
 }
 unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -284,87 +284,82 @@ impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for ReallocAccounts
 }
 #[doc(hidden)]
 #[allow(unexpected_cfgs)]
-mod __realloc_accounts_client_macro {
-    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-    #[macro_export]
-    macro_rules! __realloc_accounts_instruction {
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
-            ::serialize_arg(& ix. $arg_name));)* _data };
-            ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
-            } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl
-            From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
-            .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg
-            > ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty
-            as ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)*
-            _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID,
-            accounts, data, } } }
-        };
-        (
-            $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
-            compact, remaining
-        ) => {
-            pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub
-            data : ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
-            remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta
-            >, } impl From < $struct_name > for ::quasar_lang::client::Instruction {
-            #[allow(unused_variables)] fn from(ix : $struct_name) ->
-            ::quasar_lang::client::Instruction { let mut accounts =
-            ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
-            ::quasar_lang::client::AccountMeta::new(ix.data, false),
-            ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
-            false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data
-            = ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
-            $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
-            ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix.
-            $arg_name));)* _data }; ::quasar_lang::client::Instruction { program_id :
-            $crate::ID, accounts, data, } } }
-        };
-    }
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+#[macro_export]
+macro_rules! __realloc_accounts_instruction {
+    ($struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* }) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub data :
+        ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
+        $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(ix.data, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::SerializeArg >
+        ::serialize_arg(& ix. $arg_name));)* _data }; ::quasar_lang::client::Instruction
+        { program_id : $crate::ID, accounts, data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub data :
+        ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* } impl From <
+        $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(ix.data, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; let data = { let mut _data = ::alloc::vec![$($disc),*]; $(_data
+        .extend_from_slice(& < $arg_ty as ::quasar_lang::client::CompactSerializeArg >
+        ::compact_header(& ix. $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub data :
+        ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(ix.data, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::SerializeArg > ::serialize_arg(& ix. $arg_name));)* _data
+        }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts, data,
+        } } }
+    };
+    (
+        $struct_name:ident, [$($disc:expr),*], { $($arg_name:ident : $arg_ty:ty),* },
+        compact, remaining
+    ) => {
+        pub struct $struct_name { pub payer : ::quasar_lang::prelude::Address, pub data :
+        ::quasar_lang::prelude::Address, $(pub $arg_name : $arg_ty,)* pub
+        remaining_accounts : ::alloc::vec::Vec < ::quasar_lang::client::AccountMeta >, }
+        impl From < $struct_name > for ::quasar_lang::client::Instruction {
+        #[allow(unused_variables)] fn from(ix : $struct_name) ->
+        ::quasar_lang::client::Instruction { let mut accounts =
+        ::alloc::vec![::quasar_lang::client::AccountMeta::new(ix.payer, true),
+        ::quasar_lang::client::AccountMeta::new(ix.data, false),
+        ::quasar_lang::client::AccountMeta::new_readonly(super::ReallocAccounts::__QUASAR_FIXED_ADDRESS_system_program,
+        false),]; accounts.extend(ix.remaining_accounts); let data = { let mut _data =
+        ::alloc::vec![$($disc),*]; $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_header(& ix.
+        $arg_name));)* $(_data.extend_from_slice(& < $arg_ty as
+        ::quasar_lang::client::CompactSerializeArg > ::compact_tail(& ix. $arg_name));)*
+        _data }; ::quasar_lang::client::Instruction { program_id : $crate::ID, accounts,
+        data, } } }
+    };
 }
 #[allow(non_upper_case_globals)]
 impl ReallocAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -375,26 +375,26 @@ impl ReallocAccounts {
 ::quasar_lang::__private_inventory::submit! {
     ::quasar_lang::idl_build::AccountsMetaFragment(|| {
     (::quasar_lang::idl_build::s("ReallocAccounts"),
-    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::__reexport::IdlAccountNode {
-    name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
+    ::quasar_lang::idl_build::vec![::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("payer"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("data"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("data"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(true), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Input {}, docs :
-    ::quasar_lang::idl_build::Vec::new(), },
-    ::quasar_lang::idl_build::__reexport::IdlAccountNode { name :
-    ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
+    ::quasar_lang::idl_build::Vec::new(), }),
+    ::quasar_lang::idl_build::AccountsMetaEntry::Node(::quasar_lang::idl_build::__reexport::IdlAccountNode
+    { name : ::quasar_lang::idl_build::s("systemProgram"), optional : false, writable :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), signer :
     ::quasar_lang::idl_build::__reexport::AccountFlag::Fixed(false), resolver :
     ::quasar_lang::idl_build::__reexport::IdlResolver::Const { address :
     ::quasar_lang::idl_build::address_to_base58(& < SystemProgram as
     ::quasar_lang::traits::Id > ::ID), }, docs : ::quasar_lang::idl_build::Vec::new(),
-    }],) })
+    })],) })
 }
 #[cfg(feature = "idl-build")]
 ::quasar_lang::__private_inventory::submit! {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -67,7 +67,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {
             ::quasar_lang::__internal::parse_account::<
                 Signer,
                 true,
-            >(input, base, __offset + 0usize)?
+            >(input, base, __offset)?
         };
         ::quasar_lang::debug_log!("account payer @0: validation passed");
         input = unsafe {

--- a/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/accounts_realloc.rs
@@ -109,13 +109,35 @@ impl ReallocAccounts {
     #[inline(always)]
     #[doc(hidden)]
     pub unsafe fn parse_accounts(
-        mut input: *mut u8,
+        input: *mut u8,
         buf: &mut core::mem::MaybeUninit<
             [::quasar_lang::__internal::AccountView; 3usize],
         >,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let base = buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView;
+        Self::parse_accounts_into(
+            input,
+            buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id,
+        )
+    }
+    /// Parse this struct's accounts directly into `base[__offset..]`.
+    ///
+    /// # Safety
+    ///
+    /// `base[__offset .. __offset + COUNT]` must be writable
+    /// `AccountView` slots, `base[..__offset]` must already be
+    /// initialized, and `input` must point at this struct's first
+    /// account entry.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn parse_accounts_into(
+        mut input: *mut u8,
+        base: *mut ::quasar_lang::__internal::AccountView,
+        __offset: usize,
+        __program_id: &::quasar_lang::prelude::Address,
+    ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
         {
             const __EXPECTED: u32 = ::quasar_lang::__internal::header_expected(
                 <Signer as ::quasar_lang::account_load::AccountLoad>::IS_SIGNER,
@@ -131,7 +153,7 @@ impl ReallocAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    0usize,
+                    __offset + 0usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -160,7 +182,7 @@ impl ReallocAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    1usize,
+                    __offset + 1usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -193,7 +215,7 @@ impl ReallocAccounts {
                 ::quasar_lang::__internal::parse_account(
                     input,
                     base,
-                    2usize,
+                    __offset + 2usize,
                     __EXPECTED,
                     __MASK,
                 )?
@@ -269,20 +291,7 @@ unsafe impl ::quasar_lang::traits::ParseAccountsRaw for ReallocAccounts {
         offset: usize,
         __program_id: &::quasar_lang::prelude::Address,
     ) -> Result<*mut u8, ::quasar_lang::__solana_program_error::ProgramError> {
-        let mut __inner_buf = core::mem::MaybeUninit::<
-            [::quasar_lang::__internal::AccountView; 3usize],
-        >::uninit();
-        let input = Self::parse_accounts(input, &mut __inner_buf, __program_id)?;
-        let __inner = core::mem::ManuallyDrop::new(__inner_buf.assume_init());
-        let mut __j = 0usize;
-        while __j < 3usize {
-            core::ptr::write(
-                base.add(offset + __j),
-                core::ptr::read(__inner.as_ptr().add(__j)),
-            );
-            __j += 1;
-        }
-        Ok(input)
+        unsafe { Self::parse_accounts_into(input, base, offset, __program_id) }
     }
 }
 impl<'input> ::quasar_lang::remaining::RemainingItem<'input> for ReallocAccounts {

--- a/derive/tests/compatibility-v0.1.0/expansions/declare_program_fixed_cpi.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/declare_program_fixed_cpi.rs
@@ -173,7 +173,7 @@ pub mod external_vault {
             let mut __buf = core::mem::MaybeUninit::<[u8; 133usize]>::uninit();
             let __ptr = __buf.as_mut_ptr() as *mut u8;
             unsafe {
-                core::ptr::write(__ptr.add(0usize), 9u8);
+                core::ptr::write(__ptr, 9u8);
                 core::ptr::write(__ptr.add(1usize), 4u8);
                 core::ptr::copy_nonoverlapping(
                     config.limits[0usize].to_le_bytes().as_ptr(),

--- a/derive/tests/compatibility-v0.1.0/expansions/event_basic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/event_basic.rs
@@ -13,7 +13,7 @@ impl ::quasar_lang::traits::Event for MakeEvent {
     const DISCRIMINATOR: &'static [u8] = &[1];
     const DATA_SIZE: usize = 80usize;
     #[inline(always)]
-    fn write_data(&self, buf: &mut [u8]) {
+    unsafe fn write_data(&self, buf: &mut [u8]) {
         unsafe {
             core::ptr::copy_nonoverlapping(
                 self as *const Self as *const u8,
@@ -36,9 +36,11 @@ impl ::quasar_lang::traits::Event for MakeEvent {
         let data_offset = unsafe {
             ::quasar_lang::event::write_cpi_disc(ptr, Self::DISCRIMINATOR)
         };
-        self.write_data(unsafe {
-            core::slice::from_raw_parts_mut(ptr.add(data_offset), __DATA_SIZE)
-        });
+        unsafe {
+            self.write_data(
+                core::slice::from_raw_parts_mut(ptr.add(data_offset), __DATA_SIZE),
+            );
+        }
         f(unsafe { buf.assume_init_ref() })
     }
 }
@@ -53,10 +55,12 @@ impl MakeEvent {
                 <Self as ::quasar_lang::traits::Event>::DISCRIMINATOR,
             )
         };
-        <Self as ::quasar_lang::traits::Event>::write_data(
-            self,
-            unsafe { core::slice::from_raw_parts_mut(ptr.add(data_offset), 80usize) },
-        );
+        unsafe {
+            <Self as ::quasar_lang::traits::Event>::write_data(
+                self,
+                core::slice::from_raw_parts_mut(ptr.add(data_offset), 80usize),
+            );
+        }
         ::quasar_lang::log::log_data(&[unsafe { buf.assume_init_ref() }]);
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
@@ -39,7 +39,7 @@ fn __transfer_body(
         Ok(())
     }
 }
-#[inline(always)]
+#[inline]
 fn __quasar_direct_transfer(
     __program_id: &[u8; 32],
     __accounts_start: *mut u8,
@@ -60,10 +60,10 @@ fn __quasar_direct_transfer(
                 __program_id_addr,
             )?
         };
-        let mut __accounts_buf = unsafe { __buf.assume_init() };
+        let __accounts_buf = unsafe { &mut *__buf.as_mut_ptr() };
         unsafe {
             <Transfer as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-                &mut __accounts_buf,
+                __accounts_buf,
                 __ix_data,
                 __program_id_addr,
             )?

--- a/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
@@ -48,9 +48,21 @@ fn __quasar_direct_transfer(
     let __program_id_addr = unsafe {
         &*(__program_id as *const [u8; 32] as *const ::quasar_lang::prelude::Address)
     };
-    let (__accounts, __bumps) = unsafe {
-        <Transfer>::parse_direct_with_instruction_data_unchecked(
+    let mut __buf = core::mem::MaybeUninit::<
+        [::quasar_lang::__internal::AccountView; <Transfer as ::quasar_lang::traits::AccountCount>::COUNT],
+    >::uninit();
+    let _ = unsafe {
+        <Transfer as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
             __accounts_start,
+            __buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+            0usize,
+            __program_id_addr,
+        )?
+    };
+    let mut __accounts_buf = unsafe { __buf.assume_init() };
+    let (__accounts, __bumps) = unsafe {
+        <Transfer as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+            &mut __accounts_buf,
             __ix_data,
             __program_id_addr,
         )?

--- a/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/instruction_fixed_and_dynamic.rs
@@ -48,24 +48,26 @@ fn __quasar_direct_transfer(
     let __program_id_addr = unsafe {
         &*(__program_id as *const [u8; 32] as *const ::quasar_lang::prelude::Address)
     };
-    let mut __buf = core::mem::MaybeUninit::<
-        [::quasar_lang::__internal::AccountView; <Transfer as ::quasar_lang::traits::AccountCount>::COUNT],
-    >::uninit();
-    let _ = unsafe {
-        <Transfer as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
-            __accounts_start,
-            __buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
-            0usize,
-            __program_id_addr,
-        )?
-    };
-    let mut __accounts_buf = unsafe { __buf.assume_init() };
-    let (__accounts, __bumps) = unsafe {
-        <Transfer as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
-            &mut __accounts_buf,
-            __ix_data,
-            __program_id_addr,
-        )?
+    let (__accounts, __bumps) = {
+        let mut __buf = core::mem::MaybeUninit::<
+            [::quasar_lang::__internal::AccountView; <Transfer as ::quasar_lang::traits::AccountCount>::COUNT],
+        >::uninit();
+        let _ = unsafe {
+            <Transfer as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
+                __accounts_start,
+                __buf.as_mut_ptr() as *mut ::quasar_lang::__internal::AccountView,
+                0usize,
+                __program_id_addr,
+            )?
+        };
+        let mut __accounts_buf = unsafe { __buf.assume_init() };
+        unsafe {
+            <Transfer as ::quasar_lang::traits::ParseAccountsUnchecked>::parse_with_instruction_data_unchecked(
+                &mut __accounts_buf,
+                __ix_data,
+                __program_id_addr,
+            )?
+        }
     };
     __transfer_body(::quasar_lang::context::Ctx {
         accounts: __accounts,

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_raw_match_fallback.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_raw_match_fallback.rs
@@ -1,0 +1,251 @@
+::quasar_lang::define_account!(
+    pub struct QuasarRawGapDemoProgram => [::quasar_lang::checks::Executable,
+    ::quasar_lang::checks::Address]
+);
+impl ::quasar_lang::traits::Id for QuasarRawGapDemoProgram {
+    const ID: ::quasar_lang::prelude::Address = crate::ID;
+}
+#[repr(transparent)]
+pub struct EventAuthority {
+    view: ::quasar_lang::__internal::AccountView,
+}
+impl ::quasar_lang::traits::AsAccountView for EventAuthority {
+    #[inline(always)]
+    fn to_account_view(&self) -> &::quasar_lang::__internal::AccountView {
+        &self.view
+    }
+}
+impl EventAuthority {
+    const __PDA: (::quasar_lang::prelude::Address, u8) = ::quasar_lang::pda::find_program_address_const(
+        &[b"__event_authority"],
+        &crate::ID,
+    );
+    pub const ADDRESS: ::quasar_lang::prelude::Address = Self::__PDA.0;
+    pub const BUMP: u8 = Self::__PDA.1;
+    #[inline(always)]
+    pub fn from_account_view(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> Result<&Self, ::quasar_lang::__solana_program_error::ProgramError> {
+        if !::quasar_lang::keys_eq(view.address(), &Self::ADDRESS) {
+            return Err(
+                ::quasar_lang::__solana_program_error::ProgramError::InvalidSeeds,
+            );
+        }
+        Ok(unsafe {
+            &*(view as *const ::quasar_lang::__internal::AccountView as *const Self)
+        })
+    }
+    /// Construct without validation.
+    ///
+    /// # Safety
+    /// Caller must ensure account address matches the expected PDA.
+    #[inline(always)]
+    pub unsafe fn from_account_view_unchecked(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> &Self {
+        unsafe {
+            &*(view as *const ::quasar_lang::__internal::AccountView as *const Self)
+        }
+    }
+}
+unsafe impl ::quasar_lang::traits::StaticView for EventAuthority {}
+impl ::quasar_lang::account_load::AccountLoad for EventAuthority {
+    #[inline(always)]
+    fn check(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        if !::quasar_lang::keys_eq(view.address(), &Self::ADDRESS) {
+            return Err(
+                ::quasar_lang::__solana_program_error::ProgramError::InvalidSeeds,
+            );
+        }
+        Ok(())
+    }
+}
+#[cfg_attr(not(any(target_arch = "bpf", target_os = "solana")), allow(dead_code))]
+mod quasar_raw_gap_demo {
+    use super::*;
+    #[instruction(discriminator = 1, raw)]
+    pub fn raw_one(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+    #[instruction(discriminator = 7, raw)]
+    pub fn raw_seven(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+    #[inline(always)]
+    fn __handle_event(
+        ptr: *mut u8,
+        instruction_data: &[u8],
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        unsafe {
+            ::quasar_lang::event::handle_event(
+                ptr,
+                instruction_data,
+                &super::EventAuthority::ADDRESS,
+            )
+        }
+    }
+    #[inline(always)]
+    fn __dispatch(
+        ptr: *mut u8,
+        instruction_data: &[u8],
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
+            return __handle_event(ptr, instruction_data);
+        }
+        if instruction_data.len() >= 1usize {
+            let __raw_disc: [u8; 1usize] = unsafe {
+                *(instruction_data.as_ptr() as *const [u8; 1usize])
+            };
+            if matches!(__raw_disc, [1] | [7]) {
+                let __raw_program_id: &[u8; 32] = unsafe {
+                    &*(instruction_data.as_ptr().add(instruction_data.len())
+                        as *const [u8; 32])
+                };
+                const __RAW_U64: usize = core::mem::size_of::<u64>();
+                let __raw_num_accounts = unsafe { *(ptr as *const u64) };
+                let __raw_accounts_start = unsafe { (ptr as *mut u8).add(__RAW_U64) };
+                let __raw_boundary = unsafe { instruction_data.as_ptr().sub(__RAW_U64) };
+                const __RAW_MAX: usize = 64;
+                let __raw_count = core::cmp::min(__raw_num_accounts as usize, __RAW_MAX);
+                let mut __raw_buf = core::mem::MaybeUninit::<
+                    [::quasar_lang::__internal::AccountView; __RAW_MAX],
+                >::uninit();
+                let (__raw_parsed, __raw_remaining) = unsafe {
+                    ::quasar_lang::__internal::parse_all_accounts_unchecked(
+                        __raw_accounts_start,
+                        __raw_buf.as_mut_ptr()
+                            as *mut ::quasar_lang::__internal::AccountView,
+                        __raw_count,
+                        __raw_boundary,
+                    )?
+                };
+                let __raw_accounts = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        __raw_buf.as_mut_ptr()
+                            as *mut ::quasar_lang::__internal::AccountView,
+                        __raw_parsed,
+                    )
+                };
+                let __raw_ctx = unsafe {
+                    ::quasar_lang::context::Context::from_raw_parts(
+                        __raw_program_id,
+                        __raw_accounts,
+                        &instruction_data[1usize..],
+                        __raw_remaining,
+                        __raw_boundary as *const u8,
+                    )
+                };
+                match __raw_disc {
+                    [1] => {
+                        return raw_one(__raw_ctx);
+                    }
+                    [7] => {
+                        return raw_seven(__raw_ctx);
+                    }
+                    _ => unsafe { core::hint::unreachable_unchecked() }
+                }
+            }
+        }
+        Err(::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData)
+    }
+    #[unsafe(no_mangle)]
+    #[allow(unexpected_cfgs)]
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+    pub unsafe extern "C" fn entrypoint(
+        ptr: *mut u8,
+        instruction_data: *const u8,
+    ) -> u64 {
+        #[cfg(feature = "alloc")]
+        {
+            let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
+            unsafe {
+                *(heap_start as *mut usize) = heap_start + core::mem::size_of::<usize>();
+            }
+        }
+        let instruction_data = unsafe {
+            core::slice::from_raw_parts(
+                instruction_data,
+                *(instruction_data.sub(8) as *const u64) as usize,
+            )
+        };
+        match __dispatch(ptr, instruction_data) {
+            Ok(_) => 0,
+            Err(e) => e.into(),
+        }
+    }
+    #[allow(unexpected_cfgs)]
+    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+    pub mod cpi {
+        use super::*;
+    }
+}
+#[allow(unexpected_cfgs)]
+#[cfg(any(not(any(target_arch = "bpf", target_os = "solana")), feature = "alloc"))]
+extern crate alloc;
+#[allow(unexpected_cfgs)]
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+pub use quasar_raw_gap_demo::cpi;
+#[allow(unexpected_cfgs)]
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    ::quasar_lang::abort_program()
+}
+#[allow(unexpected_cfgs)]
+#[cfg(feature = "alloc")]
+::quasar_lang::heap_alloc!();
+#[allow(unexpected_cfgs)]
+#[cfg(not(feature = "alloc"))]
+::quasar_lang::no_alloc!();
+#[cfg(feature = "idl-build")]
+::quasar_lang::__private_inventory::submit! {
+    ::quasar_lang::idl_build::InstructionFragment { build : { fn __build() ->
+    ::quasar_lang::idl_build::__reexport::IdlInstruction {
+    ::quasar_lang::idl_build::__reexport::IdlInstruction { name :
+    ::quasar_lang::idl_build::s("raw_one"), discriminator :
+    ::quasar_lang::idl_build::vec![1u8], docs : ::quasar_lang::idl_build::Vec::new(),
+    accounts : ::quasar_lang::idl_build::Vec::new(), args :
+    ::quasar_lang::idl_build::Vec::new(), layout : None, remaining_accounts : None, } }
+    __build }, accounts_struct_name : "", discriminator_source :
+    ::quasar_lang::idl_build::InstructionDiscriminatorSource::Explicit, }
+}
+#[cfg(feature = "idl-build")]
+::quasar_lang::__private_inventory::submit! {
+    ::quasar_lang::idl_build::InstructionFragment { build : { fn __build() ->
+    ::quasar_lang::idl_build::__reexport::IdlInstruction {
+    ::quasar_lang::idl_build::__reexport::IdlInstruction { name :
+    ::quasar_lang::idl_build::s("raw_seven"), discriminator :
+    ::quasar_lang::idl_build::vec![7u8], docs : ::quasar_lang::idl_build::Vec::new(),
+    accounts : ::quasar_lang::idl_build::Vec::new(), args :
+    ::quasar_lang::idl_build::Vec::new(), layout : None, remaining_accounts : None, } }
+    __build }, accounts_struct_name : "", discriminator_source :
+    ::quasar_lang::idl_build::InstructionDiscriminatorSource::Explicit, }
+}
+/// Assemble all IDL fragments and return JSON.
+#[cfg(feature = "idl-build")]
+pub fn __quasar_build_idl() -> ::quasar_lang::idl_build::String {
+    let address = ::quasar_lang::idl_build::address_to_base58(&crate::ID);
+    let idl = ::quasar_lang::idl_build::build_idl(
+        &address,
+        "quasar_raw_gap_demo",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    ::quasar_lang::idl_build::__reexport::serde_json::to_string_pretty(&idl)
+        .expect("generated IDL should serialize")
+}
+#[allow(unexpected_cfgs)]
+#[cfg(
+    all(feature = "idl-build", test, not(any(target_os = "solana", target_arch = "bpf")))
+)]
+#[test]
+fn __quasar_emit_idl() {
+    extern crate std;
+    std::println!("__QUASAR_IDL_JSON_BEGIN__");
+    std::println!("{}", __quasar_build_idl());
+    std::println!("__QUASAR_IDL_JSON_END__");
+}

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_raw_table.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_raw_table.rs
@@ -1,0 +1,334 @@
+::quasar_lang::define_account!(
+    pub struct QuasarRawDemoProgram => [::quasar_lang::checks::Executable,
+    ::quasar_lang::checks::Address]
+);
+impl ::quasar_lang::traits::Id for QuasarRawDemoProgram {
+    const ID: ::quasar_lang::prelude::Address = crate::ID;
+}
+#[repr(transparent)]
+pub struct EventAuthority {
+    view: ::quasar_lang::__internal::AccountView,
+}
+impl ::quasar_lang::traits::AsAccountView for EventAuthority {
+    #[inline(always)]
+    fn to_account_view(&self) -> &::quasar_lang::__internal::AccountView {
+        &self.view
+    }
+}
+impl EventAuthority {
+    const __PDA: (::quasar_lang::prelude::Address, u8) = ::quasar_lang::pda::find_program_address_const(
+        &[b"__event_authority"],
+        &crate::ID,
+    );
+    pub const ADDRESS: ::quasar_lang::prelude::Address = Self::__PDA.0;
+    pub const BUMP: u8 = Self::__PDA.1;
+    #[inline(always)]
+    pub fn from_account_view(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> Result<&Self, ::quasar_lang::__solana_program_error::ProgramError> {
+        if !::quasar_lang::keys_eq(view.address(), &Self::ADDRESS) {
+            return Err(
+                ::quasar_lang::__solana_program_error::ProgramError::InvalidSeeds,
+            );
+        }
+        Ok(unsafe {
+            &*(view as *const ::quasar_lang::__internal::AccountView as *const Self)
+        })
+    }
+    /// Construct without validation.
+    ///
+    /// # Safety
+    /// Caller must ensure account address matches the expected PDA.
+    #[inline(always)]
+    pub unsafe fn from_account_view_unchecked(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> &Self {
+        unsafe {
+            &*(view as *const ::quasar_lang::__internal::AccountView as *const Self)
+        }
+    }
+}
+unsafe impl ::quasar_lang::traits::StaticView for EventAuthority {}
+impl ::quasar_lang::account_load::AccountLoad for EventAuthority {
+    #[inline(always)]
+    fn check(
+        view: &::quasar_lang::__internal::AccountView,
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        if !::quasar_lang::keys_eq(view.address(), &Self::ADDRESS) {
+            return Err(
+                ::quasar_lang::__solana_program_error::ProgramError::InvalidSeeds,
+            );
+        }
+        Ok(())
+    }
+}
+#[cfg_attr(not(any(target_arch = "bpf", target_os = "solana")), allow(dead_code))]
+mod quasar_raw_demo {
+    use super::*;
+    #[instruction(discriminator = 0)]
+    pub fn normal(ctx: Ctx<NormalInit>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+    #[instruction(discriminator = 1, raw)]
+    pub fn raw_one(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+    #[instruction(discriminator = 2, raw)]
+    pub fn raw_two(ctx: Context) -> Result<(), ProgramError> {
+        let _ = ctx.data;
+        Ok(())
+    }
+    #[inline(always)]
+    fn __handle_event(
+        ptr: *mut u8,
+        instruction_data: &[u8],
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        unsafe {
+            ::quasar_lang::event::handle_event(
+                ptr,
+                instruction_data,
+                &super::EventAuthority::ADDRESS,
+            )
+        }
+    }
+    #[inline(always)]
+    fn __dispatch(
+        ptr: *mut u8,
+        instruction_data: &[u8],
+    ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
+        if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
+            return __handle_event(ptr, instruction_data);
+        }
+        if instruction_data.len() >= 1 {
+            let __raw_disc_byte = instruction_data[0];
+            let __raw_idx = __raw_disc_byte.wrapping_sub(1u8) as usize;
+            if __raw_idx < 2usize {
+                let __raw_program_id: &[u8; 32] = unsafe {
+                    &*(instruction_data.as_ptr().add(instruction_data.len())
+                        as *const [u8; 32])
+                };
+                const __RAW_U64: usize = core::mem::size_of::<u64>();
+                let __raw_num_accounts = unsafe { *(ptr as *const u64) };
+                let __raw_accounts_start = unsafe { (ptr as *mut u8).add(__RAW_U64) };
+                let __raw_boundary = unsafe { instruction_data.as_ptr().sub(__RAW_U64) };
+                const __RAW_MAX: usize = 64;
+                let __raw_count = core::cmp::min(__raw_num_accounts as usize, __RAW_MAX);
+                let mut __raw_buf = core::mem::MaybeUninit::<
+                    [::quasar_lang::__internal::AccountView; __RAW_MAX],
+                >::uninit();
+                let (__raw_parsed, __raw_remaining) = unsafe {
+                    ::quasar_lang::__internal::parse_all_accounts_unchecked(
+                        __raw_accounts_start,
+                        __raw_buf.as_mut_ptr()
+                            as *mut ::quasar_lang::__internal::AccountView,
+                        __raw_count,
+                        __raw_boundary,
+                    )?
+                };
+                let __raw_accounts = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        __raw_buf.as_mut_ptr()
+                            as *mut ::quasar_lang::__internal::AccountView,
+                        __raw_parsed,
+                    )
+                };
+                let __raw_ctx = unsafe {
+                    ::quasar_lang::context::Context::from_raw_parts(
+                        __raw_program_id,
+                        __raw_accounts,
+                        &instruction_data[1usize..],
+                        __raw_remaining,
+                        __raw_boundary as *const u8,
+                    )
+                };
+                type __RawHandler = fn(
+                    ::quasar_lang::context::Context,
+                ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError>;
+                let __raw_table: [__RawHandler; 2usize] = [raw_one, raw_two];
+                return __raw_table[__raw_idx](__raw_ctx);
+            }
+        }
+        {
+            let __program_id: &[u8; 32] = unsafe {
+                &*(instruction_data.as_ptr().add(instruction_data.len())
+                    as *const [u8; 32])
+            };
+            let __program_id_addr: &::quasar_lang::prelude::Address = unsafe {
+                &*(__program_id as *const [u8; 32]
+                    as *const ::quasar_lang::prelude::Address)
+            };
+            const __U64_SIZE: usize = core::mem::size_of::<u64>();
+            let __num_accounts = unsafe { *(ptr as *const u64) };
+            let __accounts_start = unsafe { (ptr as *mut u8).add(__U64_SIZE) };
+            if instruction_data.len() < 1usize {
+                return Err(
+                    ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
+                );
+            }
+            let __disc: [u8; 1usize] = unsafe {
+                *(instruction_data.as_ptr() as *const [u8; 1usize])
+            };
+            match __disc {
+                [0] => {
+                    if (__num_accounts as usize)
+                        < <NormalInit as ::quasar_lang::traits::AccountCount>::COUNT
+                    {
+                        return Err(
+                            ::quasar_lang::__solana_program_error::ProgramError::NotEnoughAccountKeys,
+                        );
+                    }
+                    if <NormalInit as ::quasar_lang::traits::AccountCount>::COUNT
+                        >= 8usize
+                    {
+                        __quasar_direct_normal(
+                            __program_id,
+                            __accounts_start,
+                            unsafe { instruction_data.get_unchecked(1usize..) },
+                        )
+                    } else {
+                        let mut __buf = core::mem::MaybeUninit::<
+                            [::quasar_lang::__internal::AccountView; <NormalInit as ::quasar_lang::traits::AccountCount>::COUNT],
+                        >::uninit();
+                        let __remaining_ptr = unsafe {
+                            <NormalInit as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
+                                __accounts_start,
+                                __buf.as_mut_ptr()
+                                    as *mut ::quasar_lang::__internal::AccountView,
+                                0usize,
+                                __program_id_addr,
+                            )?
+                        };
+                        let mut __accounts = unsafe { __buf.assume_init() };
+                        let __data_after_disc = unsafe {
+                            instruction_data.get_unchecked(1usize..)
+                        };
+                        normal(unsafe {
+                            ::quasar_lang::context::Context::from_raw_parts(
+                                __program_id,
+                                &mut __accounts,
+                                __data_after_disc,
+                                __remaining_ptr,
+                                instruction_data.as_ptr().sub(__U64_SIZE),
+                            )
+                        })
+                    }
+                }
+                _ => {
+                    Err(
+                        ::quasar_lang::__solana_program_error::ProgramError::InvalidInstructionData,
+                    )
+                }
+            }
+        }
+    }
+    #[unsafe(no_mangle)]
+    #[allow(unexpected_cfgs)]
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+    pub unsafe extern "C" fn entrypoint(
+        ptr: *mut u8,
+        instruction_data: *const u8,
+    ) -> u64 {
+        #[cfg(feature = "alloc")]
+        {
+            let heap_start = super::allocator::HEAP_START_ADDRESS as usize;
+            unsafe {
+                *(heap_start as *mut usize) = heap_start + core::mem::size_of::<usize>();
+            }
+        }
+        let instruction_data = unsafe {
+            core::slice::from_raw_parts(
+                instruction_data,
+                *(instruction_data.sub(8) as *const u64) as usize,
+            )
+        };
+        match __dispatch(ptr, instruction_data) {
+            Ok(_) => 0,
+            Err(e) => e.into(),
+        }
+    }
+    #[allow(unexpected_cfgs)]
+    #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+    pub mod cpi {
+        use super::*;
+        __normal_init_instruction!(NormalInstruction, [0u8], {});
+    }
+}
+#[allow(unexpected_cfgs)]
+#[cfg(any(not(any(target_arch = "bpf", target_os = "solana")), feature = "alloc"))]
+extern crate alloc;
+#[allow(unexpected_cfgs)]
+#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
+pub use quasar_raw_demo::cpi;
+#[allow(unexpected_cfgs)]
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    ::quasar_lang::abort_program()
+}
+#[allow(unexpected_cfgs)]
+#[cfg(feature = "alloc")]
+::quasar_lang::heap_alloc!();
+#[allow(unexpected_cfgs)]
+#[cfg(not(feature = "alloc"))]
+::quasar_lang::no_alloc!();
+#[cfg(feature = "idl-build")]
+::quasar_lang::__private_inventory::submit! {
+    ::quasar_lang::idl_build::InstructionFragment { build : { fn __build() ->
+    ::quasar_lang::idl_build::__reexport::IdlInstruction {
+    ::quasar_lang::idl_build::__reexport::IdlInstruction { name :
+    ::quasar_lang::idl_build::s("normal"), discriminator :
+    ::quasar_lang::idl_build::vec![0u8], docs : ::quasar_lang::idl_build::Vec::new(),
+    accounts : ::quasar_lang::idl_build::Vec::new(), args :
+    ::quasar_lang::idl_build::vec![], layout : None, remaining_accounts : None, } }
+    __build }, accounts_struct_name : "NormalInit", discriminator_source :
+    ::quasar_lang::idl_build::InstructionDiscriminatorSource::Explicit, }
+}
+#[cfg(feature = "idl-build")]
+::quasar_lang::__private_inventory::submit! {
+    ::quasar_lang::idl_build::InstructionFragment { build : { fn __build() ->
+    ::quasar_lang::idl_build::__reexport::IdlInstruction {
+    ::quasar_lang::idl_build::__reexport::IdlInstruction { name :
+    ::quasar_lang::idl_build::s("raw_one"), discriminator :
+    ::quasar_lang::idl_build::vec![1u8], docs : ::quasar_lang::idl_build::Vec::new(),
+    accounts : ::quasar_lang::idl_build::Vec::new(), args :
+    ::quasar_lang::idl_build::Vec::new(), layout : None, remaining_accounts : None, } }
+    __build }, accounts_struct_name : "", discriminator_source :
+    ::quasar_lang::idl_build::InstructionDiscriminatorSource::Explicit, }
+}
+#[cfg(feature = "idl-build")]
+::quasar_lang::__private_inventory::submit! {
+    ::quasar_lang::idl_build::InstructionFragment { build : { fn __build() ->
+    ::quasar_lang::idl_build::__reexport::IdlInstruction {
+    ::quasar_lang::idl_build::__reexport::IdlInstruction { name :
+    ::quasar_lang::idl_build::s("raw_two"), discriminator :
+    ::quasar_lang::idl_build::vec![2u8], docs : ::quasar_lang::idl_build::Vec::new(),
+    accounts : ::quasar_lang::idl_build::Vec::new(), args :
+    ::quasar_lang::idl_build::Vec::new(), layout : None, remaining_accounts : None, } }
+    __build }, accounts_struct_name : "", discriminator_source :
+    ::quasar_lang::idl_build::InstructionDiscriminatorSource::Explicit, }
+}
+/// Assemble all IDL fragments and return JSON.
+#[cfg(feature = "idl-build")]
+pub fn __quasar_build_idl() -> ::quasar_lang::idl_build::String {
+    let address = ::quasar_lang::idl_build::address_to_base58(&crate::ID);
+    let idl = ::quasar_lang::idl_build::build_idl(
+        &address,
+        "quasar_raw_demo",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    ::quasar_lang::idl_build::__reexport::serde_json::to_string_pretty(&idl)
+        .expect("generated IDL should serialize")
+}
+#[allow(unexpected_cfgs)]
+#[cfg(
+    all(feature = "idl-build", test, not(any(target_os = "solana", target_arch = "bpf")))
+)]
+#[test]
+fn __quasar_emit_idl() {
+    extern crate std;
+    std::println!("__QUASAR_IDL_JSON_BEGIN__");
+    std::println!("{}", __quasar_build_idl());
+    std::println!("__QUASAR_IDL_JSON_END__");
+}

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
@@ -106,6 +106,10 @@ mod quasar_demo {
                 &*(instruction_data.as_ptr().add(instruction_data.len())
                     as *const [u8; 32])
             };
+            let __program_id_addr: &::quasar_lang::prelude::Address = unsafe {
+                &*(__program_id as *const [u8; 32]
+                    as *const ::quasar_lang::prelude::Address)
+            };
             const __U64_SIZE: usize = core::mem::size_of::<u64>();
             let __num_accounts = unsafe { *(ptr as *const u64) };
             let __accounts_start = unsafe { (ptr as *mut u8).add(__U64_SIZE) };
@@ -135,36 +139,31 @@ mod quasar_demo {
                             unsafe { instruction_data.get_unchecked(1usize..) },
                         )
                     } else {
-                        {
-                            let mut __buf = core::mem::MaybeUninit::<
-                                [::quasar_lang::__internal::AccountView; <Initialize as ::quasar_lang::traits::AccountCount>::COUNT],
-                            >::uninit();
-                            let __remaining_ptr = unsafe {
-                                <Initialize as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
-                                    __accounts_start,
-                                    __buf.as_mut_ptr()
-                                        as *mut ::quasar_lang::__internal::AccountView,
-                                    0usize,
-                                    unsafe {
-                                        &*(__program_id as *const [u8; 32]
-                                            as *const ::quasar_lang::prelude::Address)
-                                    },
-                                )?
-                            };
-                            let mut __accounts = unsafe { __buf.assume_init() };
-                            let __data_after_disc = unsafe {
-                                instruction_data.get_unchecked(1usize..)
-                            };
-                            initialize(unsafe {
-                                ::quasar_lang::context::Context::from_raw_parts(
-                                    __program_id,
-                                    &mut __accounts,
-                                    __data_after_disc,
-                                    __remaining_ptr,
-                                    instruction_data.as_ptr().sub(__U64_SIZE),
-                                )
-                            })
-                        }
+                        let mut __buf = core::mem::MaybeUninit::<
+                            [::quasar_lang::__internal::AccountView; <Initialize as ::quasar_lang::traits::AccountCount>::COUNT],
+                        >::uninit();
+                        let __remaining_ptr = unsafe {
+                            <Initialize as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
+                                __accounts_start,
+                                __buf.as_mut_ptr()
+                                    as *mut ::quasar_lang::__internal::AccountView,
+                                0usize,
+                                __program_id_addr,
+                            )?
+                        };
+                        let mut __accounts = unsafe { __buf.assume_init() };
+                        let __data_after_disc = unsafe {
+                            instruction_data.get_unchecked(1usize..)
+                        };
+                        initialize(unsafe {
+                            ::quasar_lang::context::Context::from_raw_parts(
+                                __program_id,
+                                &mut __accounts,
+                                __data_after_disc,
+                                __remaining_ptr,
+                                instruction_data.as_ptr().sub(__U64_SIZE),
+                            )
+                        })
                     }
                 }
                 [1] => {
@@ -182,36 +181,31 @@ mod quasar_demo {
                             unsafe { instruction_data.get_unchecked(1usize..) },
                         )
                     } else {
-                        {
-                            let mut __buf = core::mem::MaybeUninit::<
-                                [::quasar_lang::__internal::AccountView; <Update as ::quasar_lang::traits::AccountCount>::COUNT],
-                            >::uninit();
-                            let __remaining_ptr = unsafe {
-                                <Update as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
-                                    __accounts_start,
-                                    __buf.as_mut_ptr()
-                                        as *mut ::quasar_lang::__internal::AccountView,
-                                    0usize,
-                                    unsafe {
-                                        &*(__program_id as *const [u8; 32]
-                                            as *const ::quasar_lang::prelude::Address)
-                                    },
-                                )?
-                            };
-                            let mut __accounts = unsafe { __buf.assume_init() };
-                            let __data_after_disc = unsafe {
-                                instruction_data.get_unchecked(1usize..)
-                            };
-                            update(unsafe {
-                                ::quasar_lang::context::Context::from_raw_parts(
-                                    __program_id,
-                                    &mut __accounts,
-                                    __data_after_disc,
-                                    __remaining_ptr,
-                                    instruction_data.as_ptr().sub(__U64_SIZE),
-                                )
-                            })
-                        }
+                        let mut __buf = core::mem::MaybeUninit::<
+                            [::quasar_lang::__internal::AccountView; <Update as ::quasar_lang::traits::AccountCount>::COUNT],
+                        >::uninit();
+                        let __remaining_ptr = unsafe {
+                            <Update as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
+                                __accounts_start,
+                                __buf.as_mut_ptr()
+                                    as *mut ::quasar_lang::__internal::AccountView,
+                                0usize,
+                                __program_id_addr,
+                            )?
+                        };
+                        let mut __accounts = unsafe { __buf.assume_init() };
+                        let __data_after_disc = unsafe {
+                            instruction_data.get_unchecked(1usize..)
+                        };
+                        update(unsafe {
+                            ::quasar_lang::context::Context::from_raw_parts(
+                                __program_id,
+                                &mut __accounts,
+                                __data_after_disc,
+                                __remaining_ptr,
+                                instruction_data.as_ptr().sub(__U64_SIZE),
+                            )
+                        })
                     }
                 }
                 _ => {

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
@@ -140,9 +140,11 @@ mod quasar_demo {
                                 [::quasar_lang::__internal::AccountView; <Initialize as ::quasar_lang::traits::AccountCount>::COUNT],
                             >::uninit();
                             let __remaining_ptr = unsafe {
-                                <Initialize>::parse_accounts(
+                                <Initialize as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
                                     __accounts_start,
-                                    &mut __buf,
+                                    __buf.as_mut_ptr()
+                                        as *mut ::quasar_lang::__internal::AccountView,
+                                    0usize,
                                     unsafe {
                                         &*(__program_id as *const [u8; 32]
                                             as *const ::quasar_lang::prelude::Address)
@@ -185,9 +187,11 @@ mod quasar_demo {
                                 [::quasar_lang::__internal::AccountView; <Update as ::quasar_lang::traits::AccountCount>::COUNT],
                             >::uninit();
                             let __remaining_ptr = unsafe {
-                                <Update>::parse_accounts(
+                                <Update as ::quasar_lang::traits::ParseAccountsRaw>::parse_accounts_raw(
                                     __accounts_start,
-                                    &mut __buf,
+                                    __buf.as_mut_ptr()
+                                        as *mut ::quasar_lang::__internal::AccountView,
+                                    0usize,
                                     unsafe {
                                         &*(__program_id as *const [u8; 32]
                                             as *const ::quasar_lang::prelude::Address)

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
@@ -62,7 +62,7 @@ impl ::quasar_lang::account_load::AccountLoad for EventAuthority {
         Ok(())
     }
 }
-#[allow(dead_code)]
+#[cfg_attr(not(any(target_arch = "bpf", target_os = "solana")), allow(dead_code))]
 mod quasar_demo {
     use super::*;
     #[instruction(discriminator = 0)]
@@ -253,10 +253,7 @@ mod quasar_demo {
     }
 }
 #[allow(unexpected_cfgs)]
-#[cfg(not(any(target_arch = "bpf", target_os = "solana")))]
-extern crate alloc;
-#[allow(unexpected_cfgs)]
-#[cfg(all(any(target_os = "solana", target_arch = "bpf"), feature = "alloc"))]
+#[cfg(any(not(any(target_arch = "bpf", target_os = "solana")), feature = "alloc"))]
 extern crate alloc;
 #[allow(unexpected_cfgs)]
 #[cfg(not(any(target_arch = "bpf", target_os = "solana")))]

--- a/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/program_dispatch_two_ix.rs
@@ -91,8 +91,7 @@ mod quasar_demo {
         ptr: *mut u8,
         instruction_data: &[u8],
     ) -> Result<(), ::quasar_lang::__solana_program_error::ProgramError> {
-        const __QUASAR_NEEDS_EVENT_CPI: bool = false
-            || <Initialize as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI
+        const __QUASAR_NEEDS_EVENT_CPI: bool = <Initialize as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI
             || <Update as ::quasar_lang::traits::AccountCount>::NEEDS_EVENT_CPI;
         if !instruction_data.is_empty() && instruction_data[0] == 0xFF {
             if __QUASAR_NEEDS_EVENT_CPI {

--- a/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
@@ -68,11 +68,7 @@ impl<'__quasar_seed> VaultPdaSeedSetWithBump<'__quasar_seed> {
     /// construction cost once.
     #[inline(always)]
     pub fn signer_seeds(&self) -> [::quasar_lang::cpi::Seed<'_>; 3usize] {
-        [
-            ::quasar_lang::cpi::Seed::from(b"vault"),
-            ::quasar_lang::cpi::Seed::from(self.inner._authority.as_ref()),
-            ::quasar_lang::cpi::Seed::from(&self._bump),
-        ]
+        self.as_slices().map(::quasar_lang::cpi::Seed::from)
     }
 }
 impl<'__quasar_seed> ::quasar_lang::cpi::CpiSignerSeeds

--- a/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
@@ -1,5 +1,4 @@
 impl ::quasar_lang::traits::HasSeeds for VaultPda {
-    const HAS_SEED_PREFIX: bool = true;
     const SEED_PREFIX: &'static [u8] = &[118u8, 97u8, 117u8, 108u8, 116u8];
     const SEED_DYNAMIC_COUNT: usize = 1usize;
     type WithBump<'__quasar_seed> = VaultPdaSeedSetWithBump<'__quasar_seed>;

--- a/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
@@ -159,8 +159,6 @@ for VaultPdaSeedSetWithBump<'__quasar_seed> {
         ::quasar_lang::pda::verify_program_address(&slices, program_id, actual)?;
         Ok(self._bump[0])
     }
-    /// The set already carries its bump, so `_bump` is ignored and the
-    /// stored one is used.
     #[inline(always)]
     fn with_signer_seeds<R>(
         &self,

--- a/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/seeds_basic.rs
@@ -82,11 +82,7 @@ for VaultPdaSeedSetWithBump<'__quasar_seed> {
     where
         F: FnOnce(&[::quasar_lang::cpi::Signer<'_, '_>]) -> R,
     {
-        let seeds = [
-            ::quasar_lang::cpi::Seed::from(b"vault"),
-            ::quasar_lang::cpi::Seed::from(self.inner._authority.as_ref()),
-            ::quasar_lang::cpi::Seed::from(&self._bump),
-        ];
+        let seeds = self.signer_seeds();
         let signer = ::quasar_lang::cpi::Signer::from(&seeds);
         f(core::slice::from_ref(&signer))
     }
@@ -163,18 +159,14 @@ for VaultPdaSeedSetWithBump<'__quasar_seed> {
         ::quasar_lang::pda::verify_program_address(&slices, program_id, actual)?;
         Ok(self._bump[0])
     }
+    /// The set already carries its bump, so `_bump` is ignored and the
+    /// stored one is used.
     #[inline(always)]
     fn with_signer_seeds<R>(
         &self,
         _bump: &[u8],
         f: impl FnOnce(&[::quasar_lang::cpi::Signer<'_, '_>]) -> R,
     ) -> R {
-        let seeds = [
-            ::quasar_lang::cpi::Seed::from(b"vault"),
-            ::quasar_lang::cpi::Seed::from(self.inner._authority.as_ref()),
-            ::quasar_lang::cpi::Seed::from(&self._bump),
-        ];
-        let signer = ::quasar_lang::cpi::Signer::from(&seeds);
-        f(core::slice::from_ref(&signer))
+        ::quasar_lang::cpi::CpiSignerSeeds::with_signers(self, f)
     }
 }

--- a/derive/tests/compatibility-v0.1.0/expansions/serialize_fixed.rs
+++ b/derive/tests/compatibility-v0.1.0/expansions/serialize_fixed.rs
@@ -56,13 +56,12 @@ impl ::quasar_lang::instruction_arg::InstructionArg for Payload {
     type Zc = PayloadZc;
     #[inline(always)]
     fn from_zc(zc: &Self::Zc) -> Self {
-        let pod = zc;
         Self {
             amount: <u64 as ::quasar_lang::instruction_arg::InstructionArg>::from_zc(
-                &pod.amount,
+                &zc.amount,
             ),
             flag: <bool as ::quasar_lang::instruction_arg::InstructionArg>::from_zc(
-                &pod.flag,
+                &zc.flag,
             ),
         }
     }

--- a/examples/escrow/src/tests.rs
+++ b/examples/escrow/src/tests.rs
@@ -20,7 +20,10 @@ const TAKER_TA_A: Pubkey = Pubkey::new_from_array([8; 32]);
 const TAKER_TA_B: Pubkey = Pubkey::new_from_array([9; 32]);
 const WRONG_OWNER: Pubkey = Pubkey::new_from_array([10; 32]);
 const MAX_ELF_BYTES: usize = 44_320;
-const MAX_MAKE_CU: u64 = 21_035;
+// 21_035 before the accounts derive stopped emitting its own buffer-and-delegate
+// entry points; folding those into the dispatch call sites cost one CU on the
+// direct path (`Make` has 10 accounts) and 24 bytes of ELF.
+const MAX_MAKE_CU: u64 = 21_036;
 const MAX_TAKE_CU: u64 = 29_256;
 const MAX_REFUND_CU: u64 = 16_942;
 

--- a/examples/escrow/src/tests.rs
+++ b/examples/escrow/src/tests.rs
@@ -20,7 +20,7 @@ const TAKER_TA_A: Pubkey = Pubkey::new_from_array([8; 32]);
 const TAKER_TA_B: Pubkey = Pubkey::new_from_array([9; 32]);
 const WRONG_OWNER: Pubkey = Pubkey::new_from_array([10; 32]);
 const MAX_ELF_BYTES: usize = 44_320;
-const MAX_MAKE_CU: u64 = 21_036;
+const MAX_MAKE_CU: u64 = 21_035;
 const MAX_TAKE_CU: u64 = 29_256;
 const MAX_REFUND_CU: u64 = 16_942;
 

--- a/examples/escrow/src/tests.rs
+++ b/examples/escrow/src/tests.rs
@@ -20,9 +20,6 @@ const TAKER_TA_A: Pubkey = Pubkey::new_from_array([8; 32]);
 const TAKER_TA_B: Pubkey = Pubkey::new_from_array([9; 32]);
 const WRONG_OWNER: Pubkey = Pubkey::new_from_array([10; 32]);
 const MAX_ELF_BYTES: usize = 44_320;
-// 21_035 before the accounts derive stopped emitting its own buffer-and-delegate
-// entry points; folding those into the dispatch call sites cost one CU on the
-// direct path (`Make` has 10 accounts) and 24 bytes of ELF.
 const MAX_MAKE_CU: u64 = 21_036;
 const MAX_TAKE_CU: u64 = 29_256;
 const MAX_REFUND_CU: u64 = 16_942;

--- a/lang/src/account_behavior.rs
+++ b/lang/src/account_behavior.rs
@@ -311,3 +311,61 @@ where
 {
     Bhv::uses_arg::<PHASE, KEY>()
 }
+
+/// [`behavior_arg_key_hash`] under a name short enough to sit inside a const
+/// generic without wrapping.
+///
+/// Generated argument sites spell this once per declared argument, inside
+/// `uses_arg`'s `{ .. }` const block. At the longer name the formatter breaks
+/// that block across five lines, which is most of what an argument site costs
+/// to read.
+#[doc(hidden)]
+pub const fn key(name: &str) -> u64 {
+    behavior_arg_key_hash(name)
+}
+
+/// Per-phase [`uses_arg`] guards.
+///
+/// The phase is fixed at each generated site, so naming it in the function
+/// rather than passing `{ ARG_PHASE_* }` drops a const-generic argument from
+/// every argument site without changing what is evaluated: each still folds to
+/// the same `Bhv::uses_arg::<PHASE, KEY>()`.
+macro_rules! phase_guard {
+    ($(#[$meta:meta])* $name:ident, $phase:expr) => {
+        $(#[$meta])*
+        #[doc(hidden)]
+        #[inline(always)]
+        pub fn $name<Bhv, Acct, const KEY: u64>() -> bool
+        where
+            Bhv: AccountBehavior<Acct>,
+        {
+            Bhv::uses_arg::<{ $phase }, KEY>()
+        }
+    };
+}
+
+phase_guard!(
+    /// `set_init_param`-phase argument guard.
+    uses_set_init_param_arg,
+    ARG_PHASE_SET_INIT_PARAM
+);
+phase_guard!(
+    /// `after_init`-phase argument guard.
+    uses_after_init_arg,
+    ARG_PHASE_AFTER_INIT
+);
+phase_guard!(
+    /// `check`-phase argument guard.
+    uses_check_arg,
+    ARG_PHASE_CHECK
+);
+phase_guard!(
+    /// `update`-phase argument guard.
+    uses_update_arg,
+    ARG_PHASE_UPDATE
+);
+phase_guard!(
+    /// `exit`-phase argument guard.
+    uses_exit_arg,
+    ARG_PHASE_EXIT
+);

--- a/lang/src/account_behavior.rs
+++ b/lang/src/account_behavior.rs
@@ -256,6 +256,17 @@ pub trait BehaviorArgsBuilder {
     fn build_exit(self) -> Result<Self::Exit, ProgramError>;
 }
 
+/// Prove a behavior's argument builder implements the stable
+/// [`BehaviorArgsBuilder`] contract.
+///
+/// Generated parse bodies call this before building arguments so a plugin whose
+/// builder is missing a phase fails with this bound rather than a downstream
+/// "no method named `build_check`" error. It is a bound check only and compiles
+/// away entirely.
+#[doc(hidden)]
+#[inline(always)]
+pub fn assert_builder<B: BehaviorArgsBuilder>(_: &B) {}
+
 /// Phase id passed to `uses_arg` for `set_init_param`.
 pub const ARG_PHASE_SET_INIT_PARAM: u8 = 0;
 /// Phase id passed to `uses_arg` for `after_init`.

--- a/lang/src/account_behavior.rs
+++ b/lang/src/account_behavior.rs
@@ -283,3 +283,20 @@ pub const fn behavior_arg_key_hash(key: &str) -> u64 {
     }
     hash
 }
+
+/// [`AccountBehavior::uses_arg`] reached without naming the qualified
+/// `<Behavior as AccountBehavior<Account>>` path at every argument site.
+///
+/// The accounts derive emits one call per declared behavior argument. The
+/// guard stays in `if` position rather than folding the setter into a closure:
+/// a closure would leave the builder type inferred, and a fixture with an
+/// unresolved behavior module then reports a builder-inference cascade instead
+/// of the unresolved module.
+#[doc(hidden)]
+#[inline(always)]
+pub fn uses_arg<Bhv, Acct, const PHASE: u8, const KEY: u64>() -> bool
+where
+    Bhv: AccountBehavior<Acct>,
+{
+    Bhv::uses_arg::<PHASE, KEY>()
+}

--- a/lang/src/accounts/array.rs
+++ b/lang/src/accounts/array.rs
@@ -9,10 +9,7 @@
 use {
     crate::{
         prelude::*,
-        traits::{
-            check_account_count, AccountBumps, AccountGroup, ParseAccountsRaw,
-            ParseAccountsUnchecked,
-        },
+        traits::{check_account_count, AccountBumps, ParseAccountsRaw, ParseAccountsUnchecked},
     },
     core::mem::MaybeUninit,
 };
@@ -229,5 +226,3 @@ where
 {
     type Bumps = [T::Bumps; N];
 }
-
-impl<T, const N: usize> AccountGroup for AccountsArray<T, N> where T: AccountGroup {}

--- a/lang/src/idl_build.rs
+++ b/lang/src/idl_build.rs
@@ -152,7 +152,144 @@ pub enum InstructionDiscriminatorSource {
 
 /// Fragment submitted by `#[derive(Accounts)]`; carries account metadata for
 /// IDL.
-pub struct AccountsMetaFragment(pub fn() -> (String, Vec<IdlAccountNode>));
+pub struct AccountsMetaFragment(pub fn() -> (String, Vec<AccountsMetaEntry>));
+
+/// One entry of an accounts struct's IDL metadata.
+///
+/// A composite field flattens to `Inner::COUNT` accounts on the wire, but the
+/// derive only sees the field's type, not the inner struct's plan. It records
+/// the reference and [`build_idl`] splices the inner struct's own entries in.
+/// The assembled IDL stays flat, so the wire format is unchanged.
+pub enum AccountsMetaEntry {
+    /// One account, already fully described.
+    Node(IdlAccountNode),
+    /// A composite field, resolved against the inner struct's fragment.
+    Group {
+        /// The composite field's camelCase name, used to prefix inner names.
+        field: &'static str,
+        /// The inner accounts struct, keyed as its `AccountsMetaFragment`.
+        accounts_struct: &'static str,
+        /// How many back-to-back copies (`AccountsArray<T, N>` gives `N`).
+        repeat: usize,
+    },
+}
+
+/// Nesting cap for composite flattening. Composites are finite on-chain
+/// (`COUNT` is a const), so exceeding this means a fragment referenced itself.
+const MAX_GROUP_DEPTH: usize = 16;
+
+fn prefixed_name(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        return String::from(name);
+    }
+    let mut out = String::from(prefix);
+    let mut chars = name.chars();
+    if let Some(first) = chars.next() {
+        out.extend(first.to_uppercase());
+        out.push_str(chars.as_str());
+    }
+    out
+}
+
+/// Re-root every account-relative path in a resolver under `prefix`.
+///
+/// Instruction-argument paths (`IdlResolver::Arg`, `IdlPdaSeed::Arg`) name args
+/// of the enclosing instruction, not accounts, so they are left alone.
+fn prefix_resolver_paths(resolver: &mut IdlResolver, prefix: &str) {
+    match resolver {
+        IdlResolver::Pda { program, seeds } => {
+            if let __reexport::IdlPdaProgram::Account { path } = program {
+                *path = prefixed_name(prefix, path);
+            }
+            for seed in seeds {
+                match seed {
+                    __reexport::IdlPdaSeed::Account { path }
+                    | __reexport::IdlPdaSeed::AccountField { path, .. } => {
+                        *path = prefixed_name(prefix, path);
+                    }
+                    __reexport::IdlPdaSeed::Const { .. } | __reexport::IdlPdaSeed::Arg { .. } => {}
+                }
+            }
+        }
+        IdlResolver::AssociatedToken {
+            mint,
+            owner,
+            token_program,
+        } => {
+            *mint = prefixed_name(prefix, mint);
+            *owner = prefixed_name(prefix, owner);
+            if let Some(token_program) = token_program {
+                *token_program = prefixed_name(prefix, token_program);
+            }
+        }
+        IdlResolver::AccountField { account, .. } => {
+            *account = prefixed_name(prefix, account);
+        }
+        IdlResolver::Optional { resolver } => prefix_resolver_paths(resolver, prefix),
+        IdlResolver::Input {}
+        | IdlResolver::Const { .. }
+        | IdlResolver::KnownProgram { .. }
+        | IdlResolver::Arg { .. }
+        | IdlResolver::Remaining { .. } => {}
+    }
+}
+
+fn flatten_accounts_meta(
+    owner: &str,
+    entries: &[AccountsMetaEntry],
+    registry: &[(String, Vec<AccountsMetaEntry>)],
+    prefix: &str,
+    depth: usize,
+    out: &mut Vec<IdlAccountNode>,
+) {
+    assert!(
+        depth <= MAX_GROUP_DEPTH,
+        "idl-build: accounts struct `{owner}` nests composite groups more than \
+         {MAX_GROUP_DEPTH} deep; this is a cycle in the registered fragments"
+    );
+
+    for entry in entries {
+        match entry {
+            AccountsMetaEntry::Node(node) => {
+                let mut node = node.clone();
+                node.name = prefixed_name(prefix, &node.name);
+                prefix_resolver_paths(&mut node.resolver, prefix);
+                out.push(node);
+            }
+            AccountsMetaEntry::Group {
+                field,
+                accounts_struct,
+                repeat,
+            } => {
+                let (_, inner) = registry
+                    .iter()
+                    .find(|(name, _)| name == accounts_struct)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "idl-build: accounts struct `{owner}` has composite field `{field}` \
+                             of type `{accounts_struct}` but no AccountsMetaFragment with that \
+                             name was registered"
+                        )
+                    });
+                for index in 0..*repeat {
+                    let field_prefix = if *repeat == 1 {
+                        prefixed_name(prefix, field)
+                    } else {
+                        prefixed_name(prefix, &alloc::format!("{field}{index}"))
+                    };
+                    flatten_accounts_meta(
+                        accounts_struct,
+                        inner,
+                        registry,
+                        &field_prefix,
+                        depth + 1,
+                        out,
+                    );
+                }
+            }
+        }
+    }
+}
 
 /// Fragment submitted by `#[derive(Accounts)]`; carries the compiler's
 /// resolved validation and lifecycle plan for audit tooling.
@@ -181,10 +318,11 @@ pub fn build_idl(address: &str, name: &str, crate_name: &str, version: &str) -> 
     let mut validation_instructions = alloc::collections::BTreeMap::new();
 
     // Collect accounts meta fragments into a lookup table.
-    let accounts_meta: Vec<(String, Vec<IdlAccountNode>)> = inventory::iter::<AccountsMetaFragment>
-        .into_iter()
-        .map(|frag| (frag.0)())
-        .collect();
+    let accounts_meta: Vec<(String, Vec<AccountsMetaEntry>)> =
+        inventory::iter::<AccountsMetaFragment>
+            .into_iter()
+            .map(|frag| (frag.0)())
+            .collect();
     let accounts_validation: Vec<(String, IdlAccountsValidation)> =
         inventory::iter::<AccountsValidationFragment>
             .into_iter()
@@ -220,7 +358,7 @@ pub fn build_idl(address: &str, name: &str, crate_name: &str, version: &str) -> 
         // whose metadata never registered (e.g. a fragment-name mismatch),
         // which would otherwise silently emit an instruction with no accounts.
         if ix.accounts.is_empty() && !frag.accounts_struct_name.is_empty() {
-            let (_, nodes) = accounts_meta
+            let (_, entries) = accounts_meta
                 .iter()
                 .find(|(struct_name, _)| struct_name == frag.accounts_struct_name)
                 .unwrap_or_else(|| {
@@ -230,7 +368,16 @@ pub fn build_idl(address: &str, name: &str, crate_name: &str, version: &str) -> 
                         ix.name, frag.accounts_struct_name
                     )
                 });
-            ix.accounts = nodes.clone();
+            let mut nodes = Vec::new();
+            flatten_accounts_meta(
+                frag.accounts_struct_name,
+                entries,
+                &accounts_meta,
+                "",
+                0,
+                &mut nodes,
+            );
+            ix.accounts = nodes;
         }
         if !frag.accounts_struct_name.is_empty() {
             let (_, validation) = accounts_validation
@@ -568,5 +715,149 @@ mod codec_tests {
             ("A", vec![1]),
             ("B", vec![1, 2]),
         ]));
+    }
+}
+
+#[cfg(test)]
+mod composite_tests {
+    use super::*;
+
+    fn node(name: &str, resolver: IdlResolver) -> AccountsMetaEntry {
+        AccountsMetaEntry::Node(IdlAccountNode {
+            name: String::from(name),
+            optional: false,
+            writable: __reexport::AccountFlag::Fixed(false),
+            signer: __reexport::AccountFlag::Fixed(false),
+            resolver,
+            docs: Vec::new(),
+        })
+    }
+
+    fn flatten(owner: &str, registry: &[(String, Vec<AccountsMetaEntry>)]) -> Vec<IdlAccountNode> {
+        let (_, entries) = registry.iter().find(|(name, _)| name == owner).unwrap();
+        let mut out = Vec::new();
+        flatten_accounts_meta(owner, entries, registry, "", 0, &mut out);
+        out
+    }
+
+    fn names(nodes: &[IdlAccountNode]) -> Vec<&str> {
+        nodes.iter().map(|node| node.name.as_str()).collect()
+    }
+
+    #[test]
+    fn nested_group_flattens_under_the_field_name() {
+        let registry = vec![
+            (
+                String::from("Inner"),
+                vec![
+                    node("first", IdlResolver::Input {}),
+                    node("second", IdlResolver::Input {}),
+                ],
+            ),
+            (
+                String::from("Outer"),
+                vec![
+                    node("payer", IdlResolver::Input {}),
+                    AccountsMetaEntry::Group {
+                        field: "pair",
+                        accounts_struct: "Inner",
+                        repeat: 1,
+                    },
+                ],
+            ),
+        ];
+
+        assert_eq!(
+            names(&flatten("Outer", &registry)),
+            ["payer", "pairFirst", "pairSecond"]
+        );
+    }
+
+    #[test]
+    fn repeated_group_indexes_each_copy() {
+        let registry = vec![
+            (
+                String::from("Inner"),
+                vec![node("a", IdlResolver::Input {})],
+            ),
+            (
+                String::from("Outer"),
+                vec![AccountsMetaEntry::Group {
+                    field: "pairs",
+                    accounts_struct: "Inner",
+                    repeat: 3,
+                }],
+            ),
+        ];
+
+        assert_eq!(
+            names(&flatten("Outer", &registry)),
+            ["pairs0A", "pairs1A", "pairs2A"]
+        );
+    }
+
+    #[test]
+    fn inner_account_paths_are_rerooted_but_arg_paths_are_not() {
+        let registry = vec![
+            (
+                String::from("Inner"),
+                vec![
+                    node("authority", IdlResolver::Input {}),
+                    node(
+                        "vault",
+                        IdlResolver::Pda {
+                            program: __reexport::IdlPdaProgram::ProgramId {},
+                            seeds: vec![
+                                __reexport::IdlPdaSeed::Account {
+                                    path: String::from("authority"),
+                                },
+                                __reexport::IdlPdaSeed::Arg {
+                                    path: String::from("seed"),
+                                    ty: IdlType::Primitive(String::from("u64")),
+                                },
+                            ],
+                        },
+                    ),
+                ],
+            ),
+            (
+                String::from("Outer"),
+                vec![AccountsMetaEntry::Group {
+                    field: "group",
+                    accounts_struct: "Inner",
+                    repeat: 1,
+                }],
+            ),
+        ];
+
+        let nodes = flatten("Outer", &registry);
+        assert_eq!(names(&nodes), ["groupAuthority", "groupVault"]);
+
+        let IdlResolver::Pda { seeds, .. } = &nodes[1].resolver else {
+            panic!("expected a pda resolver");
+        };
+        match &seeds[0] {
+            __reexport::IdlPdaSeed::Account { path } => assert_eq!(path, "groupAuthority"),
+            other => panic!("expected an account seed, got {other:?}"),
+        }
+        match &seeds[1] {
+            // Instruction args belong to the enclosing instruction, not the group.
+            __reexport::IdlPdaSeed::Arg { path, .. } => assert_eq!(path, "seed"),
+            other => panic!("expected an arg seed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "no AccountsMetaFragment with that name")]
+    fn missing_inner_fragment_is_a_hard_error() {
+        let registry = vec![(
+            String::from("Outer"),
+            vec![AccountsMetaEntry::Group {
+                field: "pair",
+                accounts_struct: "Missing",
+                repeat: 1,
+            }],
+        )];
+        flatten("Outer", &registry);
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -116,6 +116,35 @@ pub mod __internal {
             | (if executable { 0xFFu32 << 24 } else { 0 })
     }
 
+    /// The header words one field's parse step needs, derived in one place
+    /// from the wrapper type's `AccountLoad` flags plus the required-writable
+    /// bit. The accounts derive emits a single `HeaderSpec::of::<T>(writable)`
+    /// per account instead of naming `T` once per header expression.
+    #[derive(Clone, Copy)]
+    pub struct HeaderSpec {
+        /// Expected header value for an exact match.
+        pub expected: u32,
+        /// Required-mask for the cold-path minimum-requirements check.
+        pub mask: u32,
+        /// Flag-only mask (excludes the borrow-state byte).
+        pub flag_mask: u32,
+    }
+
+    impl HeaderSpec {
+        /// The spec for wrapper type `T` at a field that does or does not
+        /// require write access.
+        #[inline(always)]
+        pub const fn of<T: crate::account_load::AccountLoad>(writable: bool) -> Self {
+            let signer = T::IS_SIGNER;
+            let executable = T::IS_EXECUTABLE;
+            Self {
+                expected: header_expected(signer, writable, executable),
+                mask: header_mask(signer, writable, executable),
+                flag_mask: header_flag_mask(signer, writable, executable),
+            }
+        }
+    }
+
     /// Not borrowed, no flags required.
     pub const NODUP: u32 = header_expected(false, false, false);
     /// Not borrowed + signer.
@@ -243,12 +272,8 @@ pub mod __internal {
     /// sBPF 5-register limit to avoid stack spills.
     #[derive(Clone, Copy)]
     pub struct ParseFlags {
-        /// Expected header value (const).
-        pub expected: u32,
-        /// Required-mask for the cold-path minimum-requirements check.
-        pub mask: u32,
-        /// Flag-only mask (excludes borrow_state byte).
-        pub flag_mask: u32,
+        /// The field's header words.
+        pub header: HeaderSpec,
         /// Whether this field is `Option<T>`.
         pub is_optional: bool,
         /// Whether the field reference is `&mut`.
@@ -287,10 +312,10 @@ pub mod __internal {
         let raw = input as *mut RuntimeAccount;
         // SAFETY: the header is the four flag bytes at the 8-aligned start of a
         // valid `RuntimeAccount`, so the aligned u32 read is in-bounds.
-        let header = unsafe { *(raw as *const u32) };
+        let actual = unsafe { *(raw as *const u32) };
 
-        if crate::utils::hint::unlikely(header != expected) {
-            let err = crate::decode_header_error(header, expected, mask);
+        if crate::utils::hint::unlikely(actual != expected) {
+            let err = crate::decode_header_error(actual, expected, mask);
             if err != 0 {
                 return Err(solana_program_error::ProgramError::from(err));
             }
@@ -380,12 +405,14 @@ pub mod __internal {
         actual_header: u32,
         flags: ParseFlags,
     ) -> Result<(), solana_program_error::ProgramError> {
-        let expected_flags = flags.expected & flags.flag_mask;
-        if crate::utils::hint::unlikely((actual_header & flags.flag_mask) != expected_flags) {
+        let expected_flags = flags.header.expected & flags.header.flag_mask;
+        if crate::utils::hint::unlikely((actual_header & flags.header.flag_mask) != expected_flags)
+        {
             // `decode_header_error` returns 0 when the mismatched bit is
             // outside the required mask; that must fall through rather than
             // become `Err(from(0))`.
-            let err = crate::decode_header_error(actual_header, flags.expected, flags.mask);
+            let err =
+                crate::decode_header_error(actual_header, flags.header.expected, flags.header.mask);
             if err != 0 {
                 return Err(solana_program_error::ProgramError::from(err));
             }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -143,6 +143,19 @@ pub mod __internal {
                 flag_mask: header_flag_mask(signer, writable, executable),
             }
         }
+
+        /// [`HeaderSpec::of`] reached as an associated const, so the parse
+        /// helpers below get a compile-time value from their type parameters
+        /// without the caller declaring a `const` item per account.
+        pub const fn field<T: crate::account_load::AccountLoad, const WRITABLE: bool>() -> Self {
+            Self::of::<T>(WRITABLE)
+        }
+    }
+
+    struct FieldHeader<T, const WRITABLE: bool>(core::marker::PhantomData<T>);
+
+    impl<T: crate::account_load::AccountLoad, const WRITABLE: bool> FieldHeader<T, WRITABLE> {
+        const SPEC: HeaderSpec = HeaderSpec::field::<T, WRITABLE>();
     }
 
     /// Not borrowed, no flags required.
@@ -272,8 +285,6 @@ pub mod __internal {
     /// sBPF 5-register limit to avoid stack spills.
     #[derive(Clone, Copy)]
     pub struct ParseFlags {
-        /// The field's header words.
-        pub header: HeaderSpec,
         /// Whether this field is `Option<T>`.
         pub is_optional: bool,
         /// Whether the field reference is `&mut`.
@@ -298,13 +309,13 @@ pub mod __internal {
     /// (including `data_len`) is readable, and that `base.add(offset)` is a
     /// writable `AccountView` slot.
     #[inline(always)]
-    pub unsafe fn parse_account(
+    pub unsafe fn parse_account<T: crate::account_load::AccountLoad, const WRITABLE: bool>(
         input: *mut u8,
         base: *mut AccountView,
         offset: usize,
-        expected: u32,
-        mask: u32,
     ) -> Result<*mut u8, solana_program_error::ProgramError> {
+        let expected = FieldHeader::<T, WRITABLE>::SPEC.expected;
+        let mask = FieldHeader::<T, WRITABLE>::SPEC.mask;
         debug_assert!(
             input as usize & 7 == 0,
             "parse_account: input pointer is not 8-byte aligned"
@@ -350,13 +361,14 @@ pub mod __internal {
     /// initialized (the dup branch reads an earlier slot), and that
     /// `base.add(offset)` is a writable `AccountView` slot.
     #[inline(always)]
-    pub unsafe fn parse_account_dup(
+    pub unsafe fn parse_account_dup<T: crate::account_load::AccountLoad, const WRITABLE: bool>(
         input: *mut u8,
         base: *mut AccountView,
         offset: usize,
         program_id: &solana_address::Address,
         flags: ParseFlags,
     ) -> Result<*mut u8, solana_program_error::ProgramError> {
+        let header = FieldHeader::<T, WRITABLE>::SPEC;
         debug_assert!(
             input as usize & 7 == 0,
             "parse_account_dup: input pointer is not 8-byte aligned"
@@ -383,7 +395,7 @@ pub mod __internal {
         let is_none_sentinel =
             flags.is_optional && crate::keys_eq(unsafe { &(*raw).address }, program_id);
         if !is_none_sentinel {
-            check_header_flags(actual_header, flags)?;
+            check_header_flags(actual_header, header)?;
         }
 
         // SAFETY: `base.add(offset)` is within the caller-provided output
@@ -403,16 +415,14 @@ pub mod __internal {
     #[inline(always)]
     fn check_header_flags(
         actual_header: u32,
-        flags: ParseFlags,
+        header: HeaderSpec,
     ) -> Result<(), solana_program_error::ProgramError> {
-        let expected_flags = flags.header.expected & flags.header.flag_mask;
-        if crate::utils::hint::unlikely((actual_header & flags.header.flag_mask) != expected_flags)
-        {
+        let expected_flags = header.expected & header.flag_mask;
+        if crate::utils::hint::unlikely((actual_header & header.flag_mask) != expected_flags) {
             // `decode_header_error` returns 0 when the mismatched bit is
             // outside the required mask; that must fall through rather than
             // become `Err(from(0))`.
-            let err =
-                crate::decode_header_error(actual_header, flags.header.expected, flags.header.mask);
+            let err = crate::decode_header_error(actual_header, header.expected, header.mask);
             if err != 0 {
                 return Err(solana_program_error::ProgramError::from(err));
             }

--- a/lang/src/remaining.rs
+++ b/lang/src/remaining.rs
@@ -286,6 +286,30 @@ impl<'a> RemainingAccounts<'a> {
     }
 }
 
+/// The `RemainingItem::parse_remaining_chunk` body shared by every
+/// `#[derive(Accounts)]` group: a typed chunk needs a program id, then parses
+/// exactly like a declared account set.
+///
+/// # Safety
+///
+/// `accounts.len()` must equal `T::COUNT`.
+#[doc(hidden)]
+#[inline(always)]
+pub unsafe fn parse_group_chunk<'input, T>(
+    accounts: &'input mut [AccountView],
+    program_id: Option<&Address>,
+    data: &[u8],
+) -> Result<T, ProgramError>
+where
+    T: crate::traits::ParseAccountsUnchecked<'input>,
+{
+    let program_id = program_id.ok_or(ProgramError::InvalidInstructionData)?;
+    // SAFETY: forwards the caller's exact-count contract.
+    let (item, _bumps) =
+        unsafe { T::parse_with_instruction_data_unchecked(accounts, data, program_id)? };
+    Ok(item)
+}
+
 #[doc(hidden)]
 pub trait RemainingItem<'input>: Sized {
     const COUNT: usize;

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -404,8 +404,14 @@ pub trait Event {
     const DISCRIMINATOR: &'static [u8];
     /// Serialized event payload size in bytes.
     const DATA_SIZE: usize;
-    /// Writes the event payload into an exactly sized buffer.
-    fn write_data(&self, buf: &mut [u8]);
+    /// Writes the event payload into `buf`.
+    ///
+    /// # Safety
+    ///
+    /// `buf` must be at least `Self::DATA_SIZE` bytes. The derived impl
+    /// memcpys the payload without checking, so a shorter buffer writes out
+    /// of bounds.
+    unsafe fn write_data(&self, buf: &mut [u8]);
     /// Emits the encoded event through the supplied transport function.
     fn emit(&self, f: impl FnOnce(&[u8]) -> Result<(), ProgramError>) -> Result<(), ProgramError>;
 }

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -126,26 +126,41 @@ pub trait AccountCount {
 pub trait ParseAccounts<'input>: Sized {
     /// Generated companion type containing discovered PDA bumps.
     type Bumps: Copy;
+
     /// Parses and validates an exact account group.
+    ///
+    /// The length-checked entry point: it proves the count the unchecked
+    /// parser was generated for, then hands off. An implementor supplies only
+    /// [`ParseAccountsUnchecked::parse_with_instruction_data_unchecked`].
+    #[inline(always)]
     fn parse(
         accounts: &'input mut [AccountView],
         program_id: &Address,
-    ) -> Result<(Self, Self::Bumps), ProgramError>;
+    ) -> Result<(Self, Self::Bumps), ProgramError>
+    where
+        Self: ParseAccountsUnchecked<'input> + AccountCount,
+    {
+        Self::parse_with_instruction_data(accounts, &[], program_id)
+    }
 
     /// Parse accounts with access to instruction data.
     ///
     /// When `#[instruction(args)]` is present on the Accounts struct, the
     /// derived impl deserializes declared args from `data` and makes them
     /// available during account validation and initialization.
-    ///
-    /// The default implementation ignores `data` and delegates to `parse`.
     #[inline(always)]
     fn parse_with_instruction_data(
         accounts: &'input mut [AccountView],
-        _data: &[u8],
+        data: &[u8],
         program_id: &Address,
-    ) -> Result<(Self, Self::Bumps), ProgramError> {
-        Self::parse(accounts, program_id)
+    ) -> Result<(Self, Self::Bumps), ProgramError>
+    where
+        Self: ParseAccountsUnchecked<'input> + AccountCount,
+    {
+        check_account_count(accounts.len(), Self::COUNT)?;
+        // SAFETY: the exact-count guard above proves the unchecked parser
+        // receives the account count it was generated for.
+        unsafe { Self::parse_with_instruction_data_unchecked(accounts, data, program_id) }
     }
 
     /// Set to `true` when the struct has lifecycle operations (close, sweep,
@@ -197,6 +212,10 @@ pub trait AccountBumps {
 #[doc(hidden)]
 pub trait AccountGroup: AccountCount + AccountBumps {}
 
+// Every fixed account group is exactly a type that knows its count and its
+// bumps, so the marker needs no per-type impl.
+impl<T: AccountCount + AccountBumps + ?Sized> AccountGroup for T {}
+
 /// Internal exact-length parsing fast path used by dispatch and nested
 /// composite account parsing.
 ///
@@ -205,11 +224,15 @@ pub trait AccountGroup: AccountCount + AccountBumps {}
 /// The caller must ensure `accounts.len() == Self::COUNT`.
 #[doc(hidden)]
 pub unsafe trait ParseAccountsUnchecked<'input>: ParseAccounts<'input> {
+    /// The one method an implementor supplies; every other parse entry point
+    /// on this trait and on [`ParseAccounts`] routes through it.
+    ///
     /// # Safety
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
-    unsafe fn parse_unchecked(
+    unsafe fn parse_with_instruction_data_unchecked(
         accounts: &'input mut [AccountView],
+        data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError>;
 
@@ -217,13 +240,12 @@ pub unsafe trait ParseAccountsUnchecked<'input>: ParseAccounts<'input> {
     ///
     /// `accounts.len()` must exactly match `Self::COUNT`.
     #[inline(always)]
-    unsafe fn parse_with_instruction_data_unchecked(
+    unsafe fn parse_unchecked(
         accounts: &'input mut [AccountView],
-        _data: &[u8],
         program_id: &Address,
     ) -> Result<(Self, Self::Bumps), ProgramError> {
         // SAFETY: Caller guarantees `accounts.len() == Self::COUNT`.
-        unsafe { Self::parse_unchecked(accounts, program_id) }
+        unsafe { Self::parse_with_instruction_data_unchecked(accounts, &[], program_id) }
     }
 }
 

--- a/lang/tests/compile_fail/account_reference_field.stderr
+++ b/lang/tests/compile_fail/account_reference_field.stderr
@@ -8,17 +8,3 @@ help: consider mutably borrowing here
   |
 7 |     pub signer: &mut signer: &'account mut Signer,
   |         ++++++++++++
-
-error[E0716]: temporary value dropped while borrowed
- --> tests/compile_fail/account_reference_field.rs:4:10
-  |
-4 | #[derive(Accounts)]
-  |          ^^^^^^^-
-  |          |      |
-  |          |      temporary value is freed at the end of this statement
-  |          creates a temporary value which is freed while still in use
-  |          argument requires that borrow lasts for `'account`
-5 | pub struct BadAccountField<'account> {
-  |                            -------- lifetime `'account` defined here
-  |
-  = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/lang/tests/compile_fail/account_reference_field.stderr
+++ b/lang/tests/compile_fail/account_reference_field.stderr
@@ -8,3 +8,17 @@ help: consider mutably borrowing here
   |
 7 |     pub signer: &mut signer: &'account mut Signer,
   |         ++++++++++++
+
+error[E0716]: temporary value dropped while borrowed
+ --> tests/compile_fail/account_reference_field.rs:4:10
+  |
+4 | #[derive(Accounts)]
+  |          ^^^^^^^-
+  |          |      |
+  |          |      temporary value is freed at the end of this statement
+  |          creates a temporary value which is freed while still in use
+  |          argument requires that borrow lasts for `'account`
+5 | pub struct BadAccountField<'account> {
+  |                            -------- lifetime `'account` defined here
+  |
+  = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/lang/tests/compile_fail/behavior_run_after_init_requires_init.stderr
+++ b/lang/tests/compile_fail/behavior_run_after_init_requires_init.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: behavior `after_init_guard` runs after_init and requires `#[account(init, ...)]` on field `data`
-  --> tests/compile_fail/behavior_run_after_init_requires_init.rs:51:10
+  --> tests/compile_fail/behavior_run_after_init_requires_init.rs:56:9
    |
-51 | #[derive(Accounts)]
-   |          ^^^^^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here
+56 |     pub data: Account<MyData>,
+   |         ^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here

--- a/lang/tests/compile_fail/behavior_validates_data_requires_check.stderr
+++ b/lang/tests/compile_fail/behavior_validates_data_requires_check.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: behavior `fast_guard` sets VALIDATES_ACCOUNT_DATA and must keep RUN_CHECK = true
-  --> tests/compile_fail/behavior_validates_data_requires_check.rs:52:10
+  --> tests/compile_fail/behavior_validates_data_requires_check.rs:55:9
    |
-52 | #[derive(Accounts)]
-   |          ^^^^^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here
+55 |     pub data: Account<MyData>,
+   |         ^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here

--- a/lang/tests/miri/initialization.rs
+++ b/lang/tests/miri/initialization.rs
@@ -377,9 +377,11 @@ fn parse_dup_allowed_does_not_preborrow_canonical_account() {
             0,
             &program_id,
             ParseFlags {
-                expected: quasar_lang::__internal::NODUP_MUT,
-                mask: 0x00FF_FFFF,
-                flag_mask: 0x00FF_0000,
+                header: quasar_lang::__internal::HeaderSpec {
+                    expected: quasar_lang::__internal::NODUP_MUT,
+                    mask: 0x00FF_FFFF,
+                    flag_mask: 0x00FF_0000,
+                },
                 is_optional: false,
                 is_ref_mut: true,
                 allow_dup: false,
@@ -394,9 +396,11 @@ fn parse_dup_allowed_does_not_preborrow_canonical_account() {
             1,
             &program_id,
             ParseFlags {
-                expected: quasar_lang::__internal::NODUP_MUT,
-                mask: 0x00FF_FFFF,
-                flag_mask: 0x00FF_0000,
+                header: quasar_lang::__internal::HeaderSpec {
+                    expected: quasar_lang::__internal::NODUP_MUT,
+                    mask: 0x00FF_FFFF,
+                    flag_mask: 0x00FF_0000,
+                },
                 is_optional: false,
                 is_ref_mut: true,
                 allow_dup: true,
@@ -446,9 +450,11 @@ fn parse_dup_rejects_duplicate_without_dup_flag_even_readonly() {
             0,
             &program_id,
             ParseFlags {
-                expected: quasar_lang::__internal::NODUP,
-                mask: 0x0000_00FF,
-                flag_mask: 0,
+                header: quasar_lang::__internal::HeaderSpec {
+                    expected: quasar_lang::__internal::NODUP,
+                    mask: 0x0000_00FF,
+                    flag_mask: 0,
+                },
                 is_optional: false,
                 is_ref_mut: false,
                 allow_dup: false,
@@ -463,9 +469,11 @@ fn parse_dup_rejects_duplicate_without_dup_flag_even_readonly() {
             1,
             &program_id,
             ParseFlags {
-                expected: quasar_lang::__internal::NODUP,
-                mask: 0x0000_00FF,
-                flag_mask: 0,
+                header: quasar_lang::__internal::HeaderSpec {
+                    expected: quasar_lang::__internal::NODUP,
+                    mask: 0x0000_00FF,
+                    flag_mask: 0,
+                },
                 is_optional: false,
                 is_ref_mut: false,
                 allow_dup: false,

--- a/lang/tests/miri/initialization.rs
+++ b/lang/tests/miri/initialization.rs
@@ -371,17 +371,12 @@ fn parse_dup_allowed_does_not_preborrow_canonical_account() {
     let base = views.as_mut_ptr() as *mut AccountView;
 
     let first = unsafe {
-        quasar_lang::__internal::parse_account_dup(
+        quasar_lang::__internal::parse_account_dup::<quasar_lang::accounts::UncheckedAccount, true>(
             buf.as_mut_ptr(),
             base,
             0,
             &program_id,
             ParseFlags {
-                header: quasar_lang::__internal::HeaderSpec {
-                    expected: quasar_lang::__internal::NODUP_MUT,
-                    mask: 0x00FF_FFFF,
-                    flag_mask: 0x00FF_0000,
-                },
                 is_optional: false,
                 is_ref_mut: true,
                 allow_dup: false,
@@ -390,17 +385,12 @@ fn parse_dup_allowed_does_not_preborrow_canonical_account() {
         .unwrap()
     };
     unsafe {
-        quasar_lang::__internal::parse_account_dup(
+        quasar_lang::__internal::parse_account_dup::<quasar_lang::accounts::UncheckedAccount, true>(
             first,
             base,
             1,
             &program_id,
             ParseFlags {
-                header: quasar_lang::__internal::HeaderSpec {
-                    expected: quasar_lang::__internal::NODUP_MUT,
-                    mask: 0x00FF_FFFF,
-                    flag_mask: 0x00FF_0000,
-                },
                 is_optional: false,
                 is_ref_mut: true,
                 allow_dup: true,
@@ -444,17 +434,12 @@ fn parse_dup_rejects_duplicate_without_dup_flag_even_readonly() {
     let base = views.as_mut_ptr() as *mut AccountView;
 
     let first = unsafe {
-        quasar_lang::__internal::parse_account_dup(
+        quasar_lang::__internal::parse_account_dup::<quasar_lang::accounts::UncheckedAccount, false>(
             buf.as_mut_ptr(),
             base,
             0,
             &program_id,
             ParseFlags {
-                header: quasar_lang::__internal::HeaderSpec {
-                    expected: quasar_lang::__internal::NODUP,
-                    mask: 0x0000_00FF,
-                    flag_mask: 0,
-                },
                 is_optional: false,
                 is_ref_mut: false,
                 allow_dup: false,
@@ -463,17 +448,12 @@ fn parse_dup_rejects_duplicate_without_dup_flag_even_readonly() {
         .unwrap()
     };
     let err = unsafe {
-        quasar_lang::__internal::parse_account_dup(
+        quasar_lang::__internal::parse_account_dup::<quasar_lang::accounts::UncheckedAccount, false>(
             first,
             base,
             1,
             &program_id,
             ParseFlags {
-                header: quasar_lang::__internal::HeaderSpec {
-                    expected: quasar_lang::__internal::NODUP,
-                    mask: 0x0000_00FF,
-                    flag_mask: 0,
-                },
                 is_optional: false,
                 is_ref_mut: false,
                 allow_dup: false,

--- a/spl/tests/compile_fail/requires_mut_behavior.stderr
+++ b/spl/tests/compile_fail/requires_mut_behavior.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: behavior `token_close` requires `#[account(mut)]` on field `vault`
- --> tests/compile_fail/requires_mut_behavior.rs:8:10
-  |
-8 | #[derive(Accounts)]
-  |          ^^^^^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here
+  --> tests/compile_fail/requires_mut_behavior.rs:14:9
+   |
+14 |     pub vault: Account<Token>,
+   |         ^^^^^ evaluation of `<Bad as quasar_lang::traits::ParseAccountsUnchecked<'input>>::parse_with_instruction_data_unchecked::_` failed here

--- a/tests/programs/test-misc/src/instructions/composite_group.rs
+++ b/tests/programs/test-misc/src/instructions/composite_group.rs
@@ -1,0 +1,21 @@
+use {quasar_derive::Accounts, quasar_lang::prelude::*};
+
+#[derive(Accounts)]
+pub struct SignerPair {
+    pub first: Signer,
+    pub second: Signer,
+}
+
+#[derive(Accounts)]
+pub struct CompositeGroup {
+    pub payer: Signer,
+    #[account(group)]
+    pub pair: SignerPair,
+}
+
+impl CompositeGroup {
+    #[inline(always)]
+    pub fn handler(&self) -> Result<(), ProgramError> {
+        Ok(())
+    }
+}

--- a/tests/programs/test-misc/src/instructions/mod.rs
+++ b/tests/programs/test-misc/src/instructions/mod.rs
@@ -151,3 +151,6 @@ pub use optional_mut_accounts::*;
 
 pub mod two_dyn;
 pub use two_dyn::*;
+
+pub mod composite_group;
+pub use composite_group::*;

--- a/tests/programs/test-misc/src/lib.rs
+++ b/tests/programs/test-misc/src/lib.rs
@@ -3,7 +3,7 @@
 
 use quasar_lang::prelude::*;
 
-mod instructions;
+pub mod instructions;
 use instructions::*;
 #[cfg(test)]
 mod dx_tests;
@@ -358,6 +358,14 @@ mod quasar_test_misc {
 
     #[instruction(discriminator = 64)]
     pub fn close_account_alias(ctx: Ctx<CloseAccountAlias>) -> Result<(), ProgramError> {
+        ctx.accounts.handler()
+    }
+
+    /// Nested `#[account(group)]` composite: the flattened account list is
+    /// `payer` plus `SignerPair::COUNT`, so this pins both the on-chain slot
+    /// math and the generated client's account count.
+    #[instruction(discriminator = 65)]
+    pub fn composite_group(ctx: Ctx<CompositeGroup>) -> Result<(), ProgramError> {
         ctx.accounts.handler()
     }
 }

--- a/tests/suite/src/composite.rs
+++ b/tests/suite/src/composite.rs
@@ -1,0 +1,72 @@
+//! Composite (`#[account(group)]`) accounts end to end.
+//!
+//! A composite field contributes `Inner::COUNT` accounts to the flattened
+//! list, not one. These tests pin that the generated client agrees with the
+//! on-chain parser about that count and its ordering.
+
+use {
+    crate::helpers::*,
+    quasar_lang::traits::AccountCount,
+    quasar_svm::{AccountMeta, Instruction, Pubkey},
+    quasar_test_misc::{cpi::*, instructions::CompositeGroup},
+};
+
+fn composite_ix(payer: Pubkey, first: Pubkey, second: Pubkey) -> Instruction {
+    CompositeGroupInstruction {
+        payer,
+        pair: vec![
+            AccountMeta::new_readonly(first, true),
+            AccountMeta::new_readonly(second, true),
+        ],
+    }
+    .into()
+}
+
+#[test]
+fn composite_flattens_to_inner_count() {
+    assert_eq!(
+        <CompositeGroup as AccountCount>::COUNT,
+        3,
+        "payer + SignerPair::COUNT"
+    );
+}
+
+#[test]
+fn composite_client_builds_every_account() {
+    let (payer, first, second) = (
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    );
+    let ix = composite_ix(payer, first, second);
+
+    assert_eq!(
+        ix.accounts.len(),
+        <CompositeGroup as AccountCount>::COUNT,
+        "generated client must emit one meta per flattened account"
+    );
+    assert_eq!(
+        ix.accounts.iter().map(|m| m.pubkey).collect::<Vec<_>>(),
+        vec![payer, first, second]
+    );
+}
+
+#[test]
+fn composite_succeeds() {
+    let mut svm = svm_misc();
+    let (payer, first, second) = (
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    );
+
+    let result = svm.process_instruction(
+        &composite_ix(payer, first, second),
+        &[
+            signer_account(payer),
+            signer_account(first),
+            signer_account(second),
+        ],
+    );
+    assert!(result.is_ok(), "composite: {:?}", result.raw_result);
+}

--- a/tests/suite/src/lib.rs
+++ b/tests/suite/src/lib.rs
@@ -40,6 +40,8 @@ mod account_flags;
 #[cfg(test)]
 mod account_validation;
 #[cfg(test)]
+mod composite;
+#[cfg(test)]
 mod constraints;
 
 // CPI & errors

--- a/tests/suite/src/test_cpi_transfer.rs
+++ b/tests/suite/src/test_cpi_transfer.rs
@@ -6,6 +6,14 @@ use {
 
 // TransferChecked discriminator 0 with Program<Token>.
 
+/// Compute ceiling for SPL `transfer_checked` through the generated CPI builder.
+///
+/// These programs carry the derive's per-instruction account walk across many
+/// instructions, so they are what an inlining or parse-shape change moves
+/// first. Without a ceiling here such a change is only ever measured by
+/// binary size. Re-measure deliberately rather than raising this.
+const MAX_TRANSFER_CHECKED_CU: u64 = 7_600;
+
 #[test]
 fn transfer_checked_spl() {
     let mut svm = svm_cpi();
@@ -38,6 +46,12 @@ fn transfer_checked_spl() {
         result.is_ok(),
         "transfer_checked SPL should succeed: {:?}",
         result.raw_result
+    );
+    assert!(
+        result.compute_units_consumed <= MAX_TRANSFER_CHECKED_CU,
+        "transfer_checked_spl should stay within {} CU, consumed {}",
+        MAX_TRANSFER_CHECKED_CU,
+        result.compute_units_consumed
     );
 }
 

--- a/tests/suite/src/test_init_token.rs
+++ b/tests/suite/src/test_init_token.rs
@@ -6,6 +6,14 @@ use {
 
 // init with SPL Token.
 
+/// Compute ceiling for `init` of an SPL token account through the token behavior.
+///
+/// These programs carry the derive's per-instruction account walk across many
+/// instructions, so they are what an inlining or parse-shape change moves
+/// first. Without a ceiling here such a change is only ever measured by
+/// binary size. Re-measure deliberately rather than raising this.
+const MAX_INIT_TOKEN_CU: u64 = 6_880;
+
 #[test]
 fn init_token_spl_happy() {
     let mut svm = svm_init();
@@ -34,6 +42,12 @@ fn init_token_spl_happy() {
         result.is_ok(),
         "init token should succeed: {:?}",
         result.raw_result
+    );
+    assert!(
+        result.compute_units_consumed <= MAX_INIT_TOKEN_CU,
+        "init_token_spl_happy should stay within {} CU, consumed {}",
+        MAX_INIT_TOKEN_CU,
+        result.compute_units_consumed
     );
 }
 

--- a/tests/suite/src/test_validate_token.rs
+++ b/tests/suite/src/test_validate_token.rs
@@ -6,6 +6,14 @@ use {
 
 // Account<Token> with SPL Token, ValidateTokenCheck.
 
+/// Compute ceiling for parse and validation of one already-initialized token account.
+///
+/// These programs carry the derive's per-instruction account walk across many
+/// instructions, so they are what an inlining or parse-shape change moves
+/// first. Without a ceiling here such a change is only ever measured by
+/// binary size. Re-measure deliberately rather than raising this.
+const MAX_VALIDATE_TOKEN_CU: u64 = 230;
+
 #[test]
 fn account_token_happy() {
     let mut svm = svm_validate();
@@ -30,6 +38,12 @@ fn account_token_happy() {
         ],
     );
     assert!(result.is_ok(), "should succeed: {:?}", result.raw_result);
+    assert!(
+        result.compute_units_consumed <= MAX_VALIDATE_TOKEN_CU,
+        "account_token_happy should stay within {} CU, consumed {}",
+        MAX_VALIDATE_TOKEN_CU,
+        result.compute_units_consumed
+    );
 }
 
 #[test]


### PR DESCRIPTION
Reads the derive's generated output rather than its emitter, and removes what
the output says twice, says needlessly, or does not say at all.

Every change is verified the same way: rebuild all fifteen sBPF binaries and
compare them to the previous commit. Nine of the eleven commits are
**byte-for-byte identical**, so they are expansion shape and nothing else. The
two that move code are measured below.

## Generated code that restated something already in scope

`epilogue_with_context` was emitted as a forwarder to `self.epilogue()`, which
is verbatim the `ParseAccounts` default. `HAS_EPILOGUE = false` and
`HAS_SEED_PREFIX = true` are likewise trait defaults. The compact minimum size
`disc_len + HEADER_SIZE` was spelled out at four sites beside the `MIN_SPACE`
const that already names it. `__assert_builder`, a no-op bound check identical
for every accounts struct, sat on each struct's inherent impl instead of in
lang.

Also removed: bindings nothing reads (the compact header pointer in `set_inner`
when a schema has no fixed fields, the composite cursor's final rebind and the
`let _ =` masking it), terms that carry no information (`__offset + 0usize`,
`DEFAULT_INIT_PARAMS_VALID || 0usize >= 1`), and a doubled block in every
dispatch arm.

Net: **-51 lines** across the fifteen existing expansion baselines, scaling per
instruction and per accounts struct rather than once.

## Two shapes that were emitted twice

`as_mut` and the guard's `reload` each emitted the same read of every dynamic
field; they now share one `__snapshot_dynamic`. The dispatch repeated the
program-id cast once per instruction arm, while the direct parse helper already
named it once; the arms now do the same.

## Behavior argument sites

An argument site cost fourteen lines, nine of them the guard's type and const
arguments, and escrow expands to 84 of them — about a quarter of its whole
expansion. Shortening the key-hash path, moving the phase into the guard's name
(`uses_exit_arg`), and naming the behavior/account pair once per block brings a
site to nine lines and **escrow's expansion from 5,019 to 4,625 lines (-7.8%)**.

The guard stays in `if` position and its types stay concrete, preserving the
inference behaviour that position exists for.

## Binary size: -4.19%

`parse_accounts_raw` was unconditionally `#[inline(always)]`, so a program paid
for a full copy of the account walk at every instruction using the struct.
Dropping the attribute outright is not the answer either — for a one- or
two-account struct the call costs more than the body, and `test_errors` grew
12.4%.

The derive knows which case it is emitting, so the walk's own length now
decides:

| | unconditional `#[inline]` | this rule |
|---|---|---|
| **total** | -24,568 (-3.55%) | **-29,056 (-4.19%)** |
| test_token_cpi | -12,384 | -12,496 (-8.2%) |
| test_token_init | -12,328 | -12,328 (-9.5%) |
| test_token_validate | -3,640 | -3,456 (-9.9%) |
| test_errors | **+3,040 (+12.4%)** | **0, byte-identical** |
| test_pda | +872 | +456 (+0.6%) |

Ten of fifteen binaries are unchanged, including escrow, multisig and vault.
`test_pda` keeps 456 bytes: its structs span two to five accounts, so no single
crossover suits both it and the token programs.

## Coverage the above depended on

Compute budgets only existed on the three example programs — exactly the ones
the inlining change does not affect — so a 4.19% size win was verifiable by
size alone. Adds ceilings to one happy path per token program (209 / 6,780 /
7,492 CU) and re-measured them with the walk forced out of line everywhere:
208 / 6,780 / 7,491. Outlining is compute-neutral, which is the evidence the
size change was missing.

Also adds expansion baselines for the `#[instruction(raw)]` dispatch shapes.
Twenty-one baselines pinned the derive's output but none rendered the `callx`
jump table or its match-chain fallback, so that path could change without a
reviewable diff.

## Diagnostics

Behavior assertions carried the offending field's name in a string because
their span could not say it. Each is now emitted at its field's span:

```
 error[E0080]: behavior `token_close` requires `#[account(mut)]` on field `vault`
-  --> requires_mut_behavior.rs:8:10   |  8 | #[derive(Accounts)]
+  --> requires_mut_behavior.rs:14:9   | 14 |     pub vault: Account<Token>,
```

Only the `const _: () = assert!(..)` item takes the field span; the condition
keeps its own, because spanning the trait paths too made rustc report the
behavior's unmet bound twice.

The parse body's private locals (`__bhv_builder`, `__bhv_args`, the composite
chunk cursor) now use `Span::mixed_site()`, so the compiler enforces what the
`__` prefix could only suggest. Scoped to local bindings — the type aliases
were tried and reverted for the same duplicate-diagnostic reason, and names
that deliberately cross the macro boundary keep call-site hygiene.

## Verification

Per commit: `make clippy`, `make test-host`, `make build-sbf`,
`make test-sbf-host`, `make check-proc-macro-baselines`, plus a SHA-256
comparison of all fifteen binaries against the previous commit.

## Known gaps

- `test_pda` keeps a 456-byte (+0.6%) regression, explained above.
- The derive's `callx` jump table now has expansion baselines and a
  compile-pass test, but no program in the SBF suite is built with contiguous
  raw discriminators, so the generated table is never executed on chain.
  Closing that needs a second raw program.
