### PR TITLE
fix(derive): let an Address instruction arg be a PDA seed, at no cost

### DIFF
--- a/derive/src/accounts/mod.rs
+++ b/derive/src/accounts/mod.rs
@@ -312,8 +312,8 @@ fn emit_pda_address_fns(
     };
     // `find_address` takes every seed by value.
     let owned_source_arg = |source: &SeedSource| match source {
-        SeedSource::PlainAccount(i) | SeedSource::ArgRef(i) => quote! { *#i },
-        SeedSource::DerivedAccount(i) => quote! { #i },
+        SeedSource::PlainAccount(i) | SeedSource::ArgRef(i) => quote! { #i },
+        SeedSource::DerivedAccount(i) => quote! { &#i },
         SeedSource::ArgValue(i, _) => quote! { #i },
         SeedSource::FieldValue { input, .. } => quote! { #input },
         SeedSource::Const(expr) => quote! { #expr },
@@ -842,18 +842,23 @@ fn emit_signer_helpers_impl(ctx: SignerHelpersCtx<'_>) -> proc_macro2::TokenStre
                 Some(quote! {
                     #[inline(always)]
                     #[allow(unused_variables)]
-                    pub fn #method_name<'__quasar_seed>(
+                    pub fn #method_name<'__quasar_seed, __R>(
                         &'__quasar_seed self,
                         bumps: &'__quasar_seed #bumps_name,
                         data: &'__quasar_seed [u8],
-                    ) -> Result<
-                        <#set_ty as #krate::traits::HasSeeds>::WithBump<'__quasar_seed>,
-                        #krate::prelude::ProgramError,
-                    > {
+                        f: impl FnOnce(
+                            &<#set_ty as #krate::traits::HasSeeds>::WithBump<'_>,
+                        ) -> __R,
+                    ) -> Result<__R, #krate::prelude::ProgramError> {
                         let __ix_data = data;
                         #ix_arg_extraction
                         #(#field_refs)*
-                        Ok(#addr_expr.with_bump(bumps.#field_name))
+                        // The seed set borrows the instruction arguments
+                        // destructured just above, which are locals. Handing it
+                        // to a closure keeps it from escaping, so the seeds stay
+                        // borrowed instead of every seed set owning its copy.
+                        let __seeds = #addr_expr.with_bump(bumps.#field_name);
+                        Ok(f(&__seeds))
                     }
                 })
             } else {

--- a/derive/src/accounts/resolve/lower.rs
+++ b/derive/src/accounts/resolve/lower.rs
@@ -387,7 +387,15 @@ fn strip_seed_into(expr: &Expr) -> &Expr {
 }
 
 /// If `expr` is a single-segment path, return that identifier.
+///
+/// Sees through a leading `&`: an `Address` seed is passed by reference, so
+/// the seed argument reads `&authority`, and the identifier underneath is what
+/// names the account field or instruction argument.
 fn single_ident(expr: &Expr) -> Option<syn::Ident> {
+    let expr = match expr {
+        Expr::Reference(reference) => reference.expr.as_ref(),
+        other => other,
+    };
     if let Expr::Path(ep) = expr {
         if ep.qself.is_none() && ep.path.segments.len() == 1 {
             return Some(ep.path.segments[0].ident.clone());

--- a/derive/src/seed_param.rs
+++ b/derive/src/seed_param.rs
@@ -12,6 +12,10 @@ pub(crate) enum SeedType {
     U16,
     U32,
     U64,
+    I8,
+    I16,
+    I32,
+    I64,
     Bytes(usize),
 }
 
@@ -25,6 +29,10 @@ impl SeedType {
             SeedType::U16 => quote! { [u8; 2] },
             SeedType::U32 => quote! { [u8; 4] },
             SeedType::U64 => quote! { [u8; 8] },
+            SeedType::I8 => quote! { [u8; 1] },
+            SeedType::I16 => quote! { [u8; 2] },
+            SeedType::I32 => quote! { [u8; 4] },
+            SeedType::I64 => quote! { [u8; 8] },
             SeedType::Bytes(len) => quote! { [u8; #len] },
         }
     }
@@ -38,6 +46,10 @@ impl SeedType {
             SeedType::U16 => quote! { u16 },
             SeedType::U32 => quote! { u32 },
             SeedType::U64 => quote! { u64 },
+            SeedType::I8 => quote! { i8 },
+            SeedType::I16 => quote! { i16 },
+            SeedType::I32 => quote! { i32 },
+            SeedType::I64 => quote! { i64 },
             SeedType::Bytes(len) => quote! { [u8; #len] },
         }
     }
@@ -52,6 +64,10 @@ impl SeedType {
             SeedType::U16 => quote! { u16 },
             SeedType::U32 => quote! { u32 },
             SeedType::U64 => quote! { u64 },
+            SeedType::I8 => quote! { i8 },
+            SeedType::I16 => quote! { i16 },
+            SeedType::I32 => quote! { i32 },
+            SeedType::I64 => quote! { i64 },
             SeedType::Bytes(len) => quote! { [u8; #len] },
         }
     }
@@ -69,7 +85,13 @@ impl SeedType {
         match self {
             SeedType::Address | SeedType::Bytes(_) => quote! { #param },
             SeedType::U8 => quote! { [#param] },
-            SeedType::U16 | SeedType::U32 | SeedType::U64 => quote! { #param.to_le_bytes() },
+            SeedType::U16
+            | SeedType::U32
+            | SeedType::U64
+            | SeedType::I8
+            | SeedType::I16
+            | SeedType::I32
+            | SeedType::I64 => quote! { #param.to_le_bytes() },
         }
     }
 
@@ -82,7 +104,15 @@ impl SeedType {
         };
         match self {
             SeedType::Address => quote! { #access.as_ref() },
-            SeedType::U8 | SeedType::U16 | SeedType::U32 | SeedType::U64 | SeedType::Bytes(_) => {
+            SeedType::U8
+            | SeedType::U16
+            | SeedType::U32
+            | SeedType::U64
+            | SeedType::I8
+            | SeedType::I16
+            | SeedType::I32
+            | SeedType::I64
+            | SeedType::Bytes(_) => {
                 quote! { &#access }
             }
         }
@@ -98,11 +128,15 @@ pub(crate) fn parse_seed_type(ty: Type) -> Result<SeedType> {
                 "u16" => Ok(SeedType::U16),
                 "u32" => Ok(SeedType::U32),
                 "u64" => Ok(SeedType::U64),
+                "i8" => Ok(SeedType::I8),
+                "i16" => Ok(SeedType::I16),
+                "i32" => Ok(SeedType::I32),
+                "i64" => Ok(SeedType::I64),
                 _ => Err(Error::new(
                     ident.span(),
                     format!(
-                        "unsupported seed type; expected Address, u8, u16, u32, u64, or [u8; N] \
-                         where N <= {MAX_SEED_LEN}"
+                        "unsupported seed type; expected Address, u8, u16, u32, u64, i8, i16, i32, i64, or \
+                         [u8; N] where N <= {MAX_SEED_LEN}"
                     ),
                 )),
             };

--- a/derive/tests/compile_pass/instruction_address_seed.rs
+++ b/derive/tests/compile_pass/instruction_address_seed.rs
@@ -1,0 +1,33 @@
+//! An `Address` instruction argument used as a PDA seed.
+//!
+//! The seed set owns its seeds, so the generated signer helper can return one
+//! built from an instruction argument, which is a local.
+#![allow(unexpected_cfgs)]
+extern crate alloc;
+use quasar_derive::Accounts;
+use quasar_lang::prelude::*;
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+#[seeds(b"v", authority: Address)]
+pub struct V {
+    pub authority: Address,
+}
+
+#[derive(Accounts)]
+#[instruction(authority: Address)]
+pub struct ReadIt {
+    #[account(address = V::seeds(&authority))]
+    pub v: Account<V>,
+}
+
+#[derive(Accounts)]
+#[instruction(authority: Address, id: u64)]
+pub struct InitIt {
+    #[account(mut)]
+    pub payer: Signer,
+    #[account(init, payer = payer, address = V::seeds(&authority))]
+    pub v: Account<V>,
+    pub system_program: Program<SystemProgram>,
+}
+fn main() {}

--- a/derive/tests/compile_pass/signed_int_seeds.rs
+++ b/derive/tests/compile_pass/signed_int_seeds.rs
@@ -1,0 +1,21 @@
+//! Signed integers as PDA seeds, stored as their little-endian bytes like the
+//! unsigned widths.
+#![allow(unexpected_cfgs)]
+extern crate alloc;
+use quasar_derive::Accounts;
+use quasar_lang::prelude::*;
+solana_address::declare_id!("11111111111111111111111111111112");
+
+#[account(discriminator = 1)]
+#[seeds(b"tick", tick: i32, offset: i64, flag: i8, small: i16)]
+pub struct Tick {
+    pub authority: Address,
+}
+
+#[derive(Accounts)]
+#[instruction(tick: i32, offset: i64, flag: i8, small: i16)]
+pub struct UseSigned {
+    #[account(address = Tick::seeds(tick, offset, flag, small))]
+    pub tick_account: Account<Tick>,
+}
+fn main() {}


### PR DESCRIPTION
Supersedes #488, which found a real bug and diagnosed it correctly. Credit to
@datasalaryman — this keeps the finding and the regression test, and changes
what is repaired.

## The bug

An `#[instruction(x: Address)]` used as a PDA seed was **structurally
impossible**, not merely awkward:

```rust
#[derive(Accounts)]
#[instruction(mint_x: Address, mint_y: Address)]
pub struct Initialize {
    #[account(init, payer = payer, address = Config::seeds(payer.address(), mint_x, mint_y))]
    pub config: Config,
}
```

The generated signer helper destructures the instruction arguments into locals
and then *returns* a seed set built from them, so the set borrowed a local it
outlived. Adding the `&` the compiler suggests produces `E0515`. There was no
form the user could write that compiled.

There was also a **second, independent bug** behind the same symptom:
`single_ident` matched only `Expr::Path`, so `V::seeds(&authority)` never
resolved `authority` as an instruction argument at all — `E0425`. That would
bite any `&`-form seed argument.

## What changed

Only the helper. It hands the seed set to a closure instead of returning it, so
the set cannot escape the locals it borrows. Seeds stay borrowed everywhere
else. The classifier now sees through a leading `&`.

## Why not store Address seeds by value

That is #488's shape, and it compiles. But it makes **every seed set in every
program** own a 32-byte copy in order to fix one helper. Measured against its
own base:

| | Δ |
|---|---|
| quasar_multisig | +1,360 (+4.47%) |
| quasar_test_pda | +880 (+1.08%) |
| quasar_vault | +152 (+2.10%) |
| **total** | **+2,752** |

I reproduced that shape on this branch and it also costs escrow refund **+3 CU**
and take **+2 CU**, which the checked-in budgets reject. Programs with no
instruction-argument seeds pay it too — multisig and test-pda have none.

None of this is visible on `master`, which carries no size or compute budgets;
they exist only on `0.1.0-release`. That is why this targets `0.1.0-release`.

This PR: **all fifteen sBPF binaries total 663,888 bytes, unchanged**, and no
compute budget moves.

## Also: i8 through i64 as seeds

The accepted seed types were `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`. A
signed integer was rejected, so a PDA keyed on a tick index or a signed offset
had to be widened or bit-cast by hand at every call site. Signed widths store
their little-endian bytes exactly like the unsigned ones — same storage, same
slice. Also byte-neutral.

Still rejected, deliberately: `u128`/`i128`, `bool`, `String`/`&str`, and
non-`u8` array elements.

## Verification

`make clippy`, `make test-host`, `make build-sbf`, `make test-sbf-host`,
`make check-proc-macro-baselines`, plus a size comparison of all fifteen
binaries. Two `compile_pass` fixtures cover the previously impossible cases.
