### PR TITLE
refactor(idl): one derived-account predicate, and no guessed fallbacks

### DIFF
--- a/idl/src/codegen/c.rs
+++ b/idl/src/codegen/c.rs
@@ -212,7 +212,12 @@ fn fixed_account_id_name(prefix: &str, instruction: &str, account: &str) -> Stri
 }
 
 fn emit_pubkey_const(out: &mut String, name: &str, address: &str) {
-    let bytes = bs58::decode(address).into_vec().unwrap_or_default();
+    // `validate_codegen_idl` rejects a non-base58 or wrong-length address before
+    // any backend renders it. Decoding to an all-zero key on failure used to
+    // turn a typo into a silently wrong program id in the generated header.
+    let bytes = bs58::decode(address)
+        .into_vec()
+        .expect("address validated by validate_codegen_idl");
     write!(out, "static const Pubkey {name} = {{{{").unwrap();
     for (i, b) in bytes.iter().enumerate() {
         if i > 0 {

--- a/idl/src/codegen/model.rs
+++ b/idl/src/codegen/model.rs
@@ -498,14 +498,6 @@ impl InstructionPlan {
     }
 }
 
-/// Whether a required account address is derived by generated clients.
-pub fn resolver_is_derived(resolver: &IdlResolver) -> bool {
-    matches!(
-        resolver,
-        IdlResolver::Pda { .. } | IdlResolver::AssociatedToken { .. }
-    )
-}
-
 /// Account addresses that must be available before `account` can be derived.
 pub fn resolved_account_dependencies(account: &IdlAccountNode) -> Vec<&str> {
     match &account.resolver {
@@ -540,6 +532,15 @@ pub fn resolved_account_dependencies(account: &IdlAccountNode) -> Vec<&str> {
     }
 }
 
+/// Whether generated clients compute this account's address themselves.
+///
+/// Delegates to [`account_source`], which already folds in the rule that an
+/// optional account stays caller-controlled whatever it wraps — a rule every
+/// call site used to restate, and could forget.
+fn account_is_derived(account: &IdlAccountNode) -> bool {
+    crate::codegen::accounts::account_source(account).is_ok_and(|source| source.is_derived())
+}
+
 /// Required derived accounts in dependency order, independent of IDL field
 /// order. Optional accounts remain caller-controlled and are available as
 /// inputs even when their wrapped resolver is derived.
@@ -547,13 +548,13 @@ pub fn resolved_account_order(ix: &IdlInstruction) -> CodegenResult<Vec<&IdlAcco
     let mut available = ix
         .accounts
         .iter()
-        .filter(|account| account.optional || !resolver_is_derived(&account.resolver))
+        .filter(|account| !account_is_derived(account))
         .map(|account| account.name.as_str())
         .collect::<HashSet<_>>();
     let mut pending = ix
         .accounts
         .iter()
-        .filter(|account| !account.optional && resolver_is_derived(&account.resolver))
+        .filter(|account| account_is_derived(account))
         .collect::<Vec<_>>();
     let mut ordered = Vec::with_capacity(pending.len());
 

--- a/idl/src/codegen/typescript/shared/codec.rs
+++ b/idl/src/codegen/typescript/shared/codec.rs
@@ -837,7 +837,13 @@ pub(super) fn primitive_ts_codec(primitive: &str, target: TsTarget) -> String {
             TsTarget::Web3js => "getWeb3jsAddressCodec()".to_string(),
             TsTarget::Kit => "getAddressCodec()".to_string(),
         },
-        "string" => "addCodecSizePrefix(getUtf8Codec(), getU32Codec())".to_string(),
+        // A dynamic `string` carries its declared prefix width and is rendered
+        // by the WireType-aware path; reaching here would mean emitting a
+        // guessed u32 prefix, which is the divergence `WireType::resolve`
+        // exists to make unrepresentable.
+        "string" => {
+            unreachable!("dynamic `string` requires a size-prefix codec, rejected at IR-build time")
+        }
         other if other.starts_with('[') => {
             let size = crate::codegen::parse_fixed_array_size(other).unwrap_or(1);
             format!("fixCodecSize(getBytesCodec(), {})", size)


### PR DESCRIPTION
Three fixes from auditing the client generators for the defect class that
produced the last one: a decision made in more than one place, and a fallback
that guesses instead of failing.

## One derived-account predicate

`resolver_is_derived` sat beside `account_source` answering the same question a
different way, and every call site had to remember to combine it with "unless
the account is optional" — the rule `account_source` exists to hold. Both
callers now go through the classifier and the duplicate is gone.

## Two fallbacks that guess

Both are unreachable today. Neither should stay reachable-looking.

- `primitive_ts_codec("string")` hardcoded a **u32** size prefix while the model
  resolves the declared width from the IDL. Dynamic types without a codec are
  rejected at IR-build time and the `WireType` path renders the rest, so
  reaching this arm would mean emitting a guessed prefix — exactly the
  "bare string/vec defaults to u32" divergence `WireType::resolve` was written
  to make unrepresentable. It now panics with that invariant stated. Verified
  unreachable by generating all five targets from a string-carrying IDL.
- The C backend base58-decoded a program address with `unwrap_or_default`,
  turning a typo into an all-zero key in the generated header. Addresses are
  validated before any backend renders, so the invariant is now stated with
  `expect` rather than silently absorbed.

## Verification

48 test groups green workspace-wide, `cargo fmt --check` clean,
`clippy --workspace --all-targets` silent.

Two further findings from the same audit — the `cpi` client and the IDL clients
implementing the seed-naming rule and the derived-account gate twice — live on
`feat/quasar-test-ergonomics` (#486), because both implementations only exist
once that branch lands. They are fixed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kW9Yvfpa5fsh3JsdY9xMr
